### PR TITLE
Fix LT-21854: Delete reports button not working properly

### DIFF
--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -758,15 +758,10 @@ namespace SIL.FieldWorks.LexText.Controls
 		private void AddParserReport(ParserReport parserReport)
 		{
 			ReadParserReports();
-			// m_parserReportsDialog's window updates when m_parserReports changes
-			// because m_parserReports is an ObservableCollection.
-			ParserReportViewModel viewModel = new ParserReportViewModel { ParserReport = parserReport };
+			m_parserReports.Insert(0, new ParserReportViewModel { ParserReport = parserReport });
 			if (m_parserReportsDialog != null)
-				// Call AddParserReport so that the window will see property changes.
-				((ParserReportsViewModel)m_parserReportsDialog.DataContext).AddParserReport(viewModel);
-			else
-				// Add at front so that newest reports appear first.
-				m_parserReports.Insert(0, viewModel);
+				// Reset ParserReports so that the window gets notified when the new report is selected.
+				((ParserReportsViewModel)m_parserReportsDialog.DataContext).ParserReports = m_parserReports;
 		}
 
 		/// <summary>

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -760,8 +760,13 @@ namespace SIL.FieldWorks.LexText.Controls
 			ReadParserReports();
 			// m_parserReportsDialog's window updates when m_parserReports changes
 			// because m_parserReports is an ObservableCollection.
-			// Add at front so that newest reports appear first.
-			m_parserReports.Insert(0, new ParserReportViewModel { ParserReport = parserReport });
+			ParserReportViewModel viewModel = new ParserReportViewModel { ParserReport = parserReport };
+			if (m_parserReportsDialog != null)
+				// Call AddParserReport so that the window will see property changes.
+				((ParserReportsViewModel)m_parserReportsDialog.DataContext).AddParserReport(viewModel);
+			else
+				// Add at front so that newest reports appear first.
+				m_parserReports.Insert(0, viewModel);
 		}
 
 		/// <summary>

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -57,6 +57,7 @@ namespace SIL.FieldWorks.LexText.Controls
 				if (report.IsSelected)
 				{
 					report.ParserReport.DeleteJsonFile();
+					report.IsSelected = false;
 					ParserReports.Remove(report);
 				}
 			}

--- a/Src/LexText/ParserUI/ParserReportsViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportsViewModel.cs
@@ -105,5 +105,11 @@ namespace SIL.FieldWorks.LexText.Controls
 			OnPropertyChanged(nameof(CanDiffReports));
 			OnPropertyChanged(nameof(CanDeleteReports));
 		}
+
+		public void AddParserReport(ParserReportViewModel report)
+		{
+			ParserReports.Insert(0, report);
+			report.PropertyChanged += OnReportPropertyChanged;
+		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportsViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportsViewModel.cs
@@ -15,31 +15,29 @@ namespace SIL.FieldWorks.LexText.Controls
 			get => _parserReports;
 			set
 			{
-				if (_parserReports != value)
+				// Do this even if value == _parserReports because it may have new items.
+				// Unsubscribe from PropertyChanged events of old collection items
+				if (_parserReports != null)
 				{
-					// Unsubscribe from PropertyChanged events of old collection items
-					if (_parserReports != null)
+					foreach (var report in _parserReports)
 					{
-						foreach (var report in _parserReports)
-						{
-							report.PropertyChanged -= OnReportPropertyChanged;
-						}
+						report.PropertyChanged -= OnReportPropertyChanged;
 					}
-
-					_parserReports = value;
-
-					// Subscribe to PropertyChanged events of new collection items
-					if (_parserReports != null)
-					{
-						foreach (var report in _parserReports)
-						{
-							report.PropertyChanged += OnReportPropertyChanged;
-						}
-					}
-
-					OnPropertyChanged(nameof(ParserReports));
-					UpdateButtonStates(); // Update button states when the collection changes
 				}
+
+				_parserReports = value;
+
+				// Subscribe to PropertyChanged events of new collection items
+				if (_parserReports != null)
+				{
+					foreach (var report in _parserReports)
+					{
+						report.PropertyChanged += OnReportPropertyChanged;
+					}
+				}
+
+				OnPropertyChanged(nameof(ParserReports));
+				UpdateButtonStates(); // Update button states when the collection changes
 			}
 		}
 		public bool CanShowReport => ParserReports.Count(report => report.IsSelected) == 1;
@@ -104,12 +102,6 @@ namespace SIL.FieldWorks.LexText.Controls
 			OnPropertyChanged(nameof(CanShowReport));
 			OnPropertyChanged(nameof(CanDiffReports));
 			OnPropertyChanged(nameof(CanDeleteReports));
-		}
-
-		public void AddParserReport(ParserReportViewModel report)
-		{
-			ParserReports.Insert(0, report);
-			report.PropertyChanged += OnReportPropertyChanged;
 		}
 	}
 }


### PR DESCRIPTION
I fixed the problem where deleting reports didn't cause the Compare button to be greyed out.
I also fixed a problem where reports that were added to the parser reports window weren't notifying the buttons when they were selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/126)
<!-- Reviewable:end -->
