### PR TITLE
Disable borders in Word Export

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -145,7 +145,13 @@ namespace SIL.FieldWorks.XWorks
 						// alignment is always a paragraph property
 						parProps.Append(alignmentStyle);
 				}
-				if (exportStyleInfo.HasBorder)
+
+				// TODO:
+				// The code below works to handle borders for the word export.
+				// However, borders do not currently display in FLEx, and once a border has been added in FLEx,
+				// deselecting the border does not actually remove it from the styles object in FLEx.
+				// Until this is fixed, it is better not to display borders in the word export.
+				/*if (exportStyleInfo.HasBorder)
 				{
 					// create borders to add to the paragraph properties
 					ParagraphBorders border = new ParagraphBorders();
@@ -173,7 +179,8 @@ namespace SIL.FieldWorks.XWorks
 					border.Append(BottomBorder);
 					parProps.Append(border);
 
-				}
+				}*/
+
 				if (exportStyleInfo.HasFirstLineIndent)
 				{
 					// Handles both first-line and hanging indent, hanging-indent will result in a negative text-indent value


### PR DESCRIPTION
- Comment out handling of borders in Word Export

Borders do not currently display in FLEx.
But once a border is added to a style in FLEx, deselecting the border does not actually remove the border object from the FLEx style. This means if a border has ever been added in FLEx, it will still exist in the configuration node and be added in the word export. Until this is fixed, we should disable borders in the word export.