### PR TITLE
LT-21761: Fix indenting for the first line after a Table

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1107,7 +1107,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			// Each entry starts a new paragraph, and any entry data added will usually be added within the same paragraph.
 			// The paragraph will end whenever a data type that cannot be in a paragraph is encounter (Tables or Pictures).
-			// A new 'continuation' paragraph will be started after the Table ot Picture if there is other data that still
+			// A new 'continuation' paragraph will be started after the Table or Picture if there is other data that still
 			// needs to be added to the entry.
 			// Create a new paragraph for the entry.
 			DocFragment wordDoc = ((WordFragmentWriter)writer).WordFragment;

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -32,6 +32,7 @@ namespace SIL.FieldWorks.XWorks
 		internal const string WritingSystemPrefix = "writingsystemprefix";
 		internal const string WritingSystemStyleName = "Writing System Abbreviation";
 		internal const string PictureAndCaptionTextframeStyle = "Image-Textframe-Style";
+		internal const string EntryStyleContinue = "-Continue";
 
 		public static Style GenerateLetterHeaderStyle(
 			ReadOnlyPropertyTable propertyTable, LcmStyleSheet mediatorStyleSheet)
@@ -81,7 +82,7 @@ namespace SIL.FieldWorks.XWorks
 			ConfigurableDictionaryNode node, ReadOnlyPropertyTable propertyTable)
 		{
 			return GenerateWordStyleFromLcmStyleSheet(styleName, wsId, node, propertyTable,
-				false);
+				false, true);
 		}
 
 		/// <summary>
@@ -95,10 +96,11 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="wsId">writing system id</param>
 		/// <param name="node">The configuration node to use for generating paragraph margin in context</param>
 		/// <param name="propertyTable">To retrieve styles</param>
+		/// <param name="allowFirstLineIndent">Indicates if the style returned should include FirstLineIndent.</param>
 		/// <returns></returns>
 		internal static Style GenerateWordStyleFromLcmStyleSheet(
 			string styleName, int wsId, ConfigurableDictionaryNode node,
-			ReadOnlyPropertyTable propertyTable, bool calculateFirstSenseStyle)
+			ReadOnlyPropertyTable propertyTable, bool calculateFirstSenseStyle, bool allowFirstLineIndent)
 		{
 			var styleSheet = FontHeightAdjuster.StyleSheetFromPropertyTable(propertyTable);
 			if (styleSheet == null || !styleSheet.Styles.Contains(styleName))
@@ -177,7 +179,10 @@ namespace SIL.FieldWorks.XWorks
 						hangingIndent = firstLineIndentValue;
 					}
 
-					parProps.Append(new Indentation() { FirstLine = firstLineIndentValue.ToString() });
+					if (allowFirstLineIndent)
+					{
+						parProps.Append(new Indentation() { FirstLine = firstLineIndentValue.ToString() });
+					}
 				}
 
 				if (exportStyleInfo.HasKeepWithNext)
@@ -574,6 +579,25 @@ namespace SIL.FieldWorks.XWorks
 			styleRules.Add(wsRule2);*/
 
 			return styleRules;
+		}
+
+		/// <summary>
+		/// Create the 'continuation' style for the entry, which is needed when an entry contains multiple paragraphs. This
+		/// style will be used for all but the first paragraph. It is the same as the style for the first paragraph except
+		/// that it does not contain the first line indenting.
+		/// </summary>
+		/// <returns>Returns the continuation style.</returns>
+		internal static Styles GenerateContinuationWordStyles(
+			ConfigurableDictionaryNode node, ReadOnlyPropertyTable propertyTable)
+		{
+			Style contStyle = GenerateWordStyleFromLcmStyleSheet(node.Style, DefaultStyle, node,
+				propertyTable, false, false);
+			contStyle.StyleName.Val = node.Style + EntryStyleContinue;
+			contStyle.StyleId = node.Style + EntryStyleContinue;
+
+			var retStyles = new Styles();
+			retStyles.AppendChild(contStyle.CloneNode(true));
+			return retStyles;
 		}
 
 		/// <summary>


### PR DESCRIPTION
The first line of an entry typically uses FirstLineIndent to indented to the left. When we have multiple paragraphs for an entry (because the entry contains Tables or Pictures) then we do not want the line following the Table or Picture to also be indented to the left. We now create a ‘continuation’ style for paragraphs following a table or picture.  It is the same as the original style except it does not use FirstLineIndent.

Change-Id: I67e282e4a02f1ff9145dfb198c4432823d156413

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/37)
<!-- Reviewable:end -->
