### PR TITLE
Word Export Style Display Names

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -163,7 +163,7 @@ namespace SIL.FieldWorks.XWorks
 				headwordWsCollator, settings, clerk);
 
 			// Create LetterHeader doc fragment and link it with the letter heading style.
-			return DocFragment.GenerateLetterHeaderDocFragment(headerTextBuilder.ToString(), WordStylesGenerator.LetterHeadingStyleName);
+			return DocFragment.GenerateLetterHeaderDocFragment(headerTextBuilder.ToString(), WordStylesGenerator.LetterHeadingDisplayName);
 		}
 
 		/*
@@ -230,14 +230,14 @@ namespace SIL.FieldWorks.XWorks
 			/// Generate the document fragment for a letter header.
 			/// </summary>
 			/// <param name="str">Letter header string.</param>
-			/// <param name="styleName">Letter header style.</param>
-			internal static DocFragment GenerateLetterHeaderDocFragment(string str, string styleName)
+			/// <param name="styleDisplayName">Letter header style name to display in Word.</param>
+			internal static DocFragment GenerateLetterHeaderDocFragment(string str, string styleDisplayName)
 			{
 				var docFrag = new DocFragment();
 				// Only create paragraph, run, and text objects if string is nonempty
 				if (!string.IsNullOrEmpty(str))
 				{
-					WP.ParagraphProperties paragraphProps = new WP.ParagraphProperties(new ParagraphStyleId() { Val = styleName });
+					WP.ParagraphProperties paragraphProps = new WP.ParagraphProperties(new ParagraphStyleId() { Val = styleDisplayName });
 					WP.Paragraph para = docFrag.DocBody.AppendChild(new WP.Paragraph(paragraphProps));
 					WP.Run run = para.AppendChild(new WP.Run());
 					// For spaces to show correctly, set preserve spaces on the text element
@@ -248,8 +248,10 @@ namespace SIL.FieldWorks.XWorks
 				return docFrag;
 			}
 
-			public static string GetWsStyleName(LcmCache cache, string styleName, ConfigurableDictionaryNode config, string writingSystem)
+			public static string GetWsStyleName(LcmCache cache, ConfigurableDictionaryNode config, string writingSystem)
 			{
+				string styleName = config.DisplayLabel;
+
 				// If the config does not contain writing system options, then just return the style name.(An example is custom fields.)
 				if (!(config.DictionaryNodeOptions is DictionaryNodeWritingSystemOptions))
 				{
@@ -266,7 +268,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 
 				// If there is no base style, return just the ws style.
-				if (styleName == null)
+				if (string.IsNullOrEmpty(styleName))
 					return WordStylesGenerator.GetWsString(wsStr);
 				// If there is a base style, return the ws-specific version of that style.
 				return styleName + WordStylesGenerator.GetWsString(wsStr);
@@ -622,50 +624,67 @@ namespace SIL.FieldWorks.XWorks
 				var run = new WP.Run();
 				WordFragment.DocBody.AppendChild(run);
 
-				if (writingSystem == null)
+				if (config == null || writingSystem == null)
 				{
 					return;
 				}
 
-				string styleName = null;
-				if (config == null || string.IsNullOrEmpty(config.Style))
+				string styleName = DocFragment.GetWsStyleName(cache, config, writingSystem);
+				if (!string.IsNullOrEmpty(styleName))
 				{
-					styleName = WordStylesGenerator.GetWsString(writingSystem);
-				}
-				else
-				{
-					styleName = DocFragment.GetWsStyleName(cache, config.Style, config, writingSystem);
-				}
-				run.Append(new RunProperties(new RunStyle() { Val = styleName }));
+					run.Append(new RunProperties(new RunStyle() { Val = styleName }));
 
-				// If the style is not in the dictionary, then add it.
-				lock (_styleDictionary)
-				{
-					if (!_styleDictionary.ContainsKey(styleName))
+					// If the style is not in the dictionary, then add it.
+					lock (_styleDictionary)
 					{
-						if (config != null && !string.IsNullOrEmpty(config.Style))
+						if (!_styleDictionary.ContainsKey(styleName))
 						{
-							var wsId = cache.LanguageWritingSystemFactoryAccessor.GetWsFromStr(writingSystem);
-							Style style = WordStylesGenerator.GenerateWordStyleFromLcmStyleSheet(config.Style, wsId, propTable);
-							if (style == null || style.Type != StyleValues.Character)
-							{
-								// If we hit this assert, then we might end up referencing a style that
-								// does not get created.
-								Debug.Assert(false);
-								return;
-							}
-
 							var wsString = WordStylesGenerator.GetWsString(writingSystem);
-							style.Append(new BasedOn() { Val = wsString });
-							style.StyleId = styleName;
-							style.StyleName = new StyleName() { Val = style.StyleId };
-							_styleDictionary[styleName] = style;
-						}
-						else
-						{
-							// If we hit this assert, then we might need to create a style for just the ws.
-							// We are expecting the ws style to be added to the _styleDictionary in GetDefaultWordStyles().
-							Debug.Assert(false);
+
+							// Get the style from the LcmStyleSheet, using the style name defined in the config.
+							if (!string.IsNullOrEmpty(config.Style))
+							{
+								var wsId = cache.LanguageWritingSystemFactoryAccessor.GetWsFromStr(writingSystem);
+								Style style = WordStylesGenerator.GenerateWordStyleFromLcmStyleSheet(config.Style, wsId, propTable);
+								if (style == null || style.Type != StyleValues.Character)
+								{
+									// If we hit this assert, then we might end up referencing a style that
+									// does not get created.
+									Debug.Assert(false);
+									return;
+								}
+
+								style.Append(new BasedOn() { Val = wsString });
+								style.StyleId = styleName;
+								style.StyleName.Val = style.StyleId;
+								_styleDictionary[styleName] = style;
+							}
+							// There is no style name defined in the config so generate a style that is identical to the writing system style
+							// except that it contains a display name that the user wants to see in the Word Styles. (example: "Reverse Abbreviation[lang='en']")
+							else
+							{
+								Style rootStyle = GetOrCreateCharacterStyle(wsString, wsString, propTable);
+								if (rootStyle != null)
+								{
+									Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(new Style(), wsString, styleName);
+									if (basedOnStyle != null)
+									{
+										_styleDictionary[styleName] = basedOnStyle;
+									}
+									else
+									{
+										// If we hit this assert, then we might end up referencing a style that
+										// does not get created.
+										Debug.Assert(false, "Could not generate BasedOn character style " + styleName);
+									}
+								}
+								else
+								{
+									// If we hit this assert, then we might end up referencing a style that
+									// does not get created.
+									Debug.Assert(false, "Could not create style for " + wsString);
+								}
+							}
 						}
 					}
 				}
@@ -703,7 +722,7 @@ namespace SIL.FieldWorks.XWorks
 			if (string.IsNullOrEmpty(config.Style) && !string.IsNullOrEmpty(config.Parent.Style) &&
 				(config.Parent.StyleType != ConfigurableDictionaryNode.StyleTypes.Paragraph))
 			{
-				AddRunStyle(elementContent, config.Parent.Style, false);
+				AddRunStyle(elementContent, config.Parent.Style, config.Parent.DisplayLabel, false);
 			}
 
 			bool eachOnANewLine = config != null &&
@@ -849,7 +868,7 @@ namespace SIL.FieldWorks.XWorks
 			if (!string.IsNullOrEmpty(config.Style) &&
 				(config.StyleType != ConfigurableDictionaryNode.StyleTypes.Paragraph))
 			{
-				AddRunStyle(content, config.Style, true);
+				AddRunStyle(content, config.Style, config.DisplayLabel, true);
 			}
 
 			var collData = CreateFragment();
@@ -950,7 +969,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			if (!string.IsNullOrEmpty(runStyle))
 			{
-				AddRunStyle(((WordFragmentWriter)writer).WordFragment, runStyle, false);
+				AddRunStyle(((WordFragmentWriter)writer).WordFragment, runStyle, runStyle, false);
 			}
 		}
 		public void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination)
@@ -1153,7 +1172,7 @@ namespace SIL.FieldWorks.XWorks
 			// Create a new paragraph for the entry.
 			DocFragment wordDoc = ((WordFragmentWriter)writer).WordFragment;
 			WP.Paragraph entryPar = wordDoc.GetNewParagraph();
-			WP.ParagraphProperties paragraphProps = new WP.ParagraphProperties(new ParagraphStyleId() {Val = config.Style});
+			WP.ParagraphProperties paragraphProps = new WP.ParagraphProperties(new ParagraphStyleId() {Val = config.DisplayLabel});
 			entryPar.Append(paragraphProps);
 
 			// Create the 'continuation' style for the entry. This style will be the same as the style for the entry with the only
@@ -1312,7 +1331,7 @@ namespace SIL.FieldWorks.XWorks
 		public IFragment GenerateSenseNumber(string formattedSenseNumber, string senseNumberWs, ConfigurableDictionaryNode senseConfigNode)
 		{
 			DocFragment senseNum = new DocFragment();
-			WP.Run run = CreateRun(formattedSenseNumber, WordStylesGenerator.SenseNumberStyleName);
+			WP.Run run = CreateRun(formattedSenseNumber, WordStylesGenerator.SenseNumberDisplayName);
 			senseNum.DocBody.AppendChild(run);
 			return senseNum;
 		}
@@ -1430,12 +1449,12 @@ namespace SIL.FieldWorks.XWorks
 		/// dictionary then create the Word style from the LCM Style Sheet and add it to the dictionary.
 		/// </summary>
 		/// <returns>Returns null if it fails to find or create the character style.</returns>
-		private Style GetOrCreateCharacterStyle(string styleName)
+		private static Style GetOrCreateCharacterStyle(string styleName, string styleDisplayName, ReadOnlyPropertyTable propertyTable)
 		{
 			Style retStyle = null;
 			lock (_styleDictionary)
 			{
-				if (_styleDictionary.TryGetValue(styleName, out retStyle))
+				if (_styleDictionary.TryGetValue(styleDisplayName, out retStyle))
 				{
 					if (retStyle.Type != StyleValues.Character)
 					{
@@ -1444,12 +1463,14 @@ namespace SIL.FieldWorks.XWorks
 				}
 				else
 				{
-					retStyle = WordStylesGenerator.GenerateWordStyleFromLcmStyleSheet(styleName, 0, _propertyTable);
+					retStyle = WordStylesGenerator.GenerateWordStyleFromLcmStyleSheet(styleName, 0, propertyTable);
 					if (retStyle == null || retStyle.Type != StyleValues.Character)
 					{
 						return null;
 					}
-					_styleDictionary[styleName] = retStyle;
+					retStyle.StyleId = styleDisplayName;
+					retStyle.StyleName.Val = retStyle.StyleId;
+					_styleDictionary[styleDisplayName] = retStyle;
 				}
 			}
 			return retStyle;
@@ -1504,7 +1525,7 @@ namespace SIL.FieldWorks.XWorks
 						// Otherwise get a unique but useful style name and re-name the style
 						styleName = GetBestUniqueNameForNode(_styleDictionary, node);
 						style.StyleId = styleName;
-						style.StyleName = new StyleName() { Val = styleName };
+						style.StyleName.Val = style.StyleId;
 						_styleDictionary[styleName] = style;
 					}
 				}
@@ -1695,13 +1716,13 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// Creates a run using the text provided and using the style provided.
 		/// </summary>
-		private WP.Run CreateRun(string runText, string runStyle)
+		private WP.Run CreateRun(string runText, string styleDisplayName)
 		{
 			WP.Run run = new WP.Run();
-			if (!string.IsNullOrEmpty(runStyle))
+			if (!string.IsNullOrEmpty(styleDisplayName))
 			{
 				WP.RunProperties runProps =
-					new WP.RunProperties(new RunStyle() { Val = runStyle });
+					new WP.RunProperties(new RunStyle() { Val = styleDisplayName });
 				run.Append(runProps);
 			}
 
@@ -1721,15 +1742,21 @@ namespace SIL.FieldWorks.XWorks
 		/// <returns>The BeforeAfterBetween run.</returns>
 		private WP.Run CreateBeforeAfterBetweenRun(string text)
 		{
-			return CreateRun(text, WordStylesGenerator.BeforeAfterBetweenStyleName);
+			return CreateRun(text, WordStylesGenerator.BeforeAfterBetweenDisplayName);
 		}
 
 		/// <summary>
 		/// Worker method for AddRunStyle(), not intended to be called from other places. If it is
 		/// then the the pre-checks on 'style' should be added to this method.
 		/// </summary>
-		private void AddRunStyle_Worker(WP.Run run, string style)
+		private void AddRunStyle_Worker(WP.Run run, string styleName, string styleDisplayName)
 		{
+			Style rootStyle = GetOrCreateCharacterStyle(styleName, styleDisplayName, _propertyTable);
+			if (rootStyle == null)
+			{
+				return;
+			}
+
 			if (run.RunProperties != null)
 			{
 				if (run.RunProperties.Descendants<RunStyle>().Any())
@@ -1738,7 +1765,7 @@ namespace SIL.FieldWorks.XWorks
 					if (!string.IsNullOrEmpty(currentRunStyle))
 					{
 						// If the current style is a language tag, then no need to add the colon.
-						string basedOnStyleName = currentRunStyle.StartsWith("[") ? (style + currentRunStyle) : (style + ":" + currentRunStyle);
+						string basedOnStyleName = currentRunStyle.StartsWith("[") ? (styleDisplayName + currentRunStyle) : (styleDisplayName + ":" + currentRunStyle);
 
 						lock (_styleDictionary)
 						{
@@ -1748,33 +1775,29 @@ namespace SIL.FieldWorks.XWorks
 							}
 							else
 							{
-								Style rootStyle = GetOrCreateCharacterStyle(style);
-								if (rootStyle != null)
+								Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(rootStyle, currentRunStyle, basedOnStyleName);
+								if (basedOnStyle != null)
 								{
-									Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(rootStyle, currentRunStyle, basedOnStyleName);
-									if (basedOnStyle != null)
-									{
-										_styleDictionary[basedOnStyleName] = basedOnStyle;
-										run.RunProperties.Descendants<RunStyle>().Last().Val = basedOnStyleName;
-									}
+									_styleDictionary[basedOnStyleName] = basedOnStyle;
+									run.RunProperties.Descendants<RunStyle>().Last().Val = basedOnStyleName;
 								}
 							}
 						}
 					}
 					else
 					{
-						run.RunProperties.Descendants<RunStyle>().Last().Val = style;
+						run.RunProperties.Descendants<RunStyle>().Last().Val = styleDisplayName;
 					}
 				}
 				else
 				{
-					run.RunProperties.Append(new RunStyle() { Val = style });
+					run.RunProperties.Append(new RunStyle() { Val = styleDisplayName });
 				}
 			}
 			else
 			{
 				WP.RunProperties runProps =
-					new WP.RunProperties(new RunStyle() { Val = style });
+					new WP.RunProperties(new RunStyle() { Val = styleDisplayName });
 				// Prepend RunProperties so it appears before any text elements contained in the run
 				run.PrependChild<WP.RunProperties>(runProps);
 			}
@@ -1787,13 +1810,14 @@ namespace SIL.FieldWorks.XWorks
 		/// style but makes it BasedOn the current style that is being used by the run.
 		/// </summary>
 		/// <param name="frag">The fragment containing the runs that should have the new style applied.</param>
-		/// <param name="style">Style to apply to the runs in the fragment.</param>
+		/// <param name="styleName">The FLEX style to apply to the runs in the fragment.</param>
+		/// <param name="styleDisplayName">The style name to display in Word.</param>
 		/// <param name="allRuns">If true then apply the style to all runs in the fragment.
 		///                       If false then only apply the style to the last run in the fragment.</param>
-		public void AddRunStyle(IFragment frag, string style, bool allRuns)
+		public void AddRunStyle(IFragment frag, string styleName, string styleDisplayName, bool allRuns)
 		{
 			string sDefaultTextStyle = "Default Paragraph Characters";
-			if (string.IsNullOrEmpty(style) || style.StartsWith(sDefaultTextStyle))
+			if (string.IsNullOrEmpty(styleName) || styleName.StartsWith(sDefaultTextStyle) || string.IsNullOrEmpty(styleDisplayName))
 			{
 				return;
 			}
@@ -1802,7 +1826,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				foreach (WP.Run run in ((DocFragment)frag).DocBody.Elements<WP.Run>())
 				{
-					AddRunStyle_Worker(run, style);
+					AddRunStyle_Worker(run, styleName, styleDisplayName);
 				}
 			}
 			else
@@ -1810,7 +1834,7 @@ namespace SIL.FieldWorks.XWorks
 				List<WP.Run> runList = ((DocFragment)frag).DocBody.Elements<WP.Run>().ToList();
 				if (runList.Any())
 				{
-					AddRunStyle_Worker(runList.Last(), style);
+					AddRunStyle_Worker(runList.Last(), styleName, styleDisplayName);
 				}
 			}
 		}

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -25,8 +25,11 @@ namespace SIL.FieldWorks.XWorks
 
 		// Names for global and default styles
 		internal const string BeforeAfterBetweenStyleName = "Dictionary-Context";
+		internal const string BeforeAfterBetweenDisplayName = "Context";
 		internal const string LetterHeadingStyleName = "Dictionary-LetterHeading";
+		internal const string LetterHeadingDisplayName = "LetterHeading";
 		internal const string SenseNumberStyleName = "Dictionary-SenseNumber";
+		internal const string SenseNumberDisplayName = "SenseNumber";
 		internal const string DictionaryNormal = "Dictionary-Normal";
 		internal const string DictionaryMinor = "Dictionary-Minor";
 		internal const string WritingSystemPrefix = "writingsystemprefix";
@@ -36,12 +39,18 @@ namespace SIL.FieldWorks.XWorks
 
 		public static Style GenerateLetterHeaderStyle(ReadOnlyPropertyTable propertyTable)
 		{
-			return GenerateWordStyleFromLcmStyleSheet(LetterHeadingStyleName, 0, propertyTable);
+			var style = GenerateWordStyleFromLcmStyleSheet(LetterHeadingStyleName, 0, propertyTable);
+			style.StyleId = LetterHeadingDisplayName;
+			style.StyleName.Val = style.StyleId;
+			return style;
 		}
 
 		public static Style GenerateBeforeAfterBetweenStyle(ReadOnlyPropertyTable propertyTable)
 		{
-			return GenerateWordStyleFromLcmStyleSheet(BeforeAfterBetweenStyleName, 0, propertyTable);
+			var style = GenerateWordStyleFromLcmStyleSheet(BeforeAfterBetweenStyleName, 0, propertyTable);
+			style.StyleId = BeforeAfterBetweenDisplayName;
+			style.StyleName.Val = style.StyleId;
+			return style;
 		}
 
 		public static Styles GetDefaultWordStyles(ReadOnlyPropertyTable propertyTable, LcmStyleSheet propStyleSheet, DictionaryConfigurationModel model)
@@ -313,13 +322,13 @@ namespace SIL.FieldWorks.XWorks
 					// Try to generate style for the sense number before the baseSelection is updated b/c
 					// the sense number is a sibling of the sense element and we are normally applying styles to the
 					// children of collections.
-					return GenerateWordStyleForSenses(configNode, senseOptions, ref styleName, propertyTable);
+					return GenerateWordStyleForSenses(configNode, senseOptions, propertyTable);
 
 				// TODO: handle listAndPara case and character portion of pictureOptions
 				// case IParaOption listAndParaOpts:
 
 				case DictionaryNodePictureOptions pictureOptions:
-					return GenerateWordStyleFromPictureOptions(configNode, pictureOptions, styleName, cache, propertyTable);
+					return GenerateWordStyleFromPictureOptions(configNode, pictureOptions, cache, propertyTable);
 
 				default:
 					{
@@ -338,11 +347,14 @@ namespace SIL.FieldWorks.XWorks
 						// if the configuration node defines a style then add all the rules generated from that style
 						if (!string.IsNullOrEmpty(configNode.Style))
 						{
-							//Generate the rules for the default font info
-							rule = GenerateWordStyleFromLcmStyleSheet(configNode.Style, DefaultStyle, configNode, propertyTable);
-
-							rule.StyleId = configNode.Style;
-							rules.AppendChild(rule.CloneNode(true));
+							if (configNode.StyleType == ConfigurableDictionaryNode.StyleTypes.Paragraph)
+							{
+								//Generate the rules for the default font info
+								rule = GenerateWordStyleFromLcmStyleSheet(configNode.Style, DefaultStyle, configNode, propertyTable);
+								rule.StyleId = configNode.DisplayLabel;
+								rule.StyleName.Val = rule.StyleId;
+								rules.AppendChild(rule.CloneNode(true));
+							}
 						}
 						return rules;
 					}
@@ -414,7 +426,7 @@ namespace SIL.FieldWorks.XWorks
 			return styleRules;
 		}
 
-		private static Styles GenerateWordStyleForSenses(ConfigurableDictionaryNode configNode, DictionaryNodeSenseOptions senseOptions, ref string baseSelection, ReadOnlyPropertyTable propertyTable)
+		private static Styles GenerateWordStyleForSenses(ConfigurableDictionaryNode configNode, DictionaryNodeSenseOptions senseOptions, ReadOnlyPropertyTable propertyTable)
 		{
 			var styleRules = new Styles();
 
@@ -433,8 +445,9 @@ namespace SIL.FieldWorks.XWorks
 			{
 				senseNumberStyle = GenerateWordStyleFromLcmStyleSheet(senseOptions.NumberStyle, senseNumberWsId, propertyTable);
 			}
+			senseNumberStyle.StyleId = SenseNumberDisplayName;
+			senseNumberStyle.StyleName = new StyleName() { Val = senseNumberStyle.StyleId };
 
-			senseNumberStyle.StyleId = SenseNumberStyleName;
 			if (!IsEmptyStyle(senseNumberStyle))
 				styleRules = AddRange(styleRules, senseNumberStyle);
 
@@ -465,12 +478,11 @@ namespace SIL.FieldWorks.XWorks
 				if (!IsEmptyStyle(senseContentStyle))
 					styleRules.Append(senseContentStyle);
 			}
-
 			return styleRules;
 		}
 
 		private static Styles GenerateWordStyleFromPictureOptions(ConfigurableDictionaryNode configNode, DictionaryNodePictureOptions pictureOptions,
-			string baseSelection, LcmCache cache, ReadOnlyPropertyTable propertyTable)
+			LcmCache cache, ReadOnlyPropertyTable propertyTable)
 		{
 			var styles = new Styles();
 
@@ -533,8 +545,8 @@ namespace SIL.FieldWorks.XWorks
 		{
 			Style contStyle = GenerateWordStyleFromLcmStyleSheet(node.Style, DefaultStyle, node,
 				propertyTable, false);
-			contStyle.StyleName.Val = node.Style + EntryStyleContinue;
-			contStyle.StyleId = node.Style + EntryStyleContinue;
+			contStyle.StyleId = node.DisplayLabel + EntryStyleContinue;
+			contStyle.StyleName.Val = contStyle.StyleId;
 
 			var retStyles = new Styles();
 			retStyles.AppendChild(contStyle.CloneNode(true));


### PR DESCRIPTION
This submission adds support for displaying the style Display Name in the Word Styles dialog (instead of displaying the style Id).

This addresses the main cases; more work is needed to handle the ‘normal’ styles, “Dictionary-Normal”, abbreviations, paragraph Styles properties, and the possibility of the same Display Name being used by different style Ids.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/84)
<!-- Reviewable:end -->
