### PR TITLE
LT-21911: Update SIL.Machine and add GuessRoots parameter

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -287,7 +287,7 @@
 		<ParatextNugetVersion>9.4.0.1-beta</ParatextNugetVersion>
 		<LcmNugetVersion>11.0.0-beta0104</LcmNugetVersion>
 		<IcuNugetVersion>70.1.123</IcuNugetVersion>
-		<HermitCrabNugetVersion>3.3.0</HermitCrabNugetVersion>
+		<HermitCrabNugetVersion>3.4.1</HermitCrabNugetVersion>
 		<IPCFrameworkVersion>1.1.1-beta0001</IPCFrameworkVersion>
 		<!-- bt393 is the master branch build of ExCss for Windows development. Update when appropriate. -->
 		<ExCssBuildType Condition="'$(OS)'=='Windows_NT'">bt393</ExCssBuildType>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -66,8 +66,8 @@
   <package id="SIL.libpalaso.l10ns" version="6.0.0" targetFramework="net461" />
   <package id="SIL.Lift" version="13.0.0-beta0076"  targetFramework="net461" />
   <package id="SIL.Media" version="13.0.0-beta0076"  targetFramework="net461" />
-  <package id="SIL.Machine" version="3.3.0"  targetFramework="netstandard2.0" />
-  <package id="SIL.Machine.Morphology.HermitCrab" version="3.3.0"  targetFramework="netstandard2.0" />
+  <package id="SIL.Machine" version="3.4.1"  targetFramework="netstandard2.0" />
+  <package id="SIL.Machine.Morphology.HermitCrab" version="3.4.1"  targetFramework="netstandard2.0" />
   <package id="SIL.ParatextShared" version="7.4.0.1"  targetFramework="net40" /> <!-- REVIEW (Hasso) 2023.05: do we still integrate with PT 7? -->
   <package id="SIL.Scripture" version="13.0.0-beta0076"  targetFramework="net461" />
   <package id="SIL.TestUtilities" version="13.0.0-beta0076"  targetFramework="net461" />


### PR DESCRIPTION
Beth reported that homographs didn't work.  I fixed this in SIL.Machine and updated FieldWorks to the fixed version.  I also added a "GuessRoots" parameter under Parser > Edit Parser Parameters so that guessing can be turned off.  I updated the acceptance test in https://jira.sil.org/browse/LT-21911 to cover both of these changes.