### PR TITLE
Fix LT-21863: Add comment field to Parser Test Reports

### DIFF
--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -41,6 +41,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public long DiffTimestamp { get; set; }
 
 		/// <summary>
+		/// User-specified comment.
+		/// </summary>
+		public string Comment { get; set; }
+
+		/// <summary>
 		/// Number of words parsed
 		/// </summary>
 		public int NumWords { get; set; }

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -571,13 +571,20 @@ namespace SIL.FieldWorks.LexText.Controls
 			return false;
 		}
 
+		/// <summary>
+		/// Check parser on all words in texts.
+		/// </summary>
 		public bool OnCheckParserOnAll(object argument)
 		{
 			CheckDisposed();
 
 			if (ConnectToParser())
 			{
-				IEnumerable<IWfiWordform> wordforms = m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().AllInstances();
+				IEnumerable<IWfiWordform> wordforms = new HashSet<IWfiWordform>();
+				foreach (var text in m_cache.LanguageProject.InterlinearTexts)
+				{
+					wordforms = wordforms.Union(text.UniqueWordforms());
+				}
 				UpdateWordforms(wordforms, ParserPriority.Low, checkParser: true, "All Texts");
 			}
 

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -25,7 +25,7 @@
 		</Grid.RowDefinitions>
 
 		<ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-			<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" SelectionChanged="DataGrid_SelectionChanged"
+			<DataGrid Name="DataGrid" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" SelectionChanged="DataGrid_SelectionChanged"
 					  MouseDoubleClick="DataGrid_MouseDoubleClick" ItemsSource="{Binding ParserReports, Mode=TwoWay}">
 				<DataGrid.Columns>
 					<DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -38,6 +38,22 @@
 						<DataGridTextColumn.Header>
 							<Label Content="{x:Static local:ParserUIStrings.ksText}" ToolTip="{x:Static local:ParserUIStrings.ksTextToolTip}"/>
 						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
+					<DataGridTextColumn Binding="{Binding ParserReport.Comment, Mode=TwoWay}" Width="100">
+						<DataGridTextColumn.Header>
+							<Label Content="{x:Static local:ParserUIStrings.ksComment}" ToolTip="{x:Static local:ParserUIStrings.ksCommentToolTip}"/>
+						</DataGridTextColumn.Header>
+						<DataGridTextColumn.ElementStyle>
+							<Style TargetType="{x:Type TextBlock}"
+							   BasedOn="{StaticResource {x:Type TextBlock}}">
+								<Setter Property="TextWrapping"
+									   Value="NoWrap" />
+								<Setter Property="TextTrimming"
+									Value="CharacterEllipsis" />
+								<Setter Property="ToolTip"
+									Value="{Binding ErrorMessage}" />
+							</Style>
+						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>
 					<DataGridTextColumn Binding="{Binding Timestamp, StringFormat=\{0:dd MMM yyyy hh:mm tt\}}">
 						<DataGridTextColumn.Header>
@@ -98,6 +114,10 @@
                     ToolTip="{x:Static local:ParserUIStrings.ksShowReportToolTip}"
                     IsEnabled="{Binding CanShowReport}"
                     Click="ShowParserReport" Width="100" Margin="5"/>
+			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"
+                    ToolTip="{x:Static local:ParserUIStrings.ksSaveReportToolTip}"
+                    IsEnabled="{Binding CanSaveReport}"
+                    Click="SaveParserReport" Width="100" Margin="5"/>
 			<Button Content="{x:Static local:ParserUIStrings.ksDiffButton}"
                     ToolTip="{x:Static local:ParserUIStrings.ksDiffButtonToolTip}"
                     IsEnabled="{Binding CanDiffReports}"

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -51,7 +51,7 @@
 								<Setter Property="TextTrimming"
 									Value="CharacterEllipsis" />
 								<Setter Property="ToolTip"
-									Value="{Binding ErrorMessage}" />
+									Value="{Binding ParserReport.Comment}" />
 							</Style>
 						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -25,12 +25,14 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public LcmCache Cache { get; set; }
 
+		public string DefaultComment = null;
+
 		public ParserReportsDialog()
 		{
 			InitializeComponent();
 		}
 
-		public ParserReportsDialog(ObservableCollection<ParserReportViewModel> parserReports, Mediator mediator, LcmCache cache)
+		public ParserReportsDialog(ObservableCollection<ParserReportViewModel> parserReports, Mediator mediator, LcmCache cache, string defaultComment)
 		{
 			InitializeComponent();
 			parserReports.Sort((x, y) => y.Timestamp.CompareTo(x.Timestamp));
@@ -38,6 +40,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			Mediator = mediator;
 			Cache = cache;
 			DataContext = new ParserReportsViewModel { ParserReports = parserReports };
+			DefaultComment = defaultComment;
 		}
 
 		private void ScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
@@ -61,6 +64,21 @@ namespace SIL.FieldWorks.LexText.Controls
 					break;
 				}
 			}
