### PR TITLE
Word Export LT-21942: Fix picture clipping problem

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2270,8 +2270,11 @@ namespace SIL.FieldWorks.XWorks
 			var elements = ((DocFragment)contentToAdd).DocBody.Elements();
 			foreach (OpenXmlElement elem in elements)
 			{
-				// Un-nestable type.
-				if (elem is WP.Paragraph || elem is WP.Table)
+				Boolean containsDrawing = elem.Descendants<Drawing>().Any();
+				// Un-nestable type (Paragraph or Table), or if a run contains a drawing, then leave it
+				// as a first level element. Runs containing drawings will later, in AddEntryData(), get
+				// put in their own paragraph.
+				if (elem is WP.Paragraph || elem is WP.Table || (elem is WP.Run && containsDrawing))
 				{
 					// End the current working paragraph and add it to the list.
 					if (EndParagraph(workingParagraph, node, continuationParagraph))


### PR DESCRIPTION
Runs containing drawings (pictures) need to be in their own Paragraph. When we are in SeparateIntoFirstLevelElements() don’t combine them with other elements in a paragraph.  Instead leave the run as a first level element so that later, in AddEntryData(), it will get put in its own paragraph with the correct style.

Change-Id: Ie62eb2edb7547d553018a61ea57b638dc146d407

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/177)
<!-- Reviewable:end -->
