### PR TITLE
Fix LT-21815: Yellow backgrounds not working properly

### DIFF
--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1208,7 +1208,9 @@ namespace SIL.FieldWorks.IText
 					if (analysis != null)
 					{
 						//set the color before we fidle with our the wordform, it right for this purpose now.
-						if (GetHasMultipleRelevantAnalyses(CurrentAnalysisTree.Wordform))
+						if (m_occurrenceSelected.Analysis.Analysis == null &&
+							m_occurrenceSelected.Analysis.Wordform != null &&
+							GetHasMultipleRelevantAnalyses(CurrentAnalysisTree.Wordform))
 						{
 							MultipleAnalysisColor = InterlinVc.MultipleApprovedGuessColor;
 						}

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1208,8 +1208,10 @@ namespace SIL.FieldWorks.IText
 					if (analysis != null)
 					{
 						//set the color before we fidle with our the wordform, it right for this purpose now.
-						if (m_occurrenceSelected.Analysis.Analysis == null &&
-							m_occurrenceSelected.Analysis.Wordform != null &&
+						if ((m_occurrenceSelected == null ||
+							m_occurrenceSelected.Analysis == null ||
+							(m_occurrenceSelected.Analysis.Analysis == null &&
+							m_occurrenceSelected.Analysis.Wordform != null)) &&
 							GetHasMultipleRelevantAnalyses(CurrentAnalysisTree.Wordform))
 						{
 							MultipleAnalysisColor = InterlinVc.MultipleApprovedGuessColor;


### PR DESCRIPTION
The background of a word should only be made yellow if there are multiple analyses AND the user hasn't chosen an analysis yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/95)
<!-- Reviewable:end -->
