### PR TITLE
Word Export: Remove TODO’s for Audio and Video content

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -796,8 +796,8 @@ namespace SIL.FieldWorks.XWorks
 
 		public IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, string classname, string srcAttribute, string caption, string safeAudioId)
 		{
-			// TODO
-			return new DocFragment("TODO: generate audio link content");
+			// We are not planning to support audio and video content for Word Export.
+			return new DocFragment();
 		}
 		public IFragment WriteProcessedObject(ConfigurableDictionaryNode config, bool isBlock, IFragment elementContent, string className)
 		{
@@ -1653,7 +1653,8 @@ namespace SIL.FieldWorks.XWorks
 		}
 		public IFragment AddAudioWsContent(string wsId, Guid linkTarget, IFragment fileContent)
 		{
-			return new DocFragment("TODO: add audiows content");
+			// We are not planning to support audio and video content for Word Export.
+			return new DocFragment();
 		}
 		public IFragment GenerateErrorContent(StringBuilder badStrBuilder)
 		{
@@ -1662,7 +1663,8 @@ namespace SIL.FieldWorks.XWorks
 		public IFragment GenerateVideoLinkContent(ConfigurableDictionaryNode config, string className, string mediaId, string srcAttribute,
 			string caption)
 		{
-			return new DocFragment("TODO: generate video link content");
+			// We are not planning to support audio and video content for Word Export.
+			return new DocFragment();
 		}
 		#endregion ILcmContentGenerator functions to implement
 


### PR DESCRIPTION
Removed TODO’s for content we do not plan to support for Word Export.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/158)
<!-- Reviewable:end -->
