### PR TITLE
LT-21787: Show infl variant info in Word Analyses

### DIFF
--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -1397,6 +1397,11 @@ namespace SIL.FieldWorks.IText
 								{
 									flid = wmb.Cache.MetaDataCacheAccessor.GetFieldId2(WfiMorphBundleTags.kClassId,
 										"DefaultSense", false);
+									if (wmb.MorphRA != null &&
+										DisplayLexGlossWithInflType(vwenv, wmb.MorphRA.Owner as ILexEntry, wmb.DefaultSense, spec, wmb.InflTypeRA))
+									{
+										break;
+									}
 								}
 							}
 							else


### PR DESCRIPTION
Show infl variant info for unapproved words in Word Analyses

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/89)
<!-- Reviewable:end -->
