### PR TITLE
Fix LT-21886: Deleting phonemes from an affix rule crashes

### DIFF
--- a/Src/LexText/Morphology/AffixRuleFormulaControl.cs
+++ b/Src/LexText/Morphology/AffixRuleFormulaControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -599,6 +599,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 							int prevCellId = GetPrevCell(seqCtxt.Hvo);
 							cellIndex = GetCellCount(prevCellId) - 1;
 							Rule.InputOS.Remove(seqCtxt);
+							// Unschedule the removal of the column.
+							m_removeCol = null;
 							return prevCellId;
 						}
 						bool reconstruct = RemoveContextsFrom(forward, sel, seqCtxt, false, out cellIndex);


### PR DESCRIPTION
I unscheduled the removal of a column that was being removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/163)
<!-- Reviewable:end -->
