### PR TITLE
Word Export: Add missing Before/After/Between content

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2005,9 +2005,12 @@ namespace SIL.FieldWorks.XWorks
 			var organizedRefs = SortAndFilterLexRefsAndTargets(collection, cmOwner, config);
 
 			// Now that we have things in the right order, try outputting one type at a time
+			bool first = true;
 			foreach (var referenceList in organizedRefs)
 			{
 				var xBldr = GenerateCrossReferenceChildren(config, pubDecorator, referenceList, cmOwner, settings);
+				settings.ContentGenerator.BetweenCrossReferenceType(xBldr, config, first);
+				first = false;
 				bldr.Append(xBldr);
 			}
 		}
@@ -2119,7 +2122,7 @@ namespace SIL.FieldWorks.XWorks
 							if (!content.IsNullOrEmpty())
 							{
 								// targets
-								settings.ContentGenerator.AddCollection(xw, config, IsBlockProperty(child),
+								settings.ContentGenerator.AddCollection(xw, child, IsBlockProperty(child),
 									CssGenerator.GetClassAttributeForConfig(child), content);
 								settings.StylesGenerator.AddStyles(child);
 							}

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2005,12 +2005,12 @@ namespace SIL.FieldWorks.XWorks
 			var organizedRefs = SortAndFilterLexRefsAndTargets(collection, cmOwner, config);
 
 			// Now that we have things in the right order, try outputting one type at a time
-			bool first = true;
+			bool firstIteration = true;
 			foreach (var referenceList in organizedRefs)
 			{
 				var xBldr = GenerateCrossReferenceChildren(config, pubDecorator, referenceList, cmOwner, settings);
-				settings.ContentGenerator.BetweenCrossReferenceType(xBldr, config, first);
-				first = false;
+				settings.ContentGenerator.BetweenCrossReferenceType(xBldr, config, firstIteration);
+				firstIteration = false;
 				bldr.Append(xBldr);
 			}
 		}

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -61,7 +61,7 @@ namespace SIL.FieldWorks.XWorks
 		IFragment AddLexReferences(ConfigurableDictionaryNode config, bool generateLexType, IFragment lexTypeContent, string className, IFragment referencesContent, bool typeBefore);
 		void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className);
 		void EndCrossReference(IFragmentWriter writer);
-		void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first);
+		void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool firstItem);
 		IFragment WriteProcessedSenses(ConfigurableDictionaryNode config, bool isBlock, IFragment senseContent, string className, IFragment sharedCollectionInfo);
 		IFragment AddAudioWsContent(string wsId, Guid linkTarget, IFragment fileContent);
 		IFragment GenerateErrorContent(StringBuilder badStrBuilder);

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -61,6 +61,7 @@ namespace SIL.FieldWorks.XWorks
 		IFragment AddLexReferences(ConfigurableDictionaryNode config, bool generateLexType, IFragment lexTypeContent, string className, IFragment referencesContent, bool typeBefore);
 		void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className);
 		void EndCrossReference(IFragmentWriter writer);
+		void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first);
 		IFragment WriteProcessedSenses(ConfigurableDictionaryNode config, bool isBlock, IFragment senseContent, string className, IFragment sharedCollectionInfo);
 		IFragment AddAudioWsContent(string wsId, Guid linkTarget, IFragment fileContent);
 		IFragment GenerateErrorContent(StringBuilder badStrBuilder);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -411,7 +411,7 @@ namespace SIL.FieldWorks.XWorks
 			((JsonFragmentWriter)writer).InsertRawJson(",");
 		}
 
-		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool firstItem)
 		{
 		}
 

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -411,6 +411,10 @@ namespace SIL.FieldWorks.XWorks
 			((JsonFragmentWriter)writer).InsertRawJson(",");
 		}
 
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		{
+		}
+
 		/// <summary>
 		/// Generates data for all senses of an entry. For better processing of json add sharedGramInfo as a separate property object
 		/// </summary>

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1621,10 +1621,10 @@ namespace SIL.FieldWorks.XWorks
 			return;
 		}
 
-		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool firstItem)
 		{
 			// Add Between text if it is not the first item in the collection.
-			if (!first && !string.IsNullOrEmpty(node.Between))
+			if (!firstItem && !string.IsNullOrEmpty(node.Between))
 			{
 				var betweenRun = CreateBeforeAfterBetweenRun(node.Between);
 				((DocFragment)content).DocBody.PrependChild(betweenRun);

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1440,9 +1440,23 @@ namespace SIL.FieldWorks.XWorks
 		}
 		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className, IFragment content)
 		{
+			// Add Before text.
+			if (!string.IsNullOrEmpty(config.Before))
+			{
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
+				((WordFragmentWriter)writer).WordFragment.DocBody.Append(beforeRun);
+			}
+
 			if (!content.IsNullOrEmpty())
 			{
 				((WordFragmentWriter)writer).WordFragment.Append(content);
+			}
+
+			// Add After text.
+			if (!string.IsNullOrEmpty(config.After))
+			{
+				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				((WordFragmentWriter)writer).WordFragment.DocBody.Append(afterRun);
 			}
 		}
 		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string getCollectionItemClassAttribute)
@@ -1606,6 +1620,17 @@ namespace SIL.FieldWorks.XWorks
 		{
 			return;
 		}
+
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		{
+			// Add Between text if it is not the first item in the collection.
+			if (!first && !string.IsNullOrEmpty(node.Between))
+			{
+				var betweenRun = CreateBeforeAfterBetweenRun(node.Between);
+				((DocFragment)content).DocBody.PrependChild(betweenRun);
+			}
+		}
+
 		public IFragment WriteProcessedSenses(ConfigurableDictionaryNode config, bool isBlock, IFragment senseContent, string className, IFragment sharedGramInfo)
 		{
 			// Add Before text for the senses.

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -992,6 +992,10 @@ namespace SIL.FieldWorks.XWorks
 			EndObject(writer);
 		}
 
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		{
+		}
+
 		public IFragment WriteProcessedSenses(ConfigurableDictionaryNode config, bool isBlock, IFragment sensesContent, string classAttribute, IFragment sharedGramInfo)
 		{
 			sharedGramInfo.Append(sensesContent);

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -992,7 +992,7 @@ namespace SIL.FieldWorks.XWorks
 			EndObject(writer);
 		}
 
-		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool first)
+		public void BetweenCrossReferenceType(IFragment content, ConfigurableDictionaryNode node, bool firstItem)
 		{
 		}
 


### PR DESCRIPTION
- Add between content for CrossRreference types.
- Add before and after content for LexicalRelations->Targets.

Note: I think passing child to AddCollection() is the correct node for the collection being added. The other implementations of AddCollection() do not use this parameter so they are not affected.

This fixes one of the issues identified in LT-21808.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/155)
<!-- Reviewable:end -->
