### PR TITLE
Fix LT-20588: Crash in Affix Process Rule

### DIFF
--- a/Src/LexText/Morphology/AffixRuleFormulaControl.cs
+++ b/Src/LexText/Morphology/AffixRuleFormulaControl.cs
@@ -176,7 +176,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		private bool DisplayColumnOption(object option)
 		{
 			SelectionHelper sel = SelectionHelper.Create(m_view);
-			if (sel.IsRange)
+			if (sel == null || sel.IsRange)
 				return false;
 
 			int cellId = GetCell(sel);

--- a/Src/LexText/Morphology/RuleFormulaControl.cs
+++ b/Src/LexText/Morphology/RuleFormulaControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -569,6 +569,12 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			var redo = string.Format(MEStrings.ksRuleRedoInsert, option);
 
 			SelectionHelper sel = SelectionHelper.Create(m_view);
+			if (sel == null)
+			{
+				// The selection can become invalid because of an undo (see LT-20588).
+				m_insertionControl.UpdateOptionsDisplay();
+				return;
+			}
 			int cellId = -1;
 			int cellIndex = -1;
 			switch (option.Type)


### PR DESCRIPTION
I fixed https://jira.sil.org/browse/LT-20588.  The problem was that doing an undo left the context-sensitive menu in a funny state.  I couldn't figure out how to trigger a reset of the menu when the undo was performed, so I settled for triggering a reset if the user clicked on any of the elements in the the menu. In general, if the user clicks anywhere then the menu will reset, so this change is just to make sure that clicking on a menu item won't cause a crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/167)
<!-- Reviewable:end -->
