### PR TITLE
Pass a content fragment to AddLexReferences()

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -1366,7 +1366,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			// To be used for things like shared grammatical info
 			var sharedCollectionInfo = settings.ContentGenerator.CreateFragment();
-			var bldr = settings.ContentGenerator.CreateFragment();
+			var frag = settings.ContentGenerator.CreateFragment();
 			IEnumerable collection;
 			if (collectionField is IEnumerable)
 			{
@@ -1384,7 +1384,7 @@ namespace SIL.FieldWorks.XWorks
 
 			if (config.DictionaryNodeOptions is DictionaryNodeSenseOptions)
 			{
-				bldr.Append(GenerateContentForSenses(config, pubDecorator, settings, collection, info, ref sharedCollectionInfo));
+				frag.Append(GenerateContentForSenses(config, pubDecorator, settings, collection, info, ref sharedCollectionInfo));
 			}
 			else
 			{
@@ -1392,11 +1392,11 @@ namespace SIL.FieldWorks.XWorks
 				ConfigurableDictionaryNode lexEntryTypeNode;
 				if (IsVariantEntryType(config, out lexEntryTypeNode))
 				{
-					bldr.Append(GenerateContentForEntryRefCollection(config, collection, cmOwner, pubDecorator, settings, lexEntryTypeNode, false));
+					frag.Append(GenerateContentForEntryRefCollection(config, collection, cmOwner, pubDecorator, settings, lexEntryTypeNode, false));
 				}
 				else if (IsComplexEntryType(config, out lexEntryTypeNode))
 				{
-					bldr.Append(GenerateContentForEntryRefCollection(config, collection, cmOwner, pubDecorator, settings, lexEntryTypeNode, true));
+					frag.Append(GenerateContentForEntryRefCollection(config, collection, cmOwner, pubDecorator, settings, lexEntryTypeNode, true));
 				}
 				else if (IsPrimaryEntryReference(config, out lexEntryTypeNode))
 				{
@@ -1413,13 +1413,13 @@ namespace SIL.FieldWorks.XWorks
 						bool first = true;
 						foreach (var entry in lerCollection.Where(item => !item.ComplexEntryTypesRS.Any() && !item.VariantEntryTypesRS.Any()))
 						{
-							bldr.Append(GenerateCollectionItemContent(config, pubDecorator, entry, collectionOwner, settings, first, lexEntryTypeNode));
+							frag.Append(GenerateCollectionItemContent(config, pubDecorator, entry, collectionOwner, settings, first, lexEntryTypeNode));
 							first = false;
 						}
 						// Display refs of each type
-						GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, bldr, lexEntryTypeNode,
+						GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, frag, lexEntryTypeNode,
 							true); // complex
-						GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, bldr, lexEntryTypeNode,
+						GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, frag, lexEntryTypeNode,
 							false); // variants
 					}
 					else
@@ -1428,36 +1428,36 @@ namespace SIL.FieldWorks.XWorks
 						bool first = true;
 						foreach (var item in lerCollection)
 						{
-							bldr.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
+							frag.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
 							first = false;
 						}
 					}
 				}
 				else if (config.FieldDescription.StartsWith("Subentries"))
 				{
-					GenerateContentForSubentries(config, collection, cmOwner, pubDecorator, settings, bldr);
+					GenerateContentForSubentries(config, collection, cmOwner, pubDecorator, settings, frag);
 				}
 				else if (IsLexReferenceCollection(config))
 				{
-					GenerateContentForLexRefCollection(config, collection.Cast<ILexReference>(), cmOwner, pubDecorator, settings, bldr);
+					GenerateContentForLexRefCollection(config, collection.Cast<ILexReference>(), cmOwner, pubDecorator, settings, frag);
 				}
 				else
 				{
 					bool first = true;
 					foreach (var item in collection)
 					{
-						bldr.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
+						frag.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
 						first = false;
 					}
 				}
 			}
 
