### PR TITLE
Fix reversal export naming & don't export empty reversals

### DIFF
--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -99,10 +99,15 @@ namespace SIL.FieldWorks.XWorks
 				configuration = configuration ?? new DictionaryConfigurationModel(
 					DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable, "ReversalIndex"), m_cache);
 				var publicationDecorator = ConfiguredLcmGenerator.GetPublicationDecoratorAndEntries(m_propertyTable, out var entriesToSave, ReversalType);
+
+				// Don't export empty reversals
+				if (entriesToSave.Length == 0)
+					return;
+
 				if (progress != null)
 				  progress.Maximum = entriesToSave.Length;
 
-				string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-" + reversalWs + ".docx";
+				string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-reversal-" + reversalWs + ".docx";
 
 				LcmWordGenerator.SavePublishedDocx(entriesToSave, publicationDecorator, int.MaxValue, configuration, m_propertyTable, reversalFilePath, progress);
 			}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/41)
<!-- Reviewable:end -->
