### PR TITLE
Fix LT-21797: Missing highlights in Analyze tab

### DIFF
--- a/Src/Common/RootSite/CollectorEnv.cs
+++ b/Src/Common/RootSite/CollectorEnv.cs
@@ -92,6 +92,8 @@ namespace SIL.FieldWorks.Common.RootSites
 			public int m_tag;
 			/// <summary>Index of the current item</summary>
 			public int m_ihvo;
+			/// <summary>String properties of the current item</summary>
+			public Dictionary<int, string> m_stringProps;
 			/// <summary>Handles counting of previous occurrences of properties</summary>
 			public PrevPropCounter m_cpropPrev = new PrevPropCounter();
 
@@ -111,6 +113,7 @@ namespace SIL.FieldWorks.Common.RootSites
 				m_hvo = hvo;
 				m_tag = tag;
 				m_ihvo = ihvo;
+				m_stringProps = new Dictionary<int, string>();
 			}
 
 			/// --------------------------------------------------------------------------------
@@ -333,6 +336,10 @@ namespace SIL.FieldWorks.Common.RootSites
 		protected IFwMetaDataCache m_mdc = null;
 		/// <summary>This is used to find virtual property handlers in setting notifiers.  See LT-8245</summary>
 		protected IVwCacheDa m_cda = null;
+		/// <summary>
+		/// This is used to store string props for the next object added.
+		/// </summary>
+		protected Dictionary<int, string> m_stringProps = new Dictionary<int, string>();
 		#endregion
 
 		#region Constructor
@@ -843,11 +850,12 @@ namespace SIL.FieldWorks.Common.RootSites
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Nothing to do here. None of our collectors cares about string properties (yet).
+		/// Save string property for the next object.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public virtual void set_StringProperty(int sp, string bstrValue)
 		{
+			m_stringProps[sp] = bstrValue;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -1319,6 +1327,12 @@ namespace SIL.FieldWorks.Common.RootSites
 			else
 				ihvo = 0; // not a vector item.
 			OpenTheObject(hvoItem, ihvo);
+			// Add any pending string props.
+			StackItem top = PeekStack;
+			if (top != null)
+				top.m_stringProps = m_stringProps;
+			// Clear pending string props.
+			m_stringProps = new Dictionary<int, string>();
 			vc.Display(this, hvoItem, frag);
 			CloseTheObject();
 			if (!wasPropOpen)

--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -101,7 +101,7 @@ namespace SIL.FieldWorks.IText
 		internal const int ktagSegmentFree = -61;
 		internal const int ktagSegmentLit = -62;
 		internal const int ktagSegmentNote = -63;
-		internal const int ktagGuessedAnalysis = -64;
+		internal const int ktagAnalysisStatus = -64;
 		// flids for paragraph annotation sequences.
 		internal int ktagSegmentForms;
 
@@ -1822,7 +1822,7 @@ namespace SIL.FieldWorks.IText
 																			(int) AnalysisGuessServices.OpinionAgent.Parser;
 							m_this.SetGuessing(m_vwenv, isHumanGuess ? ApprovedGuessColor : MachineGuessColor);
 							// Let the exporter know that this is a guessed analysis.
-							m_vwenv.AddProp(ktagGuessedAnalysis, m_this, 0);
+							m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
 						}
 						m_vwenv.AddObj(m_hvoDefault, m_this, kfragAnalysisMorphs);
 					}
@@ -1838,7 +1838,7 @@ namespace SIL.FieldWorks.IText
 							// Real analysis is just word, one we're displaying is a default
 							m_this.SetGuessing(m_vwenv);
 							// Let the exporter know that this is a guessed analysis.
-							m_vwenv.AddProp(ktagGuessedAnalysis, m_this, 0);
+							m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
 						}
 						m_vwenv.AddObj(m_hvoWfiAnalysis, m_this, kfragAnalysisMorphs);
 					}

--- a/Src/LexText/Interlinear/InterlinearExporter.cs
+++ b/Src/LexText/Interlinear/InterlinearExporter.cs
@@ -33,7 +33,6 @@ namespace SIL.FieldWorks.IText
 		bool m_fDoingInterlinName = false; // true during MSA
 		bool m_fDoingGlossPrepend = false; // true after special AddProp
 		bool m_fDoingGlossAppend = false; // true after special AddProp
-		bool m_fDoingGuessedAnalysis = false; // true after special AddProp
 		string m_sPendingPrefix; // got a prefix, need the ws from the form itself before we write it.
 		string m_sFreeAnnotationType;
 		ITsString m_tssPendingHomographNumber;
@@ -389,11 +388,6 @@ namespace SIL.FieldWorks.IText
 
 		public override void AddProp(int tag, IVwViewConstructor vc, int frag)
 		{
-			if (tag == InterlinVc.ktagGuessedAnalysis)
-			{
-				m_fDoingGuessedAnalysis = true;
-				return;
-			}
 			if (tag == InterlinVc.ktagGlossPrepend)
 			{
 				m_fDoingGlossPrepend = true;
@@ -608,16 +602,15 @@ namespace SIL.FieldWorks.IText
 					break;
 				case InterlinVc.kfragMorphBundle:
 					m_writer.WriteStartElement("morphemes");
-					if (m_fDoingGuessedAnalysis)
+					StackItem top = this.PeekStack;
+					if (top != null && top.m_stringProps.ContainsKey(InterlinVc.ktagAnalysisStatus))
 					{
-						m_writer.WriteAttributeString("analysisStatus", "guess");
+						m_writer.WriteAttributeString("analysisStatus", top.m_stringProps[InterlinVc.ktagAnalysisStatus]);
 					}
 					break;
 				default:
 					break;
 			}
-			// Clear here instead of above just to make sure it gets cleared.
-			m_fDoingGuessedAnalysis = false;
 			base.AddObjVecItems (tag, vc, frag);
 			switch(frag)
 			{


### PR DESCRIPTION
Implementing LT-21777 (Mark guessed analyses in InterlinearExport) broke the highlighting in the interlinear display because the extra AddProp threw the display code off.  I changed the code to mark the guessed analysis using set_StringProp instead, which required me to implement set_StringProp in CollectorEnv.