-			if (bldr.Length() > 0 || sharedCollectionInfo.Length() > 0)
+			if (frag.Length() > 0 || sharedCollectionInfo.Length() > 0)
 			{
 				var className = settings.StylesGenerator.AddStyles(config).Trim('.');
 				return config.DictionaryNodeOptions is DictionaryNodeSenseOptions ?
-					settings.ContentGenerator.WriteProcessedSenses(false, bldr, config, className, sharedCollectionInfo) :
-					settings.ContentGenerator.WriteProcessedCollection(false, bldr, config, className);
+					settings.ContentGenerator.WriteProcessedSenses(false, frag, config, className, sharedCollectionInfo) :
+					settings.ContentGenerator.WriteProcessedCollection(false, frag, config, className);
 			}
 			return settings.ContentGenerator.CreateFragment();
 		}
@@ -1523,7 +1523,7 @@ namespace SIL.FieldWorks.XWorks
 		private static IFragment GenerateContentForEntryRefCollection(ConfigurableDictionaryNode config, IEnumerable collection, ICmObject collectionOwner,
 			DictionaryPublicationDecorator pubDecorator, GeneratorSettings settings, ConfigurableDictionaryNode typeNode, bool isComplex)
 		{
-			var bldr = settings.ContentGenerator.CreateFragment();
+			var frag = settings.ContentGenerator.CreateFragment();
 
 			var lerCollection = collection.Cast<ILexEntryRef>().ToList();
 			// ComplexFormsNotSubentries is a filtered version of VisibleComplexFormBackRefs, so it doesn't have it's own VirtualOrdering.
@@ -1543,11 +1543,11 @@ namespace SIL.FieldWorks.XWorks
 				bool first = true;
 				foreach (var entry in lerCollection.Where(item => !item.ComplexEntryTypesRS.Any() && !item.VariantEntryTypesRS.Any()))
 				{
-					bldr.Append(GenerateCollectionItemContent(config, pubDecorator, entry, collectionOwner, settings, first, typeNode));
+					frag.Append(GenerateCollectionItemContent(config, pubDecorator, entry, collectionOwner, settings, first, typeNode));
 					first = false;
 				}
 				// Display refs of each type
-				GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, bldr, typeNode, isComplex);
+				GenerateContentForLexEntryRefsByType(config, lerCollection, collectionOwner, pubDecorator, settings, frag, typeNode, isComplex);
 			}
 			else
 			{
@@ -1555,11 +1555,11 @@ namespace SIL.FieldWorks.XWorks
 				bool first = true;
 				foreach (var item in lerCollection)
 				{
-					bldr.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
+					frag.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
 					first = false;
 				}
 			}
