### PR TITLE
Add StyleNames to style definitions in Word export

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -108,7 +108,10 @@ namespace SIL.FieldWorks.XWorks
 			var projectStyle = styleSheet.Styles[styleName];
 			var exportStyleInfo = new ExportStyleInfo(projectStyle);
 			var exportStyle = new Style();
+			// StyleId is used for style linking in the xml.
 			exportStyle.StyleId = styleName.Trim('.');
+			// StyleName is the name a user will see for the given style in Word's style sheet.
+			exportStyle.Append(new StyleName() {Val = exportStyle.StyleId});
 			var parProps = new ParagraphProperties();
 			var runProps = new StyleRunProperties();
 


### PR DESCRIPTION
- Fixes styles not linking with the style sheet in Microsoft Word.
- Fixes styles not appearing in LibreOffice.

Change-Id: I433acde125f638f963b35bcbb9b92b319062cb9a