### PR TITLE
Fix 21855: Scrolling function in Parse Test Reports

### DIFF
--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -24,7 +24,7 @@
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 
-		<ScrollViewer VerticalScrollBarVisibility="Auto">
+		<ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
 			<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" MouseDoubleClick="DataGrid_MouseDoubleClick" ItemsSource="{Binding ParserReports, Mode=TwoWay}">
 				<DataGrid.Columns>
 					<DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -38,6 +38,17 @@ namespace SIL.FieldWorks.LexText.Controls
 			DataContext = new ParserReportsViewModel { ParserReports = parserReports };
 		}
 
+		private void ScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+		{
+			ScrollViewer scrollViewer = sender as ScrollViewer;
+			if (scrollViewer != null)
+				if (e.Delta > 0)
+					scrollViewer.LineUp();
+				else
+					scrollViewer.LineDown();
+			e.Handled = true;
+		}
+
 		public void ShowParserReport(object sender, RoutedEventArgs e)
 		{
 			foreach (var report in ParserReports)


### PR DESCRIPTION
I fixed this by adding code to catch PreviewMouseWheel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/128)
<!-- Reviewable:end -->
