### PR TITLE
Fix LT-21890: Deleting from right side of affix process rule crashes

### DIFF
--- a/Src/LexText/Morphology/AffixRuleFormulaControl.cs
+++ b/Src/LexText/Morphology/AffixRuleFormulaControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -716,7 +716,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			else
 			{
 				int idx = GetIndexToRemove(mappings, sel, forward);
-				if (idx > -1)
+				if (idx > -1 && idx < mappings.Count())
 				{
 					var mapping = (IMoRuleMapping) mappings[idx];
 					index = idx - 1;


### PR DESCRIPTION
I added a check to avoid reading outside of an array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/162)
<!-- Reviewable:end -->