+		}
+
+		public void SaveParserReport(object sender, RoutedEventArgs e)
+		{
+			foreach (var report in ParserReports)
+			{
+				if (report.IsSelected)
+				{
+					ParserListener.SaveParserReport(report.ParserReport, Cache, DefaultComment);
+				}
+			}
+			// The comment may have been updated.
+			DataGrid.Items.Refresh();
+			((ParserReportsViewModel)DataContext).UpdateButtonStates();
+
 		}
 
 		public void DeleteParserReport(object sender, RoutedEventArgs e)

--- a/Src/LexText/ParserUI/ParserReportsViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportsViewModel.cs
@@ -10,6 +10,7 @@ namespace SIL.FieldWorks.LexText.Controls
 	public class ParserReportsViewModel : INotifyPropertyChanged
 	{
 		private ObservableCollection<ParserReportViewModel> _parserReports;
+
 		public ObservableCollection<ParserReportViewModel> ParserReports
 		{
 			get => _parserReports;
@@ -36,13 +37,15 @@ namespace SIL.FieldWorks.LexText.Controls
 					}
 				}
 
-				OnPropertyChanged(nameof(ParserReports));
+				// Don't call OnPropertyChanged here!  It suppresses the default behavior.
 				UpdateButtonStates(); // Update button states when the collection changes
 			}
 		}
 		public bool CanShowReport => ParserReports.Count(report => report.IsSelected) == 1;
 		public bool CanDiffReports => ParserReports.Count(report => report.IsSelected) == 2;
 		public bool CanDeleteReports => ParserReports.Any(report => report.IsSelected);
+		public bool CanSaveReport => ParserReports.Count(report => report.IsSelected) == 1 &&
+									ParserReports.Count(report => report.IsSelected && report.ParserReport.Filename == null) == 1;
 
 		public string DiffButtonContent => string.Format(ParserUIStrings.ksDelete,
 			ParserReports.Count(report => report.IsSelected));
@@ -86,6 +89,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				// Notify changes to button state properties
 				OnPropertyChanged(nameof(CanShowReport));
+				OnPropertyChanged(nameof(CanSaveReport));
 				OnPropertyChanged(nameof(CanDiffReports));
 				OnPropertyChanged(nameof(CanDeleteReports));
 				OnPropertyChanged(nameof(DiffButtonContent));
@@ -101,6 +105,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			OnPropertyChanged(nameof(CanShowReport));
 			OnPropertyChanged(nameof(CanDiffReports));
+			OnPropertyChanged(nameof(CanSaveReport));
 			OnPropertyChanged(nameof(CanDeleteReports));
 		}
 	}

--- a/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
+++ b/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
@@ -79,6 +79,24 @@ namespace SIL.FieldWorks.LexText.Controls {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comment.
+        /// </summary>
+        public static string ksComment {
+            get {
+                return ResourceManager.GetString("ksComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The comment provided by the user when the report was saved.
+        /// </summary>
+        public static string ksCommentToolTip {
+            get {
+                return ResourceManager.GetString("ksCommentToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to -.
         /// </summary>
         public static string ksDash {
@@ -138,6 +156,15 @@ namespace SIL.FieldWorks.LexText.Controls {
         public static string ksDiffHeader {
             get {
                 return ResourceManager.GetString("ksDiffHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please enter a comment for the parser report.
+        /// </summary>
+        public static string ksEnterComment {
+            get {
+                return ResourceManager.GetString("ksEnterComment", resourceCulture);
             }
         }
         
@@ -453,6 +480,24 @@ namespace SIL.FieldWorks.LexText.Controls {
         public static string ksReparseToolTip {
             get {
                 return ResourceManager.GetString("ksReparseToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save Report.
+        /// </summary>
+        public static string ksSaveReport {
+            get {
+                return ResourceManager.GetString("ksSaveReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save the report in the project.
+        /// </summary>
+        public static string ksSaveReportToolTip {
+            get {
+                return ResourceManager.GetString("ksSaveReportToolTip", resourceCulture);
             }
         }
         

--- a/Src/LexText/ParserUI/ParserUIStrings.resx
+++ b/Src/LexText/ParserUI/ParserUIStrings.resx
@@ -329,4 +329,19 @@
   <data name="ksXGenre" xml:space="preserve">
     <value>{0} genre</value>
   </data>
+  <data name="ksComment" xml:space="preserve">
+    <value>Comment</value>
+  </data>
+  <data name="ksCommentToolTip" xml:space="preserve">
+    <value>The comment provided by the user when the report was saved</value>
+  </data>
+  <data name="ksSaveReport" xml:space="preserve">
+    <value>Save Report</value>
+  </data>
+  <data name="ksSaveReportToolTip" xml:space="preserve">
+    <value>Save the report in the project</value>
+  </data>
+  <data name="ksEnterComment" xml:space="preserve">
+    <value>Please enter a comment for the parser report</value>
+  </data>
 </root>


### PR DESCRIPTION
I added a comment field to Parser Test Reports.  I also added a Save Report button.  If reports aren't saved, they are lost when the user closes the project.  When the user saves a report, they get a popup menu asking for a comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/149)
<!-- Reviewable:end -->
