### PR TITLE
Fix LT-21585: Hermit Crab Parsing Error yellow box crash

### DIFF
--- a/Src/GenerateHCConfig/ConsoleLogger.cs
+++ b/Src/GenerateHCConfig/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using SIL.LCModel;
 using SIL.FieldWorks.WordWorks.Parser;
@@ -102,6 +102,11 @@ namespace GenerateHCConfig
 		public void InvalidReduplicationForm(IMoForm form, string reason, IMoMorphSynAnalysis msa)
 		{
 			Console.WriteLine("The reduplication form \"{0}\" is invalid. Reason: {1}", form.Form.VernacularDefaultWritingSystem.Text, reason);
+		}
+
+		public void InvalidRewriteRule(IPhRegularRule rule, string reason)
+		{
+			Console.WriteLine("The rewrite rule \"{0}\" is invalid. Reason: {1}", rule.Name.BestAnalysisVernacularAlternative.Text, reason);
 		}
 	}
 }

--- a/Src/LexText/ParserCore/HCLoader.cs
+++ b/Src/LexText/ParserCore/HCLoader.cs
@@ -236,6 +236,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 						if (regRule.StrucDescOS.Count > 0 || regRule.RightHandSidesOS.Any(rhs => rhs.StrucChangeOS.Count > 0))
 						{
 							RewriteRule hcRegRule = LoadRewriteRule(regRule);
+							if (hcRegRule == null)
+								continue;
 							m_morphophonemic.PhonologicalRules.Add(hcRegRule);
 							if (!m_notOnClitics)
 								m_clitic.PhonologicalRules.Add(hcRegRule);
@@ -1698,6 +1700,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			}
 			hcPrule.Properties[HCParser.PRuleID] = prule.Hvo;
 
+			if (hcPrule.Lhs.Children.Count > 1)
+			{
+				m_logger.InvalidRewriteRule(prule, ParserCoreStrings.ksMaxElementsInRule);
+				return null;
+			}
 			foreach (IPhSegRuleRHS rhs in prule.RightHandSidesOS)
 			{
 				var psubrule = new RewriteSubrule();
@@ -1746,6 +1753,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 						rightPattern.Children.Add(new Constraint<Word, ShapeNode>(HCFeatureSystem.RightSideAnchor));
 					rightPattern.Freeze();
 					psubrule.RightEnvironment = rightPattern;
+				}
+
+				if (psubrule.Rhs.Children.Count > 1)
+				{
+					m_logger.InvalidRewriteRule(prule, ParserCoreStrings.ksMaxElementsInRule);
+					return null;
 				}
 
 				hcPrule.Subrules.Add(psubrule);

--- a/Src/LexText/ParserCore/HCParser.cs
+++ b/Src/LexText/ParserCore/HCParser.cs
@@ -641,6 +641,14 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				m_xmlWriter.WriteElementString("Reason", reason);
 				m_xmlWriter.WriteEndElement();
 			}
+			public void InvalidRewriteRule(IPhRegularRule rule, string reason)
+			{
+				m_xmlWriter.WriteStartElement("LoadError");
+				m_xmlWriter.WriteAttributeString("type", "invalid-rewrite-rule");
+				m_xmlWriter.WriteElementString("Rule", rule.Name.BestAnalysisVernacularAlternative.Text);
+				m_xmlWriter.WriteElementString("Reason", reason);
+				m_xmlWriter.WriteEndElement();
+			}
 		}
 	}
 }

--- a/Src/LexText/ParserCore/IHCLoadErrorLogger.cs
+++ b/Src/LexText/ParserCore/IHCLoadErrorLogger.cs
@@ -1,4 +1,4 @@
-﻿using SIL.LCModel;
+using SIL.LCModel;
 
 namespace SIL.FieldWorks.WordWorks.Parser
 {
@@ -10,5 +10,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		void DuplicateGrapheme(IPhPhoneme phoneme);
 		void InvalidEnvironment(IMoForm form, IPhEnvironment env, string reason, IMoMorphSynAnalysis msa);
 		void InvalidReduplicationForm(IMoForm form, string reason, IMoMorphSynAnalysis msa);
+		void InvalidRewriteRule(IPhRegularRule prule, string reason);
 	}
 }