-			return bldr;
+			return frag;
 		}
 
 		private static void GenerateContentForLexEntryRefsByType(ConfigurableDictionaryNode config, List<ILexEntryRef> lerCollection, object collectionOwner, DictionaryPublicationDecorator pubDecorator,
@@ -1613,7 +1613,7 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		private static void GenerateContentForSubentries(ConfigurableDictionaryNode config, IEnumerable collection, ICmObject collectionOwner,
-			DictionaryPublicationDecorator pubDecorator, GeneratorSettings settings, IFragment bldr)
+			DictionaryPublicationDecorator pubDecorator, GeneratorSettings settings, IFragment frag)
 		{
 			var listOptions = config.DictionaryNodeOptions as DictionaryNodeListOptions;
 			var typeNode = config.ReferencedOrDirectChildren.FirstOrDefault(n => n.FieldDescription == LookupComplexEntryType);
@@ -1631,7 +1631,7 @@ namespace SIL.FieldWorks.XWorks
 				{
 					if (subentries[i].Item1 == null || !subentries[i].Item1.ComplexEntryTypesRS.Any())
 					{
-						bldr.Append(GenerateCollectionItemContent(config, pubDecorator, subentries[i].Item2, collectionOwner, settings, first));
+						frag.Append(GenerateCollectionItemContent(config, pubDecorator, subentries[i].Item2, collectionOwner, settings, first));
 						first = false;
 						subentries.RemoveAt(i--);
 					}
@@ -1643,7 +1643,7 @@ namespace SIL.FieldWorks.XWorks
 					{
 						if (subentries[i].Item1.ComplexEntryTypesRS.Any(t => t.Guid == typeGuid))
 						{
-							bldr.Append(GenerateCollectionItemContent(config, pubDecorator, subentries[i].Item2, collectionOwner, settings, first));
+							frag.Append(GenerateCollectionItemContent(config, pubDecorator, subentries[i].Item2, collectionOwner, settings, first));
 							first = false;
 							subentries.RemoveAt(i--);
 						}
@@ -1656,7 +1656,7 @@ namespace SIL.FieldWorks.XWorks
 				bool first = true;
 				foreach (var item in collection)
 				{
-					bldr.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
+					frag.Append(GenerateCollectionItemContent(config, pubDecorator, item, collectionOwner, settings, first));
 					first = false;
 				}
 			}
@@ -2104,19 +2104,19 @@ namespace SIL.FieldWorks.XWorks
 					switch (child.FieldDescription)
 					{
 						case "ConfigTargets":
-							var contentBldr = new StringBuilder();
+							var content = settings.ContentGenerator.CreateFragment();
 							foreach (var referenceListItem in referenceList)
 							{
 								var referenceItem = referenceListItem.Item2;
 								var targetItem = referenceListItem.Item1;
-								contentBldr.Append(GenerateCollectionItemContent(child, publicationDecorator, targetItem, referenceItem, settings, first));
+								content.Append(GenerateCollectionItemContent(child, publicationDecorator, targetItem, referenceItem, settings, first));
 								first = false;
 							}
-							if (contentBldr.Length > 0)
+							if (!content.IsNullOrEmpty())
 							{
 								// targets
 								settings.ContentGenerator.AddCollection(xw, IsBlockProperty(child),
-									CssGenerator.GetClassAttributeForConfig(child), config, contentBldr.ToString());
+									CssGenerator.GetClassAttributeForConfig(child), config, content);
 							}
 							break;
 						case "OwnerType":

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -51,7 +51,7 @@ namespace SIL.FieldWorks.XWorks
 		void StartEntry(IFragmentWriter writer, ConfigurableDictionaryNode config, string className, Guid entryGuid, int index, RecordClerk clerk);
 		void AddEntryData(IFragmentWriter writer, List<ConfiguredLcmGenerator.ConfigFragment> pieces);
 		void EndEntry(IFragmentWriter writer);
-		void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, string content);
+		void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, IFragment content);
 		void BeginObjectProperty(IFragmentWriter writer, bool isBlockProperty, string getCollectionItemClassAttribute);
 		void EndObject(IFragmentWriter writer);
 		void WriteProcessedContents(IFragmentWriter writer, IFragment contents);

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -58,7 +58,7 @@ namespace SIL.FieldWorks.XWorks
 		IFragment AddImage(string classAttribute, string srcAttribute, string pictureGuid);
 		IFragment AddImageCaption(string captionContent);
 		IFragment GenerateSenseNumber(string formattedSenseNumber, string senseNumberWs, ConfigurableDictionaryNode config);
-		IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className, string referencesContent, bool typeBefore);
+		IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className, IFragment referencesContent, bool typeBefore);
 		void BeginCrossReference(IFragmentWriter writer, bool isBlockProperty, string className);
 		void EndCrossReference(IFragmentWriter writer);
 		IFragment WriteProcessedSenses(bool isBlock, IFragment senseContent, ConfigurableDictionaryNode config, string className, IFragment sharedCollectionInfo);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -292,11 +292,11 @@ namespace SIL.FieldWorks.XWorks
 			((JsonFragmentWriter)xw).EndObject();
 		}
 
