### PR TITLE
Word Export LT-21942: Fixed more Export failures

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1951,7 +1951,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			MainDocumentPart mainPart = doc.MainDocumentPart;
 			ImagePart imagePart = mainPart.AddImagePart(imageType);
-			using (FileStream stream = new FileStream(imagePath, FileMode.Open))
+			using (FileStream stream = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
 			{
 				imagePart.FeedData(stream);
 			}
@@ -2418,7 +2418,7 @@ namespace SIL.FieldWorks.XWorks
 						{
 							if (elem is Paragraph)
 							{
-								var paraProps = elem.Elements<ParagraphProperties>().First();
+								var paraProps = elem.Elements<ParagraphProperties>().FirstOrDefault();
 								if (paraProps != null)
 								{
 									// Only add the uniqueId to paragraphs with the correct style.  There could


### PR DESCRIPTION
When testing with Steve’s Project additional failures were found:
1. Open image files with read access. The same image can be used by multiple entries. We were trying to open the same file with write access from different threads.
2. Use FirstOrDefault() instead of First().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/171)
<!-- Reviewable:end -->
