### PR TITLE
Fix NUnit by adding NUnit3TestAdapter

### DIFF
--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -35,6 +35,7 @@
   <package id="NUnit" version="3.13.3" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.12.0" targetFramework="net40" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.7.0" />
+  <package id="NUnit3TestAdapter" version="4.3.2" />
   <package id="ParatextData" version="9.4.0.1-beta" targetFramework="net46"/>
   <package id="protobuf-net" version="2.4.6" exclude="Build,Analyzers" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" />

--- a/Src/LexText/Interlinear/ITextDllTests/ITextDllTests.csproj
+++ b/Src/LexText/Interlinear/ITextDllTests/ITextDllTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
+  <Import Project="..\..\..\..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props" />
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.21022</ProductVersion>


### PR DESCRIPTION
You need to add NUnit3TestAdapter to each csproj file that you want to run from within VisualStudio:

<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
  <Import Project="..\..\..\..\packages\NUnit3TestAdapter.4.3.2\build\net35\NUnit3TestAdapter.props" />
  <PropertyGroup>
  ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/34)
<!-- Reviewable:end -->