-		public void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, string content)
+		public void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, IFragment content)
 		{
 			((JsonFragmentWriter)writer).InsertPropertyName(className);
 			BeginArray(writer);
-			WriteProcessedContents(writer, new StringFragment(content));
+			WriteProcessedContents(writer, content);
 			EndArray(writer);
 		}
 

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -364,7 +364,7 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		public IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className,
-			string referencesContent, bool typeBefore)
+			IFragment referencesContent, bool typeBefore)
 		{
 			var bldr = new StringBuilder();
 			var fragment = new StringFragment(bldr);
@@ -382,7 +382,7 @@ namespace SIL.FieldWorks.XWorks
 				// Write an array with the references.
 				xw.WritePropertyName("references");
 				xw.WriteStartArray();
-				xw.WriteRaw(referencesContent);
+				xw.WriteRaw(referencesContent.ToString());
 				xw.WriteEndArray();
 				// Write properties related to the factored type (if any and if after).
 				if (generateLexType && !typeBefore)

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1323,17 +1323,11 @@ namespace SIL.FieldWorks.XWorks
 		{
 			return;
 		}
-		public void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, string content)
+		public void AddCollection(IFragmentWriter writer, bool isBlockProperty, string className, ConfigurableDictionaryNode config, IFragment content)
 		{
-			var frag = ((WordFragmentWriter)writer).WordFragment;
-			if (isBlockProperty && (config.StyleType == ConfigurableDictionaryNode.StyleTypes.Paragraph))
-				frag.AddStyleLink(config.Style, config, ConfigurableDictionaryNode.StyleTypes.Paragraph);
-			else if (!isBlockProperty)
-				frag.AddStyleLink(config.Style, config, ConfigurableDictionaryNode.StyleTypes.Character);
-
-			if (!string.IsNullOrEmpty(content))
+			if (!content.IsNullOrEmpty())
 			{
-				frag.Append(content);
+				((WordFragmentWriter)writer).WordFragment.Append(content);
 			}
 		}
 		public void BeginObjectProperty(IFragmentWriter writer, bool isBlockProperty, string getCollectionItemClassAttribute)

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1381,7 +1381,7 @@ namespace SIL.FieldWorks.XWorks
 			senseNum.AddStyleLink(WordStylesGenerator.SenseNumberStyleName, senseConfigNode, ConfigurableDictionaryNode.StyleTypes.Character);
 			return senseNum;
 		}
-		public IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className, string referencesContent, bool typeBefore)
+		public IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className, IFragment referencesContent, bool typeBefore)
 		{
 			var fragment = new DocFragment();
 			// Generate the factored ref types element (if before).
@@ -1390,7 +1390,7 @@ namespace SIL.FieldWorks.XWorks
 				fragment.Append(WriteProcessedObject(false, lexTypeContent, config, className));
 			}
 			// Then add all the contents for the LexReferences (e.g. headwords)
-			fragment.Append(new DocFragment(referencesContent));
+			fragment.Append(referencesContent);
 			// Generate the factored ref types element (if after).
 			if (generateLexType && !typeBefore)
 			{

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -961,7 +961,7 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		public IFragment AddLexReferences(bool generateLexType, IFragment lexTypeContent, ConfigurableDictionaryNode config, string className,
-			string referencesContent, bool typeBefore)
+			IFragment referencesContent, bool typeBefore)
 		{
 			var bldr = new StringBuilder(100);
 			var fragment = new StringFragment(bldr);
@@ -971,7 +971,7 @@ namespace SIL.FieldWorks.XWorks
 				bldr.Append(WriteProcessedObject(false, lexTypeContent, config, className));
 			}
 			// Then add all the contents for the LexReferences (e.g. headwords)
-			bldr.Append(referencesContent);
+			bldr.Append(referencesContent.ToString());
 			// Generate the factored ref types element (if after).
 			if (generateLexType && !typeBefore)
 			{

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -884,12 +884,12 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		public void AddCollection(IFragmentWriter writer, bool isBlockProperty,
-			string className, ConfigurableDictionaryNode config, string content)
+			string className, ConfigurableDictionaryNode config, IFragment content)
 		{
 			var xw = ((XmlFragmentWriter)writer).Writer;
 			xw.WriteStartElement(isBlockProperty ? "div" : "span");
 			xw.WriteAttributeString("class", className);
-			xw.WriteRaw(content);
+			xw.WriteRaw(content.ToString());
 			xw.WriteEndElement();
 		}
 


### PR DESCRIPTION
Converting the fragment to a string was resulting in the loss of all styling for Word Export.  Now we pass the content fragment to AddLexReferences() and let the xhtml and json generators do the conversion to a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/60)
<!-- Reviewable:end -->
