### PR TITLE
Word Export: Fix duplicate & missing before and after

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -1609,7 +1609,7 @@ namespace SIL.FieldWorks.XWorks
 							lexEntryType.Owner, settings, false)
 						: null;
 					var className = generateLexType ? settings.StylesGenerator.AddStyles(typeNode).Trim('.') : null;
-					var refsByType = settings.ContentGenerator.AddLexReferences(config, generateLexType,
+					var refsByType = settings.ContentGenerator.AddLexReferences(typeNode, generateLexType,
 						lexTypeContent, className, combinedContent, IsTypeBeforeForm(config));
 					bldr.Append(refsByType);
 				}


### PR DESCRIPTION
The wrong node was being passed to AddLexReferences().
Note: This change does not impact LcmXhtmlGenerator. It’s implementation does not use the node.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/148)
<!-- Reviewable:end -->
