### PR TITLE
Fix LT-21892: NotOnClitics box does not work as expected

### DIFF
--- a/Src/LexText/ParserCore/HCLoader.cs
+++ b/Src/LexText/ParserCore/HCLoader.cs
@@ -236,9 +236,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 						if (regRule.StrucDescOS.Count > 0 || regRule.RightHandSidesOS.Any(rhs => rhs.StrucChangeOS.Count > 0))
 						{
 							RewriteRule hcRegRule = LoadRewriteRule(regRule);
-							m_morphophonemic.PhonologicalRules.Add(hcRegRule);
+
+							// Choose which stratum the phonological rules apply on.
 							if (!m_notOnClitics)
 								m_clitic.PhonologicalRules.Add(hcRegRule);
+							else
+								m_morphophonemic.PhonologicalRules.Add(hcRegRule);
 							m_language.PhonologicalRules.Add(hcRegRule);
 						}
 						break;
@@ -248,9 +251,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 						if (metaRule.LeftSwitchIndex != -1 && metaRule.RightSwitchIndex != -1)
 						{
 							MetathesisRule hcMetaRule = LoadMetathesisRule(metaRule);
-							m_morphophonemic.PhonologicalRules.Add(hcMetaRule);
+
+							// Choose which stratum the phonological rules apply on.
 							if (!m_notOnClitics)
 								m_clitic.PhonologicalRules.Add(hcMetaRule);
+							else
+								m_morphophonemic.PhonologicalRules.Add(hcMetaRule);
 							m_language.PhonologicalRules.Add(hcMetaRule);
 						}
 						break;


### PR DESCRIPTION
I have a fix for this bug, but Andy wants me to do something more ambitious.  Here is the background:

When NotOnClitics is disabled, FieldWorks asks HermitCrab to apply the rules in the following order (in generation direction):
morphological rules -> phonological rules -> clitic rules
When NotOnClitics is enabled, FieldWorks asks HermitCrab to apply the rules as follows:
morphological rules -> phonological rules -> clitic rules -> phonological rules
This causes the phonological rules to be applied twice to the non-clitic portion, which is not what the grammar writer intended.
I fixed this by having FieldWorks ask HermitCrab to apply the rules as follows:
morphological rules -> clitic rules -> phonological rules
This produces the desired result: the phonological rules apply to the clitics and they apply to the non-clitic part just once.
However, Andy wanted me to let the user specify where phonological rules apply:
morphological rules -> phonological rules (1) -> clitic rules -> phonological rules (2)
This is the correct approach in the long run, but is a much bigger change since it requires a change to the UI (the data model already supports it).  I asked Andy to create a new Jira ticket for this request instead.

Shall we make my temporary fix, or shall I try to implement Andy's solution now?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/164)
<!-- Reviewable:end -->
