### PR TITLE
Add BasedOn style property and fix duplicate styles

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -116,6 +116,9 @@ namespace SIL.FieldWorks.XWorks
 			var parProps = new ParagraphProperties();
 			var runProps = new StyleRunProperties();
 
+			if (exportStyleInfo.BasedOnStyle?.Name != null)
+				exportStyle.BasedOn = new BasedOn() { Val = exportStyleInfo.BasedOnStyle.Name };
+
 			// Create paragraph and run styles as specified by exportStyleInfo.
 			// Only if the style to export is a paragraph style should we create paragraph formatting options like indentation, alignment, border, etc.
 			if (exportStyleInfo.IsParagraphStyle)
@@ -456,6 +459,7 @@ namespace SIL.FieldWorks.XWorks
 				wsStyle.Append(new BasedOn() { Val = configNode.Style });
 
 				wsStyle.StyleId = configNode.Style + wsString;
+				wsStyle.StyleName = new StyleName(){ Val = wsStyle.StyleId };
 
 				if (!IsEmptyStyle(wsStyle))
 					return wsStyle;
@@ -561,6 +565,7 @@ namespace SIL.FieldWorks.XWorks
 			var styleRules = new Styles();
 			var wsRule1 = GetOnlyCharacterStyle(GenerateWordStyleFromLcmStyleSheet(WritingSystemStyleName, 0, configNode, propertyTable));
 			wsRule1.StyleId = (string.Format("{0}.{1}", baseSelection, WritingSystemPrefix)).Trim('.');
+			wsRule1.StyleName = new StyleName() { Val = wsRule1.StyleId };
 			styleRules = AddRange(styleRules, wsRule1);
 
 			// TODO: Determine how to handle after content in Word export (can't add content via a style)
@@ -871,8 +876,8 @@ namespace SIL.FieldWorks.XWorks
 			return null;
 		}
 
-		public static bool AreStylesEquivalent(Styles first,
-			Styles second)
+		public static bool AreStylesEquivalent(Style first,
+			Style second)
 		{
 			// OuterXml gets the markup that represents the current element and all of its child elements.
 			// All styles and style specification added to the styles element will be its children;


### PR DESCRIPTION
- Add based on property when generating styles from LCM stylesheet that have based on specified in FLEx.

- Edit styleDictionary to store individual styles instead of groups of styles.

- Revise AddStyles so it adds each style one time only, using the stylenames instead of css classes as the dictionary keys.

NOTE: In the Word export, the style dictionary should save each style individually rather than a collection of styles associated with a given css class.
Otherwise, any given style may be added to the styles xml multiple times, once for each css class using that style.

Remaining task:
- Homograph-Number style is still being duplicated. It is handled in a different function and requires its own fix.

Change-Id: I9530c894fdae8251ab4211f1c7529fa63586b446

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/32)
<!-- Reviewable:end -->
