### PR TITLE
Fix LT-21814: Guess Word not working properly for the repetitive words in the Analyze tab

### DIFF
--- a/Src/LexText/Interlinear/InterlinDocRootSiteBase.cs
+++ b/Src/LexText/Interlinear/InterlinDocRootSiteBase.cs
@@ -920,6 +920,10 @@ namespace SIL.FieldWorks.IText
 		{
 			// now update the guesses for the paragraphs.
 			var pdut = new ParaDataUpdateTracker(Vc.GuessServices, Vc.Decorator);
+			if (wordforms != null)
+				// The user may have changed the analyses for wordforms. (LT-21814)
+				foreach (var wordform in wordforms)
+					pdut.NoteChangedAnalysis(wordform.Hvo);
 			foreach (IStTxtPara para in RootStText.ParagraphsOS)
 				pdut.LoadAnalysisData(para, wordforms);
 			if (fUpdateDisplayWhereNeeded)

--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -2575,6 +2575,11 @@ namespace SIL.FieldWorks.IText
 			base.NoteCurrentAnnotation(occurrence);
 		}
 
+		public void NoteChangedAnalysis(int hvo)
+		{
+			m_analysesWithNewGuesses.Add(hvo);
+		}
+
 		private void MarkCurrentAnnotationAsChanged()
 		{
 			// something has changed in the cache for the annotation or its analysis,


### PR DESCRIPTION
A change in how GetBestGuess works on May 1st provoked this problem.  I fixed it by changing how the display gets notified that wordforms may have been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/90)
<!-- Reviewable:end -->
