### PR TITLE
Fix gram info dropdown: LT-21584 Part2

### DIFF
--- a/Src/Common/Controls/Widgets/FwComboBox.cs
+++ b/Src/Common/Controls/Widgets/FwComboBox.cs
@@ -1069,8 +1069,8 @@ namespace SIL.FieldWorks.Common.Widgets
 			}
 			else
 			{
-				//m_comboListBox.FormWidth = this.Size.Width;
-				sz.Width = Width;
+				// If the programmer set an explicit width for the list box, that width is stored in DropDownWidth.
+				sz.Width = DropDownWidth;
 			}
 
 			if (sz != m_dropDownBox.Form.Size)

--- a/Src/Common/Controls/Widgets/PopupTree.cs
+++ b/Src/Common/Controls/Widgets/PopupTree.cs
@@ -293,7 +293,7 @@ namespace SIL.FieldWorks.Common.Widgets
 		{
 			get
 			{
-				return new Size(300, 600);
+				return new Size(300, 400);
 				// Previously, used (120, 200) for the default size.
 				// Width set to 120 lets the popuptree dropdown match the width of the box that it drops down from,
 				// but this doesn't allow enough space to view trees that contain several layers.

--- a/Src/LexText/LexTextControls/MSAGroupBox.cs
+++ b/Src/LexText/LexTextControls/MSAGroupBox.cs
@@ -625,7 +625,6 @@ namespace SIL.FieldWorks.LexText.Controls
 			//
 			this.m_fwcbAffixTypes.AdjustStringHeight = true;
 			this.m_fwcbAffixTypes.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.m_fwcbAffixTypes.DropDownWidth = 140;
 			this.m_fwcbAffixTypes.DroppedDown = false;
 			resources.ApplyResources(this.m_fwcbAffixTypes, "m_fwcbAffixTypes");
 			this.m_fwcbAffixTypes.Name = "m_fwcbAffixTypes";
@@ -642,7 +641,8 @@ namespace SIL.FieldWorks.LexText.Controls
 			// m_tcMainPOS
 			//
 			this.m_tcMainPOS.AdjustStringHeight = true;
-			this.m_tcMainPOS.DropDownWidth = 140;
+			// Setting width to match the default width used by popuptree
+			this.m_tcMainPOS.DropDownWidth = 300;
 			this.m_tcMainPOS.DroppedDown = false;
 			resources.ApplyResources(this.m_tcMainPOS, "m_tcMainPOS");
 			this.m_tcMainPOS.Name = "m_tcMainPOS";


### PR DESCRIPTION
Fix behavior of grammatical info dropdown in the New Entry dialogue.

- Correct the variable used to overwrite width in ShowDropDownBox() in the case that width is explicitly specified for the listbox.
- Specify DropDownWidth for the MainPOS dropdown to match the default width for popuptree.
- The AffixTypes dropdown is meant to match button width, so its DropDownWidth should not be explicitly set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/173)
<!-- Reviewable:end -->
