### PR TITLE
Word Export LT-21768: Font properties for bullets

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2500,6 +2500,16 @@ namespace SIL.FieldWorks.XWorks
 				return;
 			}
 
+			// Add any font properties that were explicitly set.
+			if (bulletInfo.FontInfo != null && bulletInfo.FontInfo.IsAnyExplicit)
+			{
+				WP.RunProperties runProps = WordStylesGenerator.GetExplicitFontProperties(bulletInfo.FontInfo);
+				if (runProps.HasChildren)
+				{
+					abstractLevel.Append(runProps);
+				}
+			}
+
 			// Add the new AbstractNum after the last AbstractNum.
 			// Word cares about the order of AbstractNum elements and NumberingInstance elements.
 			var abstractNum = new AbstractNum(abstractLevel) { AbstractNumberId = bulletUniqueId };


### PR DESCRIPTION
Add font property support for bullets and numbers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/178)
<!-- Reviewable:end -->
