### PR TITLE
Fix LT-21872: Import Phonology crashes in Grammar area

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -285,7 +285,7 @@
 		<ChorusNugetVersion>5.2.0-beta0003</ChorusNugetVersion>
 		<PalasoNugetVersion>13.0.0-beta0076</PalasoNugetVersion>
 		<ParatextNugetVersion>9.4.0.1-beta</ParatextNugetVersion>
-		<LcmNugetVersion>11.0.0-beta0103</LcmNugetVersion>
+		<LcmNugetVersion>11.0.0-beta0104</LcmNugetVersion>
 		<IcuNugetVersion>70.1.123</IcuNugetVersion>
 		<HermitCrabNugetVersion>2.5.13</HermitCrabNugetVersion>
 		<IPCFrameworkVersion>1.1.1-beta0001</IPCFrameworkVersion>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -53,15 +53,15 @@
   <package id="SIL.Core" version="13.0.0-beta0076"  targetFramework="net461" />
   <package id="SIL.DesktopAnalytics" version="4.0.0" targetFramework="net461" />
   <package id="SIL.FLExBridge.IPCFramework" version="1.1.1-beta0001"  targetFramework="net461" />
-  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.FixData" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tests" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tools" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils" version="11.0.0-beta0103"  targetFramework="net461" />
-  <package id="SIL.LCModel" version="11.0.0-beta0103"  targetFramework="net461" />
+  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.FixData" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tests" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tools" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils" version="11.0.0-beta0104"  targetFramework="net461" />
+  <package id="SIL.LCModel" version="11.0.0-beta0104"  targetFramework="net461" />
   <package id="SIL.Lexicon" version="13.0.0-beta0076"  targetFramework="net461" />
   <package id="SIL.libpalaso.l10ns" version="6.0.0" targetFramework="net461" />
   <package id="SIL.Lift" version="13.0.0-beta0076"  targetFramework="net461" />

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -1949,54 +1949,21 @@ namespace SIL.FieldWorks.XWorks
 			DialogResult result = MessageBox.Show(xWorksStrings.DeletePhonology, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 			if (result != DialogResult.Yes)
 				return true;
-			DeletePhonology();
-			using (new WaitCursor(form, true))
-			{
-				using (var dlg = new ProgressDialogWithTask(this))
-				{
-					dlg.AllowCancel = true;
-					dlg.Maximum = 200;
-					dlg.Message = filename;
-					dlg.RunTask(true, ImportPhonology, filename, caption);
-				}
-			}
-			return true;
-		}
 
-		private object ImportPhonology(IThreadedProgress dlg, object[] parameters)
-		{
 			try
 			{
 				var phonologyServices = new PhonologyServices(Cache);
-				phonologyServices.ImportPhonologyFromXml((string)parameters[0]);
-				dlg.Step(200);
-				// Let the dialog update.
-				Thread.Sleep(100);
+				phonologyServices.DeletePhonology();
+				phonologyServices.ImportPhonologyFromXml(filename);
+				m_mediator.SendMessage("MasterRefresh", null);
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine("Error: " + ex.Message);
-				MessageBox.Show(ex.Message, (string)parameters[1]);
+				MessageBox.Show(ex.Message, caption);
 			}
-			return false;
-		}
 
-
-		private void DeletePhonology()
-		{
-			NonUndoableUnitOfWorkHelper.Do(Cache.ServiceLocator.GetInstance<IActionHandler>(), () =>
-			{
-				IPhPhonData phonData = Cache.LangProject.PhonologicalDataOA;
-				// Delete what is covered by ImportPhonology.
-				phonData.ContextsOS.Clear();
-				phonData.EnvironmentsOS.Clear();
-				phonData.FeatConstraintsOS.Clear();
-				phonData.NaturalClassesOS.Clear();
-				phonData.PhonemeSetsOS.Clear();
-				phonData.PhonRulesOS.Clear();
-				Cache.LanguageProject.PhFeatureSystemOA.TypesOC.Clear();
-				Cache.LanguageProject.PhFeatureSystemOA.FeaturesOC.Clear();
-			});
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This was fixed by changing PhonologyServices in liblcm and also doing a Master Refresh.  I removed ProgressDialogWithTask because it crashed trying to unlock something that had already been unlocked.  The Master Refresh indicates when the import is done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/142)
<!-- Reviewable:end -->
