### PR TITLE
Lt 21835: Improve Parser Testbed UI

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
+++ b/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
@@ -17,10 +17,10 @@
 		<command id="CmdParseWordsInCurrentText" label="Parse Words in Te_xt" message="ParseWordsInCurrentText"/>
 		<command id="CmdClearSelectedWordParserAnalyses" label="Clear Current Parser _Analyses" message="ClearSelectedWordParserAnalyses"/>
 		<command id="CmdReInitializeParser" label="Re_load Grammar / Lexicon" message="ReInitParser" tooltip="Reloads data from the Grammar and Lexicon, so the parser uses your latest changes."/>
-        <command id="CmdCheckParserOnCurrentText" label="Check Parser on Text" message="CheckParserOnCurrentText" tooltip="Checks parser on currrent text and reports results."/>
-        <command id="CmdCheckParserOnTestbed" label="Check Parser on Testbed" message="CheckParserOnTestbed" tooltip="Checks parser on texts in Testbed genre and reports results."/>
-        <command id="CmdCheckParserOnAll" label="Check Parser on All" message="CheckParserOnAll" tooltip="Checks parser on all texts and reports results."/>
-        <command id="CmdShowParserReports" label="Show Parser Reports" message="ShowParserReports" tooltip="Shows parser reports."/>
+        <command id="CmdCheckParserOnCurrentText" label="On Current Text" message="CheckParserOnCurrentText" tooltip="Checks parser on currrent text and reports results."/>
+        <command id="CmdCheckParserOnTestbed" label="On Testbed" message="CheckParserOnTestbed" tooltip="Checks parser on texts in Testbed genre and reports results."/>
+        <command id="CmdCheckParserOnAll" label="On All Texts" message="CheckParserOnAll" tooltip="Checks parser on all texts and reports results."/>
+        <command id="CmdShowParserReports" label="Show Test Reports..." message="ShowParserReports" tooltip="Shows test reports."/>
         <command id="CmdImportWordSet" label="_Import Word Set..." message="ImportWordSet"/>
 		<command id="CmdChooseXAmpleParser" label="Default Parser (XAmple)" message="ChooseParser">
 			<parameters parser="XAmple"/>
@@ -276,7 +276,7 @@
 	  <item command="CmdParseCurrentWord"/>
 	  <item command="CmdClearSelectedWordParserAnalyses" defaultVisible="false"/>
           <item label="-" translate="do not translate"/>
-          <menu id="CheckParserMenu" label="Check Parser">
+          <menu id="CheckParserMenu" label="Run Tests">
             <item command="CmdCheckParserOnTestbed"/>
             <item command="CmdCheckParserOnCurrentText"/>
             <item command="CmdCheckParserOnAll"/>

--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -93,20 +93,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public Boolean IsDiff { get; set; }
 
 		/// <summary>
-		/// Title used for window.
-		/// This should be unique.
-		/// </summary>
-		[JsonIgnore]
-		public string Title
-		{
-			get
-			{
-				string time = IsDiff ? new TimeSpan(Timestamp).ToString() : new DateTime(Timestamp).ToString();
-				return (IsDiff ? "Diff " : "") + ProjectName + ", " + SourceText + ", " + time + "," + MachineName;
-			}
-		}
-
-		/// <summary>
 		/// The filename that the report came from.
 		/// </summary>
 		[JsonIgnore]

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -525,12 +525,10 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				// Get all of the wordforms in the Testbed texts.
 				IEnumerable<IWfiWordform> wordforms = new HashSet<IWfiWordform>();
-				IEnumerable<SIL.LCModel.IText> texts = m_cache.ServiceLocator.GetInstance<ITextRepository>().AllInstances();
-				foreach (SIL.LCModel.IText text in texts)
-					if (text is IStText iStText)
-						foreach (var genre in iStText.GenreCategories)
-							if (genre.ShortName == "Testbed")
-								wordforms.Union(iStText.UniqueWordforms());
+				foreach (var text in m_cache.LanguageProject.InterlinearTexts)
+					foreach (var genre in text.GenreCategories)
+						if (genre.ShortName == "Testbed")
+							wordforms = wordforms.Union(text.UniqueWordforms());
 
 				// Check all of the wordforms.
 				UpdateWordforms(wordforms, ParserPriority.Medium, true, "Testbed Texts");
