### PR TITLE
LT-20855: Fix unlink button position for right to left

### DIFF
--- a/Src/LexText/Interlinear/FocusBoxController.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.cs
@@ -200,6 +200,9 @@ namespace SIL.FieldWorks.IText
 				btnUndoChanges.Anchor = AnchorStyles.Left;
 				btnUndoChanges.Location = new Point(
 					btnConfirmChanges.Width + btnConfirmChangesForWholeText.Width, btnUndoChanges.Location.Y);
+				btnBreakPhrase.Anchor = AnchorStyles.Left;
+				btnBreakPhrase.Location = new Point(
+					btnConfirmChanges.Width + btnConfirmChangesForWholeText.Width + btnUndoChanges.Width, btnBreakPhrase.Location.Y);
 				btnMenu.Anchor = AnchorStyles.Right;
 				btnMenu.Location = new Point(panelControlBar.Width - btnMenu.Width, btnMenu.Location.Y);
 			}


### PR DESCRIPTION
Fix the position of the unlink button when the writing system is right to left.

Change-Id: I818384b8066213b570c39155137ad18ef842d10a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/24)
<!-- Reviewable:end -->
