### PR TITLE
LT-21778: Fix image textframe styles

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -468,12 +468,12 @@ namespace SIL.FieldWorks.XWorks
 				if (forceNewParagraph)
 				{
 					// When forcing a new paragraph use a 'continuation' style for the new paragraph.
-					// The continuation style is based on the style used in the last paragraph.
+					// The continuation style is based on the style used in the first paragraph.
 					string style = null;
-					WP.Paragraph lastParagraph = DocBody.OfType<WP.Paragraph>().LastOrDefault();
-					if (lastParagraph != null)
+					WP.Paragraph firstParagraph = DocBody.OfType<WP.Paragraph>().FirstOrDefault();
+					if (firstParagraph != null)
 					{
-						WP.ParagraphProperties paraProps = lastParagraph.OfType<WP.ParagraphProperties>().FirstOrDefault();
+						WP.ParagraphProperties paraProps = firstParagraph.OfType<WP.ParagraphProperties>().FirstOrDefault();
 						if (paraProps != null)
 						{
 							ParagraphStyleId styleId = paraProps.OfType<WP.ParagraphStyleId>().FirstOrDefault();
@@ -1206,14 +1206,16 @@ namespace SIL.FieldWorks.XWorks
 								{
 									if (pieceHasImage)
 									{
-										wordWriter.WordFragment.AppendToParagraph(frag, new Run(), true);
+										wordWriter.WordFragment.GetNewParagraph();
+										wordWriter.WordFragment.AppendToParagraph(frag, new Run(), false);
 									}
 
 									// We have now added at least one image from this piece.
 									pieceHasImage = true;
 								}
 
-								wordWriter.WordFragment.AppendToParagraph(frag, run, wordWriter.ForceNewParagraph);
+								wordWriter.WordFragment.GetNewParagraph();
+								wordWriter.WordFragment.AppendToParagraph(frag, run, false);
 								wordWriter.WordFragment.LinkParaStyle(WordStylesGenerator.PictureAndCaptionTextframeStyle);
 							}
 


### PR DESCRIPTION
Fixed the problem with the continuation style being written to paragraphs containing images/captions (instead of the textframe style being written).
To prevent the problem with the paragraph following the image/caption from using the textframe style, we now base the continuation style on the first paragraph instead of the last.

Change-Id: Ibae531ebf142719d55b912efe72746299a1ce642

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/44)
<!-- Reviewable:end -->
