### PR TITLE
Fix LT-21956: Crash when doing Ctr+A in 'Affix Process Rule' result area

### DIFF
--- a/Src/LexText/Morphology/AffixRuleFormulaControl.cs
+++ b/Src/LexText/Morphology/AffixRuleFormulaControl.cs
@@ -54,6 +54,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 				CheckDisposed();
 
 				var obj = CurrentObject;
+				if (obj == null)
+					return false;
 				if (obj.ClassID == MoCopyFromInputTags.kClassId)
 				{
 					var copy = (IMoCopyFromInput) obj;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/185)
<!-- Reviewable:end -->