--- a/Src/LexText/ParserCore/ParserCoreStrings.Designer.cs
+++ b/Src/LexText/ParserCore/ParserCoreStrings.Designer.cs
@@ -133,6 +133,15 @@ namespace SIL.FieldWorks.WordWorks.Parser {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A rule can&apos;t have more than one element in its left-hand side or its right-hand side..
+        /// </summary>
+        internal static string ksMaxElementsInRule {
+            get {
+                return ResourceManager.GetString("ksMaxElementsInRule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ???.
         /// </summary>
         internal static string ksQuestions {

--- a/Src/LexText/ParserCore/ParserCoreStrings.resx
+++ b/Src/LexText/ParserCore/ParserCoreStrings.resx
@@ -189,4 +189,7 @@
   <data name="ksTestX" xml:space="preserve">
     <value>Tested {0}</value>
   </data>
+  <data name="ksMaxElementsInRule" xml:space="preserve">
+    <value>A rule can't have more than one element in its left-hand side or its right-hand side.</value>
+  </data>
 </root>

--- a/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
@@ -994,9 +994,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			Cache.LanguageProject.PhonologicalDataOA.PhonRulesOS.Add(prule);
 			prule.Name.SetAnalysisDefaultWritingSystem("prule");
 			prule.Direction = 2;
-			IPhSimpleContextSeg segCtxt = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
-			prule.StrucDescOS.Add(segCtxt);
-			segCtxt.FeatureStructureRA = GetPhoneme("a");
 			IPhSimpleContextNC ncCtxt = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
 			prule.StrucDescOS.Add(ncCtxt);
 			ncCtxt.FeatureStructureRA = m_vowel;
@@ -1027,7 +1024,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 			Assert.That(hcPrule.Direction, Is.EqualTo(Machine.DataStructures.Direction.LeftToRight));
 			Assert.That(hcPrule.ApplicationMode, Is.EqualTo(RewriteApplicationMode.Simultaneous));
-			Assert.That(hcPrule.Lhs.ToString(), Is.EqualTo(m_lang.Strata[0].CharacterDefinitionTable["a"].FeatureStruct + VowelFS));
+			Assert.That(hcPrule.Lhs.ToString(), Is.EqualTo(VowelFS));
 
 			Assert.That(hcPrule.Subrules.Count, Is.EqualTo(1));
 			RewriteSubrule subrule = hcPrule.Subrules[0];

--- a/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
@@ -41,7 +41,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			InvalidPhoneme,
 			DuplicateGrapheme,
 			InvalidEnvironment,
-			InvalidRedupForm
+			InvalidRedupForm,
+			InvalidRewriteRule
 		}
 
 		private class TestHCLoadErrorLogger : IHCLoadErrorLogger
@@ -81,6 +82,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			public void InvalidReduplicationForm(IMoForm form, string reason, IMoMorphSynAnalysis msa)
 			{
 				m_loadErrors.Add(Tuple.Create(LoadErrorType.InvalidRedupForm, (ICmObject) msa));
+			}
+
+			public void InvalidRewriteRule(IPhRegularRule rule, string reason)
+			{
+				m_loadErrors.Add(Tuple.Create(LoadErrorType.InvalidRedupForm, (ICmObject) rule));
 			}
 		}
 

--- a/Src/Transforms/Presentation/FormatCommon.xsl
+++ b/Src/Transforms/Presentation/FormatCommon.xsl
@@ -118,6 +118,15 @@
 										</span>
 									</li>
 								</xsl:when>
+								<xsl:when test="@type = 'invalid-rewrite-rule'">
+									<li>
+										<xsl:text>The rewrite rule "</xsl:text>
+										<xsl:value-of select="Rule" />
+										<xsl:text>" is invalid. Reason: </xsl:text>
+										<xsl:value-of select="Reason" />
+										<xsl:text> </xsl:text>
+									</li>
+								</xsl:when>
 								<xsl:otherwise>
 									<!-- Do not expect any others to happen, but just in case, we show them in all their HC glory -->
 									<li><xsl:value-of select="."/></li>


### PR DESCRIPTION
I fixed LT-21585 by detecting and reporting errors in rewrite rules when they are loaded into HermitCrab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/161)
<!-- Reviewable:end -->