@@ -571,7 +569,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					// Write an empty parser report.
 					var parserReport = WriteParserReport();
 					AddParserReport(parserReport);
-					ShowParserReport(parserReport, m_mediator);
+					ShowParserReport(parserReport, m_mediator, m_cache);
 				}
 			}
 			m_parserConnection.UpdateWordforms(wordforms, priority, checkParser);
@@ -621,7 +619,7 @@ namespace SIL.FieldWorks.LexText.Controls
 
 				var parserReport = WriteParserReport();
 				AddParserReport(parserReport);
-				ShowParserReport(parserReport, m_mediator);
+				ShowParserReport(parserReport, m_mediator, m_cache);
 			}
 		}
 
@@ -661,7 +659,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				ReadParserReports();
 				// Create parser reports window.
-				m_parserReportsDialog = new ParserReportsDialog(m_parserReports, m_mediator);
+				m_parserReportsDialog = new ParserReportsDialog(m_parserReports, m_mediator, m_cache);
 				m_parserReportsDialog.Closed += ParserReportsDialog_Closed;
 			}
 			m_parserReportsDialog.Show(); // Show the dialog but do not block other app access
@@ -710,9 +708,9 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// </summary>
 		/// <param name="parserReport"></param>
 		/// <param name="mediator">the mediator is used to call TryAWord</param>
-		public static void ShowParserReport(ParserReport parserReport, Mediator mediator)
+		public static void ShowParserReport(ParserReport parserReport, Mediator mediator, LcmCache cache)
 		{
-			ParserReportDialog dialog = new ParserReportDialog(parserReport, mediator);
+			ParserReportDialog dialog = new ParserReportDialog(parserReport, mediator, cache);
 			dialog.Show();
 		}
 

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -511,7 +511,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			if (CurrentText != null && ConnectToParser())
 			{
 				IEnumerable<IWfiWordform> wordforms = CurrentText.UniqueWordforms();
-				UpdateWordforms(wordforms, ParserPriority.Medium, true, CurrentText.ShortName);
+				UpdateWordforms(wordforms, ParserPriority.Medium, checkParser: true, CurrentText.ShortName);
 			}
 
 			return true;    //we handled this.
@@ -531,7 +531,7 @@ namespace SIL.FieldWorks.LexText.Controls
 							wordforms = wordforms.Union(text.UniqueWordforms());
 
 				// Check all of the wordforms.
-				UpdateWordforms(wordforms, ParserPriority.Medium, true, "Testbed Texts");
+				UpdateWordforms(wordforms, ParserPriority.Medium, checkParser: true, "Testbed Texts");
 			}
 
 			return true;    //we handled this.
@@ -544,7 +544,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			if (ConnectToParser())
 			{
 				IEnumerable<IWfiWordform> wordforms = m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().AllInstances();
-				UpdateWordforms(wordforms, ParserPriority.Low, true, "All Texts");
+				UpdateWordforms(wordforms, ParserPriority.Low, checkParser: true, "All Texts");
 			}
 
 			return true;    //we handled this.
@@ -559,6 +559,14 @@ namespace SIL.FieldWorks.LexText.Controls
 			return true;
 		}
 
