### PR TITLE
LT-21672: Add styles to table cells

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2807,8 +2807,8 @@ namespace SIL.FieldWorks.XWorks
 				var cssStyle = CssGenerator.GenerateCssStyleFromLcmStyleSheet(style,
 					settings.Cache.WritingSystemFactory.GetWsFromStr(writingSystem), settings.PropertyTable);
 				var css = cssStyle.ToString();
-				if (!String.IsNullOrEmpty(css))
-					settings.ContentGenerator.SetRunStyle(writer, config, css);
+
+				settings.ContentGenerator.SetRunStyle(writer, config, writingSystem, css, style);
 			}
 			if (linkDestination != Guid.Empty)
 			{
@@ -3031,7 +3031,7 @@ namespace SIL.FieldWorks.XWorks
 				new ExCSS.Property("color") { Term = new HtmlColor(222, 0, 0) },
 				new ExCSS.Property("font-size") { Term = new PrimitiveTerm(UnitType.Ems, 1.5f) }
 			};
-			settings.ContentGenerator.SetRunStyle(writer, null, css.ToString());
+			settings.ContentGenerator.SetRunStyle(writer, null, writingSystem, css.ToString(), null);
 			if (text.Contains(TxtLineSplit))
 			{
 				var txtContents = text.Split(TxtLineSplit);

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2804,11 +2804,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			if (!String.IsNullOrEmpty(style))
 			{
-				var cssStyle = CssGenerator.GenerateCssStyleFromLcmStyleSheet(style,
-					settings.Cache.WritingSystemFactory.GetWsFromStr(writingSystem), settings.PropertyTable);
-				var css = cssStyle.ToString();
-
-				settings.ContentGenerator.SetRunStyle(writer, config, writingSystem, css, style);
+				settings.ContentGenerator.SetRunStyle(writer, config, settings.PropertyTable, writingSystem, style, false);
 			}
 			if (linkDestination != Guid.Empty)
 			{
@@ -3025,13 +3021,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var writingSystem = settings.Cache.WritingSystemFactory.GetStrFromWs(settings.Cache.WritingSystemFactory.UserWs);
 			settings.ContentGenerator.StartRun(writer, writingSystem);
-			// Make the error red and slightly larger than the surrounding text
-			var css = new StyleDeclaration
-			{
-				new ExCSS.Property("color") { Term = new HtmlColor(222, 0, 0) },
-				new ExCSS.Property("font-size") { Term = new PrimitiveTerm(UnitType.Ems, 1.5f) }
-			};
-			settings.ContentGenerator.SetRunStyle(writer, null, writingSystem, css.ToString(), null);
+			settings.ContentGenerator.SetRunStyle(writer, null, settings.PropertyTable, writingSystem, null, true);
 			if (text.Contains(TxtLineSplit))
 			{
 				var txtContents = text.Split(TxtLineSplit);

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Web.UI.WebControls;
+using XCore;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -33,7 +34,7 @@ namespace SIL.FieldWorks.XWorks
 		void EndBiDiWrapper(IFragmentWriter writer);
 		void StartRun(IFragmentWriter writer, string writingSystem);
 		void EndRun(IFragmentWriter writer);
-		void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle);
+		void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propertyTable, string writingSystem, string runStyle, bool error);
 		void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination);
 		void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, string externalDestination);
 		void EndLink(IFragmentWriter writer);

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -33,7 +33,7 @@ namespace SIL.FieldWorks.XWorks
 		void EndBiDiWrapper(IFragmentWriter writer);
 		void StartRun(IFragmentWriter writer, string writingSystem);
 		void EndRun(IFragmentWriter writer);
-		void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string css);
+		void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle);
 		void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination);
 		void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, string externalDestination);
 		void EndLink(IFragmentWriter writer);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -181,7 +181,7 @@ namespace SIL.FieldWorks.XWorks
 			m_runBuilder.Value.Clear();
 		}
 
