### PR TITLE
Fix LT-21858: Parser test reports pane highlights inaccurate report

### DIFF
--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -25,7 +25,8 @@
 		</Grid.RowDefinitions>
 
 		<ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-			<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" MouseDoubleClick="DataGrid_MouseDoubleClick" ItemsSource="{Binding ParserReports, Mode=TwoWay}">
+			<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" SelectionChanged="DataGrid_SelectionChanged"
+					  MouseDoubleClick="DataGrid_MouseDoubleClick" ItemsSource="{Binding ParserReports, Mode=TwoWay}">
 				<DataGrid.Columns>
 					<DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
 						ElementStyle="{StaticResource DataGridCheckBoxStyle}">

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -1,6 +1,7 @@
 using SIL.Extensions;
 using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -8,6 +9,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Threading;
 using XCore;
 
 namespace SIL.FieldWorks.LexText.Controls
@@ -118,8 +120,16 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				if(dataGrid.SelectedItem is ParserReportViewModel selectedItem)
 					ParserListener.ShowParserReport(selectedItem.ParserReport, Mediator, Cache);
-				else
-					Debug.Fail("Type of Contents of DataGrid changed, adjust double click code.");
+			}
+			else
+				Debug.Fail("Type of Contents of DataGrid changed, adjust double click code.");
+		}
+		private void DataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (sender is DataGrid dataGrid)
+			{
+				// Turn off selection in favor of the check box.
+				Dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(() => dataGrid.UnselectAll()));
 			}
 		}
 		private void CheckBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
I turned off selection in favor of the Select check box.  I also fixed a crash that occurred if you double clicked with the right mouse button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/130)
<!-- Reviewable:end -->