+		/// <summary>
+		/// Run the parser on the given wordforms and then update the wordforms
+		/// unless checkParser is true, in which case create a test report instead.
+		/// </summary>
+		/// <param name="wordforms">The wordforms to parse</param>
+		/// <param name="priority">The priority the parser is run at</param>
+		/// <param name="checkParser">Whether to check the parser and not update the wordforms</param>
+		/// <param name="sourceText">The source text for the word forms (used for the test report)</param>
 		private void UpdateWordforms(IEnumerable<IWfiWordform> wordforms, ParserPriority priority, bool checkParser = false, string sourceText = null)
 		{
 			if (checkParser)
@@ -693,14 +701,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// </summary>
 		private void AddParserReport(ParserReport parserReport)
 		{
-			if (m_parserReportsDialog != null)
-			{
-				((ParserReportsViewModel)m_parserReportsDialog.DataContext).ParserReports.Insert(0, parserReport);
-			} else
-			{
-				ReadParserReports();
-				m_parserReports.Add(parserReport);
-			}
+			ReadParserReports();
+			// m_parserReportsDialog's window updates when m_parserReports changes
+			// because m_parserReports is an ObservableCollection.
+			// Add at front so that newest reports appear first.
+			m_parserReports.Insert(0, parserReport);
 		}
 
 		/// <summary>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -95,9 +95,9 @@
 				<DataGridTextColumn Binding="{Binding ParseTime}">
 					<DataGridTextColumn.Header>
 						<StackPanel>
-							<Label ToolTip="The time it took to parse the word">Parse Time</Label>
+							<Label ToolTip="The time it took to parse the word in milliseconds">Parse Time</Label>
 							<Separator/>
-							<Label ToolTip ="Total parse time"
+							<Label ToolTip ="Total parse time in milliseconds"
 								   Content="{Binding DataContext.ParserReport.TotalParseTime, RelativeSource={RelativeSource AncestorType=DataGrid}}"></Label>
 						</StackPanel>
 					</DataGridTextColumn.Header>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -6,12 +6,22 @@
         xmlns:local="clr-namespace:SIL.FieldWorks.LexText.Controls"
         d:DataContext="{d:DesignInstance Type=local:ParserReportViewModel, IsDesignTimeCreatable=True}"
         mc:Ignorable="d"
-        Title="{Binding ParserReport.Title}" WindowStartupLocation="CenterScreen"
+        Title="{Binding Title}" WindowStartupLocation="CenterScreen"
         SizeToContent="WidthAndHeight" MinHeight="300" MaxHeight="500"
 		WindowStyle="ThreeDBorderWindow">
 	<Grid>
 		<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParserReport.ParseReports.Values}">
 			<DataGrid.Columns>
+				<DataGridTemplateColumn>
+					<DataGridTemplateColumn.CellTemplate>
+						<DataTemplate>
+							<Button Content="show"
+									ToolTip="Show the analyses of this word"
+							Click="ShowWordAnalyses"
+							CommandParameter="{Binding}"/>
+						</DataTemplate>
+					</DataGridTemplateColumn.CellTemplate>
+				</DataGridTemplateColumn>
 				<DataGridTemplateColumn>
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -2,9 +2,6 @@ using SIL.FieldWorks.Common.FwUtils;
 using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
 using SIL.LCModel.Core.Text;
-using SIL.LCModel.DomainServices;
-using System;
-using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using XCore;
@@ -40,11 +37,17 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			var button = sender as Button;
 			var parseReport = button.CommandParameter as ParseReport;
-			var wordForm = TsStringUtils.MakeString(parseReport.Word, Cache.DefaultVernWs);
-			var analysis = WfiWordformServices.FindOrCreateWordform(Cache, wordForm);
-			var fwLink = new FwLinkArgs("Analyses", analysis.Guid);
-			List<Property> additionalProps = fwLink.PropertyTableEntries;
-			Mediator.PostMessage("FollowLink", fwLink);
+			var tsString = TsStringUtils.MakeString(parseReport.Word, Cache.DefaultVernWs);
+			IWfiWordform wordform;
+			if (Cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(tsString, out wordform))
+			{
+				var fwLink = new FwLinkArgs("Analyses", wordform.Guid);
+				Mediator.PostMessage("FollowLink", fwLink);
+			} else
+			{
+				// This should never happen.
+				MessageBox.Show("Unknown word " + parseReport.Word);
+			}
 		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -1,4 +1,10 @@
+using SIL.FieldWorks.Common.FwUtils;
 using SIL.FieldWorks.WordWorks.Parser;
+using SIL.LCModel;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.DomainServices;
+using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using XCore;
@@ -8,16 +14,18 @@ namespace SIL.FieldWorks.LexText.Controls
 	public partial class ParserReportDialog : Window
 	{
 		public Mediator Mediator { get; set; }
+		public LcmCache Cache { get; set; }
 
 		public ParserReportDialog()
 		{
 			InitializeComponent();
 		}
 
-		public ParserReportDialog(ParserReport parserReport, Mediator mediator)
+		public ParserReportDialog(ParserReport parserReport, Mediator mediator, LcmCache cache)
 		{
 			InitializeComponent();
 			Mediator = mediator;
+			Cache = cache;
 			DataContext = new ParserReportViewModel { ParserReport = parserReport };
 		}
 
@@ -28,6 +36,15 @@ namespace SIL.FieldWorks.LexText.Controls
 			Mediator.SendMessage("TryThisWord", parseReport.Word);
 		}
 
