### PR TITLE
Add images to word export

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -1941,9 +1941,8 @@ namespace SIL.FieldWorks.XWorks
 					contentGenerator.WriteProcessedContents(writer, settings.ContentGenerator.AddImageCaption(captionBldr.ToString()));
 				}
 				writer.Flush();
+				return bldr;
 			}
-
-			return bldr;
 		}
 
 		private static IFragment GenerateCollectionItemContent(ConfigurableDictionaryNode config, DictionaryPublicationDecorator publicationDecorator,

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -862,7 +862,6 @@ namespace SIL.FieldWorks.XWorks
 				filePath = MakeSafeFilePath(file.AbsoluteInternalPath);
 			}
 			return filePath;
-			//return settings.UseRelativePaths ? filePath : new Uri(filePath).ToString();
 		}
 
 		private static string GenerateSrcAttributeForMediaFromFilePath(string filename, string subFolder, GeneratorSettings settings)

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -861,7 +861,8 @@ namespace SIL.FieldWorks.XWorks
 			{
 				filePath = MakeSafeFilePath(file.AbsoluteInternalPath);
 			}
-			return settings.UseRelativePaths ? filePath : new Uri(filePath).ToString();
+			return filePath;
+			//return settings.UseRelativePaths ? filePath : new Uri(filePath).ToString();
 		}
 
 		private static string GenerateSrcAttributeForMediaFromFilePath(string filename, string subFolder, GeneratorSettings settings)

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -22,9 +22,9 @@ using System.Text;
 using System.Web.UI.WebControls;
 using System.Windows.Media.Imaging;
 using XCore;
-using A = DocumentFormat.OpenXml.Drawing;
-using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
-using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
+using XmlDrawing = DocumentFormat.OpenXml.Drawing;
+using DrawingWP = DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using Pictures = DocumentFormat.OpenXml.Drawing.Pictures;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -1293,35 +1293,35 @@ namespace SIL.FieldWorks.XWorks
 			string name = (filepath.Split('\\').Last()).Split('.').First();
 			string haPosition = "right";
 			// Define the reference of the image.