-		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string css)
+		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle)
 		{
 			if(!string.IsNullOrEmpty(css))
 				((JsonFragmentWriter)writer).InsertJsonProperty("style", css);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -181,10 +181,17 @@ namespace SIL.FieldWorks.XWorks
 			m_runBuilder.Value.Clear();
 		}
 
-		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle)
+		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propertyTable, string writingSystem, string runStyle, bool error)
 		{
-			if(!string.IsNullOrEmpty(css))
-				((JsonFragmentWriter)writer).InsertJsonProperty("style", css);
+			if (!string.IsNullOrEmpty(runStyle))
+			{
+				var cache = propertyTable.GetValue<LcmCache>("cache", null);
+				var cssStyle = CssGenerator.GenerateCssStyleFromLcmStyleSheet(runStyle,
+					cache.WritingSystemFactory.GetWsFromStr(writingSystem), propertyTable);
+				string css = cssStyle?.ToString();
+				if (!string.IsNullOrEmpty(css))
+					((JsonFragmentWriter)writer).InsertJsonProperty("style", css);
+			}
 		}
 
 		public void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination)

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -683,7 +683,7 @@ namespace SIL.FieldWorks.XWorks
 		/// This is needed to set the specific style for any field that allows the
 		/// default style to be overridden (Table Cell, Custom Field, Note...).
 		/// </summary>
-		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string _, string runStyle)
+		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propertyTable, string writingSystem, string runStyle, bool error)
 		{
 			if (!string.IsNullOrEmpty(runStyle))
 			{

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using ExCSS;
 using Icu.Collation;
 using SIL.FieldWorks.Common.Controls;
 using SIL.FieldWorks.Common.FwUtils;
@@ -732,8 +733,27 @@ namespace SIL.FieldWorks.XWorks
 			((XmlFragmentWriter)writer).Writer.WriteEndElement(); // span
 		}
 
-		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle)
+		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propertyTable, string writingSystem, string runStyle, bool error)
 		{
+			StyleDeclaration cssStyle = null;
+
+			// This is primarily intended to make formatting errors stand out in the GUI.
+			// Make the error red and slightly larger than the surrounding text.
+			if (error)
+			{
+				cssStyle = new StyleDeclaration
+				{
+					new ExCSS.Property("color") { Term = new HtmlColor(222, 0, 0) },
+					new ExCSS.Property("font-size") { Term = new PrimitiveTerm(ExCSS.UnitType.Ems, 1.5f) }
+				};
+			}
+			else if (!string.IsNullOrEmpty(runStyle))
+			{
+				var cache = propertyTable.GetValue<LcmCache>("cache", null);
+				cssStyle = CssGenerator.GenerateCssStyleFromLcmStyleSheet(runStyle,
+					cache.WritingSystemFactory.GetWsFromStr(writingSystem), propertyTable);
+			}
+			string css = cssStyle?.ToString();
 			if (!String.IsNullOrEmpty(css))
 				((XmlFragmentWriter)writer).Writer.WriteAttributeString("style", css);
 		}

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -732,9 +732,10 @@ namespace SIL.FieldWorks.XWorks
 			((XmlFragmentWriter)writer).Writer.WriteEndElement(); // span
 		}
 
-		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string css)
+		public void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem, string css, string runStyle)
 		{
-			((XmlFragmentWriter)writer).Writer.WriteAttributeString("style", css);
+			if (!String.IsNullOrEmpty(css))
+				((XmlFragmentWriter)writer).Writer.WriteAttributeString("style", css);
 		}
 
 		public void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination)


### PR DESCRIPTION
This adds support for when a style is applied to a specific cell or when different styles are applied to different pieces of the text in a cell.

Note: The changes in SetRunStyle() also add support for styles that are applied to all or a portion of the text in other fields (notes, custom fields …).

Change-Id: Id1ca7ccfaeaad7e7ea7e781263151b1714d9d90f

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/17)
<!-- Reviewable:end -->