-
+		public void ShowWordAnalyses(object sender, RoutedEventArgs e)
+		{
+			var button = sender as Button;
+			var parseReport = button.CommandParameter as ParseReport;
+			var wordForm = TsStringUtils.MakeString(parseReport.Word, Cache.DefaultVernWs);
+			var analysis = WfiWordformServices.FindOrCreateWordform(Cache, wordForm);
+			var fwLink = new FwLinkArgs("Analyses", analysis.Guid);
+			List<Property> additionalProps = fwLink.PropertyTableEntries;
+			Mediator.PostMessage("FollowLink", fwLink);
+		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportViewModel.cs
@@ -14,7 +14,16 @@ namespace SIL.FieldWorks.LexText.Controls
 	{
 		public ParserReport ParserReport { get; set; }
 
-		public ParserReportViewModel()
+		public string Title
+		{
+			get
+			{
+				string time = ParserReport.IsDiff ? new TimeSpan(ParserReport.Timestamp).ToString() : new DateTime(ParserReport.Timestamp).ToString();
+				return (ParserReport.IsDiff ? "Diff " : "") + ParserReport.ProjectName + ", " + ParserReport.SourceText + ", " + time + "," + ParserReport.MachineName;
+			}
+		}
+
+	public ParserReportViewModel()
 		{
 			ParserReport = new ParserReport();
 

--- a/Src/LexText/ParserUI/ParserReportViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportViewModel.cs
@@ -23,7 +23,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			}
 		}
 
-	public ParserReportViewModel()
+		public ParserReportViewModel()
 		{
 			ParserReport = new ParserReport();
 

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:SIL.FieldWorks.LexText.Controls"
         d:DataContext="{d:DesignInstance Type=local:ParserReportsViewModel, IsDesignTimeCreatable=True}"
         mc:Ignorable="d"
-        Title="Parser Reports" WindowStartupLocation="CenterScreen"
+        Title="Parser Test Reports" WindowStartupLocation="CenterScreen"
 		SizeToContent="WidthAndHeight" MinHeight="300" MaxHeight="500"
         WindowStyle="ThreeDBorderWindow">
 	<Window.Resources>
@@ -14,7 +14,7 @@
 	</Window.Resources>
 
 	<Grid>
-		<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParserReports}">
+		<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParserReports, Mode=TwoWay}">
 			<DataGrid.Columns>
 				<DataGridTemplateColumn>
 					<DataGridTemplateColumn.CellTemplate>

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -20,7 +20,7 @@
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Button Content="show"
-									ToolTip="Show this parser report"
+									ToolTip="Show this test report"
 							Click="ShowParserReport"
 							CommandParameter="{Binding}"/>
 						</DataTemplate>
@@ -30,7 +30,7 @@
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Button Content="diff"
-									ToolTip="Take the difference between this parser report and a second report selected by the radio button"
+									ToolTip="Show the difference between this test report and the report selected by the radio button (older report is subtracted from newer report)"
 							Click="DiffParserReports"
 							CommandParameter="{Binding}"/>
 						</DataTemplate>
@@ -38,11 +38,11 @@
 				</DataGridTemplateColumn>
 				<DataGridTemplateColumn>
 					<DataGridTemplateColumn.Header>
-						<Label ToolTip="The second argument to the diff">2nd</Label>
+						<Label ToolTip="The other argument to diff">Diff</Label>
 					</DataGridTemplateColumn.Header>
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<RadioButton GroupName="2nd" IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
+							<RadioButton GroupName="Diff" IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
@@ -50,7 +50,7 @@
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Button Content="delete"
-									ToolTip="Delete this parser report from the disk"
+									ToolTip="Delete this test report from the disk"
 							Click="DeleteParserReport"
 							CommandParameter="{Binding}"/>
 						</DataTemplate>
@@ -88,7 +88,7 @@
 				</DataGridTextColumn>
 				<DataGridTextColumn Binding="{Binding TotalParseTime}">
 					<DataGridTextColumn.Header>
