### PR TITLE
Fix 2-column display by correcting image anchor

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -465,7 +465,7 @@ namespace SIL.FieldWorks.XWorks
 			// A paragraph is turned into a textframe simply by adding a frameproperties object inside the paragraph properties.
 			// We leave a 4-pt border around the textframe--80 twentieths of a point.
 			var textFrameBorder = "80";
-			var textFrameProps = new FrameProperties() { Width = textFrameWidth.ToString(), HeightType = HeightRuleValues.Auto, HorizontalSpace = textFrameBorder, VerticalSpace = textFrameBorder, Wrap = TextWrappingValues.NotBeside, VerticalPosition = VerticalAnchorValues.Text, HorizontalPosition = HorizontalAnchorValues.Margin, XAlign = HorizontalAlignmentValues.Right };
+			var textFrameProps = new FrameProperties() { Width = textFrameWidth.ToString(), HeightType = HeightRuleValues.Auto, HorizontalSpace = textFrameBorder, VerticalSpace = textFrameBorder, Wrap = TextWrappingValues.NotBeside, VerticalPosition = VerticalAnchorValues.Text, HorizontalPosition = HorizontalAnchorValues.Text, XAlign = HorizontalAlignmentValues.Right };
 			var parProps = new ParagraphProperties();
 			frameStyle.StyleId = PictureAndCaptionTextframeStyle;
 			frameStyle.StyleName = new StyleName(){Val = PictureAndCaptionTextframeStyle};


### PR DESCRIPTION
The horizontal anchor type for the textframe should be set to text rather than margin.

A text type anchor prompts the textframe to move with the text it is anchored to, while a page or margin type anchor would keep the textframe fixed in a particular location on the page.

If the horizontal anchor type is set to page or margin, images can appear in the wrong column when the document layout is set to two columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/133)
<!-- Reviewable:end -->
