### PR TITLE
Word Export: Prevent extra Before/After content for senses

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1633,8 +1633,12 @@ namespace SIL.FieldWorks.XWorks
 
 		public IFragment WriteProcessedSenses(ConfigurableDictionaryNode config, bool isBlock, IFragment senseContent, string className, IFragment sharedGramInfo)
 		{
-			// Add Before text for the senses.
-			if (!string.IsNullOrEmpty(config.Before))
+			bool eachInAParagraph = config != null &&
+									config.DictionaryNodeOptions is DictionaryNodeSenseOptions &&
+									((DictionaryNodeSenseOptions)(config.DictionaryNodeOptions)).DisplayEachSenseInAParagraph;
+
+			// Add Before text for the senses if they were not displayed in separate paragraphs.
+			if (!eachInAParagraph && !string.IsNullOrEmpty(config.Before))
 			{
 				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
 				((DocFragment)sharedGramInfo).DocBody.PrependChild(beforeRun);
@@ -1642,8 +1646,8 @@ namespace SIL.FieldWorks.XWorks
 
 			sharedGramInfo.Append(senseContent);
 
-			// Add After text for the senses.
-			if (!string.IsNullOrEmpty(config.After))
+			// Add After text for the senses if they were not displayed in separate paragraphs.
+			if (!eachInAParagraph && !string.IsNullOrEmpty(config.After))
 			{
 				var afterRun = CreateBeforeAfterBetweenRun(config.After);
 				((DocFragment)sharedGramInfo).DocBody.Append(afterRun);


### PR DESCRIPTION
When senses are in separate paragraphs we were still adding the before and after content that was around the collection of senses.  It is now only added when not in separate paragraphs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/157)
<!-- Reviewable:end -->
