### PR TITLE
Word Export: Fix indenting problem

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -865,7 +865,7 @@ namespace SIL.FieldWorks.XWorks
 				if (!string.IsNullOrEmpty(config.Style))
 				{
 					WP.ParagraphProperties paragraphProps =
-						new WP.ParagraphProperties(new ParagraphStyleId() { Val = config.Style });
+						new WP.ParagraphProperties(new ParagraphStyleId() { Val = config.DisplayLabel });
 					groupPara.PrependChild(paragraphProps);
 				}
 				groupData.DocBody.AppendChild(groupPara);
@@ -1678,7 +1678,7 @@ namespace SIL.FieldWorks.XWorks
 				if (style.Type == StyleValues.Paragraph)
 				{
 					string oldName = style.StyleId;
-					string newName = s_styleCollection.AddStyle(style, style.StyleId, style.StyleId);
+					string newName = s_styleCollection.AddStyle(style, node.Style, style.StyleId);
 					Debug.Assert(oldName == newName, "Not expecting the name for a paragraph style to ever change!");
 				}
 				else


### PR DESCRIPTION
We need to use the config.DisplayLabel instead of the config.Style for the style reference.  Some cases were previously working because these values were the same.
The change to the AddStyle() call was to fix a problem with the way paragraph styles were organized in the collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/129)
<!-- Reviewable:end -->
