### PR TITLE
Fix LT-21862: Parser can't find German nouns (caps)

### DIFF
--- a/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
@@ -109,11 +109,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			parserWorker.Parser = new TestParserClass(null, lowerXDoc);
 
 			// SUT
-			parserWorker.TryAWord("Cats", false, null);
-			Assert.AreEqual(m_taskDetailsString, lowerXDoc.ToString());
-			m_taskDetailsString = null;
-
-			// SUT
 			parserWorker.TryAWord("cats", false, null);
 			Assert.AreEqual(m_taskDetailsString, lowerXDoc.ToString());
 		}

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -109,34 +109,9 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			CheckNeedsUpdate();
 			using (var task = new TaskReport(string.Format(ParserCoreStrings.ksTraceWordformX, sForm), m_taskUpdateHandler))
 			{
+				// Assume that the user used the correct case.
 				string normForm = CustomIcu.GetIcuNormalizer(FwNormalizationMode.knmNFD).Normalize(sForm);
-
-				// Get the lowercase word.
-				var cf = new CaseFunctions(m_cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem);
-				string normFormLower = CustomIcu.GetIcuNormalizer(FwNormalizationMode.knmNFD).Normalize(cf.ToLower(sForm));
-
-				// The word is already lowercase, just return the xml.
-				if (normForm == normFormLower)
-				{
-					task.Details = fDoTrace ? m_parser.TraceWordXml(normForm, sSelectTraceMorphs) : m_parser.ParseWordXml(normForm);
-				}
-				// The word is uppercase, make a ParseWord() call for the uppercase word to determine if we should try to get
-				// the xml for the uppercase word or for the lowercase word.
-				else
-				{
-					ParseResult result = m_parser.ParseWord(normForm);
-
-					// Parse of uppercase word was successful, get it's xml.
-					if (result.Analyses.Count > 0 && result.ErrorMessage == null)
-					{
-						task.Details = fDoTrace ? m_parser.TraceWordXml(normForm, sSelectTraceMorphs) : m_parser.ParseWordXml(normForm);
-					}
-					// Parse of uppercase word was not successful, try to get the xml for the lowercase word.
-					else
-					{
-						task.Details = fDoTrace ? m_parser.TraceWordXml(normFormLower, sSelectTraceMorphs) : m_parser.ParseWordXml(normFormLower);
-					}
-				}
+				task.Details = fDoTrace ? m_parser.TraceWordXml(normForm, sSelectTraceMorphs) : m_parser.ParseWordXml(normForm);
 			}
 		}
 


### PR DESCRIPTION
The grammar couldn't parse "Frau", but this wasn't obvious to the user because TryAWord tried both uppercase and lowercase and only reported the lowercase error.  I changed TryAWord to assume that the user used the case that they wanted.  This allows the user to see the uppercase error.   If the user wants to see the lowercase results, then they can try the lowercase version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/143)
<!-- Reviewable:end -->
