### PR TITLE
Fix LT-10373: Try a Word crashes for double quote and angle bracket

### DIFF
--- a/Src/LexText/ParserUI/HCTrace.cs
+++ b/Src/LexText/ParserUI/HCTrace.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using System.Xml.Xsl;
 using SIL.LCModel;
@@ -26,12 +27,33 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public string CreateResultPage(PropertyTable propertyTable, XDocument result, bool isTrace)
 		{
+			result = FixAnyDoubleQuotes(result);
 			var args = new XsltArgumentList();
 			var loadErrorUri = new Uri(Path.Combine(Path.GetTempPath(),
 				propertyTable.GetValue<LcmCache>("cache").ProjectId.Name + "HCLoadErrors.xml"));
 			args.AddParam("prmHCTraceLoadErrorFile", "", loadErrorUri.AbsoluteUri);
 			args.AddParam("prmShowTrace", "", isTrace.ToString().ToLowerInvariant());
 			return TraceTransform.Transform(propertyTable, result, isTrace ? "HCTrace" : "HCParse", args);
+		}
+
+		/// <summary>
+		/// Convert any &amp;quot; sequences in the form to &quot; so it displays correctly
+		/// </summary>
+		/// <param name="result">The HermitCrab XML result</param>
+		/// <returns>Corrected result</returns>
+		private static XDocument FixAnyDoubleQuotes(XDocument result)
+		{
+			var forms = result.Descendants("Wordform");
+			var form = forms.FirstOrDefault();
+			if (form != null)
+			{
+				var attr = form.Attribute("form");
+				if (attr != null)
+				{
+					result = XAmpleTrace.FixAnyDoubleQuotes(result, attr.Value);
+				}
+			}
+			return result;
 		}
 	}
 }

--- a/Src/LexText/ParserUI/TryAWordDlg.cs
+++ b/Src/LexText/ParserUI/TryAWordDlg.cs
@@ -411,7 +411,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					var uri = new Uri(Path.Combine(TransformPath, "WhileTracing.htm"));
 					m_htmlControl.URL = uri.AbsoluteUri;
 					sWord = sWord.Replace(' ', '.'); // LT-7334 to allow for phrases; do this at the last minute
-					sWord = sWord.Replace("\"", "&quot;");  // LT-10373 a double quote causes a crash; change it so HTML/XML works
+					sWord = new System.Xml.Linq.XText(sWord).ToString();  // LT-10373 a double quote causes a crash; change it so HTML/XML works
 					m_parserListener.Connection.TryAWordDialogIsRunning = true; // make sure this is set properly
 					m_tryAWordResult = m_parserListener.Connection.BeginTryAWord(sWord, DoTrace, selectedTraceMorphs);
 					// waiting for result, so disable Try It button

--- a/Src/LexText/ParserUI/TryAWordDlg.cs
+++ b/Src/LexText/ParserUI/TryAWordDlg.cs
@@ -411,6 +411,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					var uri = new Uri(Path.Combine(TransformPath, "WhileTracing.htm"));
 					m_htmlControl.URL = uri.AbsoluteUri;
 					sWord = sWord.Replace(' ', '.'); // LT-7334 to allow for phrases; do this at the last minute
+					sWord = sWord.Replace("\"", "&quot;");  // LT-10373 a double quote causes a crash; change it so HTML/XML works
 					m_parserListener.Connection.TryAWordDialogIsRunning = true; // make sure this is set properly
 					m_tryAWordResult = m_parserListener.Connection.BeginTryAWord(sWord, DoTrace, selectedTraceMorphs);
 					// waiting for result, so disable Try It button

--- a/Src/LexText/ParserUI/XAmpleTrace.cs
+++ b/Src/LexText/ParserUI/XAmpleTrace.cs
@@ -13,6 +13,7 @@
 //		XAmpleTrace - Deal with results of an XAmple trace
 // </remarks>
 
+using System.Linq;
 using System.Xml.Linq;
 using XCore;
 
@@ -65,8 +66,39 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				transform = ParseTransform;
 				baseName = "XAmpleParse";
+				result = FixAnyDoubleQuotes(result);
 			}
 			return transform.Transform(propertyTable, result, baseName);
+		}
+
+		/// <summary>
+		/// Convert any &amp;quot; sequences in the form to &quot; so it displays correctly
+		/// </summary>
+		/// <param name="result">The XAmple XML result</param>
+		/// <returns>Corrected result</returns>
+		private static XDocument FixAnyDoubleQuotes(XDocument result)
+		{
+			var forms = result.Descendants("form");
+			var elem = forms.FirstOrDefault();
+			if (elem != null)
+			{
+				result = FixAnyDoubleQuotes(result, elem.Value);
+			}
+			return result;
+		}
+
+		public static XDocument FixAnyDoubleQuotes(XDocument result, string nodeValue)
+		{
+			if (nodeValue != null && nodeValue.Contains("&quot;"))
+			{
+				// The Contains method above compared to what is replaced below appears odd
+				// but what is really "&amp;quot;" is treated as "&quot;" in the node.
+				string fixedQuote = result.ToString().Replace("&amp;quot;", "&quot;");
+				XDocument fixedResult = XDocument.Parse(fixedQuote);
+				result = fixedResult;
+			}
+
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
I made the changes suggested by Andy Black, except that I generalized the fix so that it wouldn't crash on angle brackets or other special XML characters.