### PR TITLE
Word Export: Fix multiple root names that are the same

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1777,10 +1777,11 @@ namespace SIL.FieldWorks.XWorks
 							else
 							{
 								// Don't create a new style if the current style already has the same root.
-								int compareTo = currentRunStyle.IndexOf(WordStylesGenerator.StyleSeparator);
-								compareTo = compareTo != -1 ? compareTo : currentRunStyle.IndexOf("[");
-								if ((compareTo == -1 && currentRunStyle.Equals(styleDisplayName)) ||
-									(compareTo != -1 && currentRunStyle.Substring(0, compareTo).Equals(styleDisplayName)))
+								int separatorIndex = currentRunStyle.IndexOf(WordStylesGenerator.StyleSeparator);
+								separatorIndex = separatorIndex != -1 ? separatorIndex : currentRunStyle.IndexOf("[");
+								bool hasSameRoot = separatorIndex == -1 ? currentRunStyle.Equals(styleDisplayName) :
+									currentRunStyle.Substring(0, separatorIndex).Equals(styleDisplayName);
+								if (hasSameRoot)
 								{
 									return;
 								}

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1765,7 +1765,8 @@ namespace SIL.FieldWorks.XWorks
 					if (!string.IsNullOrEmpty(currentRunStyle))
 					{
 						// If the current style is a language tag, then no need to add the colon.
-						string basedOnStyleName = currentRunStyle.StartsWith("[") ? (styleDisplayName + currentRunStyle) : (styleDisplayName + ":" + currentRunStyle);
+						string basedOnStyleName = currentRunStyle.StartsWith("[") ?
+							(styleDisplayName + currentRunStyle) : (styleDisplayName + WordStylesGenerator.StyleSeparator + currentRunStyle);
 
 						lock (_styleDictionary)
 						{
@@ -1775,6 +1776,15 @@ namespace SIL.FieldWorks.XWorks
 							}
 							else
 							{
+								// Don't create a new style if the current style already has the same root.
+								int compareTo = currentRunStyle.IndexOf(WordStylesGenerator.StyleSeparator);
+								compareTo = compareTo != -1 ? compareTo : currentRunStyle.IndexOf("[");
+								if ((compareTo == -1 && currentRunStyle.Equals(styleDisplayName)) ||
+									(compareTo != -1 && currentRunStyle.Substring(0, compareTo).Equals(styleDisplayName)))
+								{
+									return;
+								}
+
 								Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(rootStyle, currentRunStyle, basedOnStyleName);
 								if (basedOnStyle != null)
 								{

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -36,6 +36,7 @@ namespace SIL.FieldWorks.XWorks
 		internal const string WritingSystemStyleName = "Writing System Abbreviation";
 		internal const string PictureAndCaptionTextframeStyle = "Image-Textframe-Style";
 		internal const string EntryStyleContinue = "-Continue";
+		internal const string StyleSeparator = " : ";
 
 		public static Style GenerateLetterHeaderStyle(ReadOnlyPropertyTable propertyTable)
 		{


### PR DESCRIPTION
When building a style that is based on another style, make sure we are not creating a new style with a root that is the same as the root of the basedOn style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/88)
<!-- Reviewable:end -->