-			DW.Anchor anchor = new DW.Anchor();
-			anchor.Append(new DW.SimplePosition() { X = 0L, Y = 0L });
+			DrawingWP.Anchor anchor = new DrawingWP.Anchor();
+			anchor.Append(new DrawingWP.SimplePosition() { X = 0L, Y = 0L });
 			anchor.Append(
-				new DW.HorizontalPosition(
-					new DW.HorizontalAlignment(haPosition)
+				new DrawingWP.HorizontalPosition(
+					new DrawingWP.HorizontalAlignment(haPosition)
 				)
 				{
 					RelativeFrom =
-					  DW.HorizontalRelativePositionValues.Margin
+					  DrawingWP.HorizontalRelativePositionValues.Margin
 				}
 			);
 			anchor.Append(
-				new DW.VerticalPosition(
-					new DW.PositionOffset("0")
+				new DrawingWP.VerticalPosition(
+					new DrawingWP.PositionOffset("0")
 				)
 				{
 					RelativeFrom =
-					DW.VerticalRelativePositionValues.Paragraph
+					DrawingWP.VerticalRelativePositionValues.Paragraph
 				}
 			);
 			anchor.Append(
-				new DW.Extent()
+				new DrawingWP.Extent()
 				{
 					Cx = widthEmus,
 					Cy = heightEmus
 				}
 			);
 			anchor.Append(
-				new DW.EffectExtent()
+				new DrawingWP.EffectExtent()
 				{
 					LeftEdge = 0L,
 					TopEdge = 0L,
@@ -1329,35 +1329,35 @@ namespace SIL.FieldWorks.XWorks
 					BottomEdge = 0L
 				}
 			);
-			anchor.Append(new DW.WrapTopBottom());
+			anchor.Append(new DrawingWP.WrapTopBottom());
 			anchor.Append(
-				new DW.DocProperties()
+				new DrawingWP.DocProperties()
 				{
 					Id = (UInt32Value)1U,
 					Name = name
 				}
 			);
 			anchor.Append(
-				new DW.NonVisualGraphicFrameDrawingProperties(
-					  new A.GraphicFrameLocks() { NoChangeAspect = true })
+				new DrawingWP.NonVisualGraphicFrameDrawingProperties(
+					  new XmlDrawing.GraphicFrameLocks() { NoChangeAspect = true })
 			);
 			anchor.Append(
-				new A.Graphic(
-					  new A.GraphicData(
-						new PIC.Picture(
+				new XmlDrawing.Graphic(
+					  new XmlDrawing.GraphicData(
+						new Pictures.Picture(
 
-						  new PIC.NonVisualPictureProperties(
-							new PIC.NonVisualDrawingProperties()
+						  new Pictures.NonVisualPictureProperties(
+							new Pictures.NonVisualDrawingProperties()
 							{
 								Id = (UInt32Value)0U,
 								Name = name + ".jpg"
 							},
-							new PIC.NonVisualPictureDrawingProperties()),
+							new Pictures.NonVisualPictureDrawingProperties()),
 
-							new PIC.BlipFill(
-								new A.Blip(
-									new A.BlipExtensionList(
-										new A.BlipExtension()
+							new Pictures.BlipFill(
+								new XmlDrawing.Blip(
+									new XmlDrawing.BlipExtensionList(
+										new XmlDrawing.BlipExtension()
 										{
 											Uri =
 											"{28A0092B-C50C-407E-A947-70E740481C1C}"
@@ -1366,26 +1366,26 @@ namespace SIL.FieldWorks.XWorks
 								{
 									Embed = partId,
 									CompressionState =
-									A.BlipCompressionValues.Print
+									XmlDrawing.BlipCompressionValues.Print
 								},
-								new A.Stretch(
-									new A.FillRectangle())),
+								new XmlDrawing.Stretch(
+									new XmlDrawing.FillRectangle())),
 
-						  new PIC.ShapeProperties(
+						  new Pictures.ShapeProperties(
 
-							new A.Transform2D(
-							  new A.Offset() { X = 0L, Y = 0L },
+							new XmlDrawing.Transform2D(
+							  new XmlDrawing.Offset() { X = 0L, Y = 0L },
 
-							  new A.Extents()
+							  new XmlDrawing.Extents()
 							  {
 								  Cx = widthEmus,
 								  Cy = heightEmus
 							  }),
 
-							new A.PresetGeometry(
-							  new A.AdjustValueList()
+							new XmlDrawing.PresetGeometry(
+							  new XmlDrawing.AdjustValueList()
 							)
-							{ Preset = A.ShapeTypeValues.Rectangle }
+							{ Preset = XmlDrawing.ShapeTypeValues.Rectangle }
 						  )
 						)
 				  )

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1350,7 +1350,7 @@ namespace SIL.FieldWorks.XWorks
 							new Pictures.NonVisualDrawingProperties()
 							{
 								Id = (UInt32Value)0U,
-								Name = name + ".jpg"
+								Name = name
 							},
 							new Pictures.NonVisualPictureDrawingProperties()),
 

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -596,28 +596,26 @@ namespace SIL.FieldWorks.XWorks
 
 			public void Dispose()
 			{
-				/*foreach (var cachEntry in collatorCache.Values)
-				{
-					cachEntry?.Dispose();
-				}
-				Dispose(true);
-				GC.SuppressFinalize(this);*/
-			}
+				// When writer is being disposed, dispose only the dictionary entries,
+				// not the word doc fragment.
+				// ConfiguredLcmGenerator consistently returns the fragment and disposes the writer,
+				// which would otherwise result in a disposed fragment being accessed.
 
-			protected virtual void Dispose(bool disposing)
-			{
-				Debug.WriteLineIf(!disposing, "****** Missing Dispose() call for " + GetType().Name + ". ****** ");
 				if (!isDisposed)
 				{
-					//WordFragment.DocFrag.Dispose();
-					WordFragment.MemStr.Dispose();
+					foreach (var cachEntry in collatorCache.Values)
+					{
+						cachEntry?.Dispose();
+					}
+
+					GC.SuppressFinalize(this);
 					isDisposed = true;
 				}
 			}
 
 			public void Flush()
 			{
-				//WordFragment.MemStr.Flush();
+				WordFragment.MemStr.Flush();
 			}
 
 			public void Insert(IFragment frag)

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Wordprocessing;
+using ExCSS;
 using SIL.FieldWorks.Common.Framework;
 using SIL.FieldWorks.Common.Widgets;
 using SIL.LCModel;
@@ -325,7 +326,8 @@ namespace SIL.FieldWorks.XWorks
 
 				// TODO: handle listAndPara and pictureOptions cases
 				// case IParaOption listAndParaOpts:
-				// case DictionaryNodePictureOptions pictureOptions:
+				//case DictionaryNodePictureOptions pictureOptions:
+					//return GenerateWordStyleFromPictureOptions(configNode, pictureOptions, styleName, cache, propertyTable);
 
 				default:
 					{

--- a/Src/xWorks/xWorks.csproj
+++ b/Src/xWorks/xWorks.csproj
@@ -168,6 +168,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Output\Debug\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="SIL.Core.Desktop, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Output\Debug\SIL.Core.Desktop.dll</HintPath>


### PR DESCRIPTION
Create image part for a word doc, create images,
clone images between document fragments,
and track relationship IDs of images.

Export caption text. Formatting of image captions
will be handled separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/22)
<!-- Reviewable:end -->
