### PR TITLE
remove offending <w:tblGrid> causing crash in Word 2019 and later

### DIFF
--- a/DistFiles/Language Explorer/Export Templates/Discourse/Discourse2Word.xsl
+++ b/DistFiles/Language Explorer/Export Templates/Discourse/Discourse2Word.xsl
@@ -249,10 +249,6 @@ color lighter.-->
 		  </w:tcBorders>
 		</xsl:if>
 	  </w:tcPr>
-	  <w:tblGrid>
-		<w:gridCol w:w="200" />
-		<!-- minimum cell width in twips (1/20 pt)-->
-	  </w:tblGrid>
 	  <xsl:apply-templates />
 	</w:tc>
   </xsl:template>
@@ -283,10 +279,6 @@ color lighter.-->
 		  </w:tcBorders>
 		</xsl:if>
 	  </w:tcPr>
-	  <w:tblGrid>
-		<w:gridCol w:w="200" />
-		<!-- twips (1/20 pt)-->
-	  </w:tblGrid>
 	  <xsl:if test="not(glosses)">
 		<w:p />
 	  </xsl:if>


### PR DESCRIPTION
This commit removes the <wtblGrid> elements from the exported Word XML file.  These elements cause MS Word 2019 and later to fail upon opening the XML file with an error message:

"We're sorry.  We cannot open the document because we found a problem with its contents.  Not enough memory resources are available to complete this operation."

JIRA issue reference: https://jira.sil.org/browse/LT-19915

Removing these elements fixes the error and allows users of Word 2019 and later to open the Discourse Chart Word XML file.  Removing the elements does not appear to have an adverse effect on the chart output.