### PR TITLE
Fix LT-21888: boundary marker name can be deleted when editing rules

### DIFF
--- a/Src/LexText/LexTextControls/PatternView.cs
+++ b/Src/LexText/LexTextControls/PatternView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
@@ -134,11 +134,16 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// <param name="e"></param>
 		protected override void OnKeyPress(KeyPressEventArgs e)
 		{
-			if (e.KeyChar == (char) Keys.Back)
+			if (e.KeyChar == (char)Keys.Back || e.KeyChar == (char)Keys.Delete)
 			{
 				if (RemoveItemsRequested != null)
 					RemoveItemsRequested(this, new RemoveItemsRequestedEventArgs(false));
 				e.Handled = true;
+			}
+			else
+			{
+				// Ignore all other characters (fixes LT-21888).
+				return;
 			}
 			base.OnKeyPress(e);
 		}

--- a/Src/LexText/LexTextControls/PatternView.cs
+++ b/Src/LexText/LexTextControls/PatternView.cs
@@ -134,11 +134,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// <param name="e"></param>
 		protected override void OnKeyPress(KeyPressEventArgs e)
 		{
+			e.Handled = true;
 			if (e.KeyChar == (char)Keys.Back || e.KeyChar == (char)Keys.Delete)
 			{
 				if (RemoveItemsRequested != null)
 					RemoveItemsRequested(this, new RemoveItemsRequestedEventArgs(false));
-				e.Handled = true;
 			}
 			else
 			{


### PR DESCRIPTION
I have a fix for this, but it might not be the best solution.

If you select a boundary marker (or any phoneme) in a phonological rule and type a character, its name gets deleted but the boundary marker does not.  I couldn't track down where in the code this happens.  I prevented this from happening by suppressing all characters except for Backspace and Delete.  This means that the user can only enter phonemes by using the menu provided.  This feels like overkill, but Matthew is OK with it if we eventually add code to allow phonemes to be entered by typing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/165)
<!-- Reviewable:end -->