-						<Label ToolTip="The time it took to parse all the distinct words in the text">Total Parse Time</Label>
+						<Label ToolTip="The time it took to parse all the distinct words in the text in milliseconds">Total Parse Time</Label>
 					</DataGridTextColumn.Header>
 				</DataGridTextColumn>
 				<DataGridTextColumn Binding="{Binding TotalAnalyses}">

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -28,7 +28,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportsDialog(ObservableCollection<ParserReport> parserReports, Mediator mediator, LcmCache cache)
 		{
 			InitializeComponent();
-			parserReports.Sort((x, y) => x.Timestamp.CompareTo(y.Timestamp));
+			parserReports.Sort((x, y) => y.Timestamp.CompareTo(x.Timestamp));
 			ParserReports = parserReports;
 			Mediator = mediator;
 			Cache = cache;

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -1,5 +1,6 @@
 using SIL.Extensions;
 using SIL.FieldWorks.WordWorks.Parser;
+using SIL.LCModel;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
@@ -17,17 +18,20 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public Mediator Mediator { get; set; }
 
+		public LcmCache Cache { get; set; }
+
 		public ParserReportsDialog()
 		{
 			InitializeComponent();
 		}
 
-		public ParserReportsDialog(ObservableCollection<ParserReport> parserReports, Mediator mediator)
+		public ParserReportsDialog(ObservableCollection<ParserReport> parserReports, Mediator mediator, LcmCache cache)
 		{
 			InitializeComponent();
 			parserReports.Sort((x, y) => x.Timestamp.CompareTo(y.Timestamp));
 			ParserReports = parserReports;
 			Mediator = mediator;
+			Cache = cache;
 			DataContext = new ParserReportsViewModel { ParserReports = parserReports };
 		}
 
@@ -35,7 +39,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			var button = sender as Button;
 			var parserReport = button.CommandParameter as ParserReport;
-			ParserListener.ShowParserReport(parserReport, Mediator);
+			ParserListener.ShowParserReport(parserReport, Mediator, Cache);
 		}
 
 		public void DeleteParserReport(object sender, RoutedEventArgs e)
@@ -63,8 +67,15 @@ namespace SIL.FieldWorks.LexText.Controls
 				MessageBox.Show("Please select a second report other than this report using the radio button labelled '2nd'.");
 				return;
 			}
+			if (parserReport.Timestamp < parserReport2.Timestamp)
+			{
+				// swap the two variables.
+				ParserReport temp = parserReport;
+				parserReport = parserReport2;
+				parserReport2 = temp;
+			}
 			var diff = parserReport.DiffParserReports(parserReport2);
-			ParserListener.ShowParserReport(diff, Mediator);
+			ParserListener.ShowParserReport(diff, Mediator, Cache);
 		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -25,10 +25,10 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportsDialog(ObservableCollection<ParserReport> parserReports, Mediator mediator)
 		{
 			InitializeComponent();
-			var sortedReports = new ObservableCollection<ParserReport>(parserReports.OrderByDescending(i => i.Timestamp));
-			ParserReports = sortedReports;
+			parserReports.Sort((x, y) => x.Timestamp.CompareTo(y.Timestamp));
+			ParserReports = parserReports;
 			Mediator = mediator;
-			DataContext = new ParserReportsViewModel { ParserReports = sortedReports };
+			DataContext = new ParserReportsViewModel { ParserReports = parserReports };
 		}
 
 		public void ShowParserReport(object sender, RoutedEventArgs e)

--- a/Src/LexText/ParserUI/ParserReportsViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportsViewModel.cs
@@ -6,7 +6,7 @@ using SIL.FieldWorks.WordWorks.Parser;
 
 namespace SIL.FieldWorks.LexText.Controls
 {
-	public class ParserReportsViewModel
+	public class ParserReportsViewModel : INotifyPropertyChanged
 	{
 		public ObservableCollection<ParserReport> ParserReports { get; set; }
 
@@ -39,6 +39,13 @@ namespace SIL.FieldWorks.LexText.Controls
 					NumZeroParses = 1
 				});
 			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected virtual void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 	}
 }


### PR DESCRIPTION
I made the following improvements:
- Make Parser Reports window be a singleton
- Make On Testbed work
- Add button to show word analyses
- Make diff always subtract the older report from the newer report
- Rename menu:
    Run Tests
        On Testbed
        On Current Text
        On All Texts
        Show Test Reports...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/105)
<!-- Reviewable:end -->
