### PR TITLE
Fix LT-21810: Yellow Crash occurs while parsing with Default Parser(XAmple)

### DIFF
--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -172,18 +172,21 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 			if (sLower != form.Text)
 			{
-				var lcResult = m_parser.ParseWord(
-					CustomIcu.GetIcuNormalizer(FwNormalizationMode.knmNFD)
-					.Normalize(sLower.Replace(' ', '.')));
-				if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
+				var text = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
+				IWfiWordform lcWordform;
+				// We cannot use WfiWordformServices.FindOrCreateWordform because of props change (LT-21810).
+				// Only parse the lowercase version if it exists.
+				if (m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(text, out lcWordform))
 				{
-					var text = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
-					IWfiWordform lcWordform;
-					// We cannot use WfiWordformServices.FindOrCreateWordform because of props change (LT-21810).
-					if (m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(text, out lcWordform))
+					var lcResult = m_parser.ParseWord(
+						CustomIcu.GetIcuNormalizer(FwNormalizationMode.knmNFD)
+						.Normalize(sLower.Replace(' ', '.')));
+					if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
+					{
 						m_parseFiler.ProcessParse(lcWordform, priority, lcResult);
-					m_parseFiler.ProcessParse(wordform, priority, result);
-					return true;
+						m_parseFiler.ProcessParse(wordform, priority, result);
+						return true;
+					}
 				}
 			}
 

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -178,8 +178,10 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
 				{
 					var text = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
-					var lcWordform = WfiWordformServices.FindOrCreateWordform(m_cache, text);
-					m_parseFiler.ProcessParse(lcWordform, priority, lcResult);
+					IWfiWordform lcWordform;
+					// We cannot use WfiWordformServices.FindOrCreateWordform because of props change (LT-21810).
+					if (m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(text, out lcWordform))
+						m_parseFiler.ProcessParse(lcWordform, priority, lcResult);
 					m_parseFiler.ProcessParse(wordform, priority, result);
 					return true;
 				}


### PR DESCRIPTION
WfiWordformServices.FindOrCreateWordform needs to be done within a unit of work, but you get a props change error if you wrap it with UndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW.  So I used TryGetObject instead.  If it doesn't exist, then nothing needs to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/86)
<!-- Reviewable:end -->
