### PR TITLE
Fix LT-21969

### DIFF
--- a/Src/LexText/ParserCore/FwXmlTraceManager.cs
+++ b/Src/LexText/ParserCore/FwXmlTraceManager.cs
@@ -366,7 +366,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				case FailureReason.DisjunctiveAllomorph:
 					trace = CreateParseCompleteElement(word,
 						new XElement("FailureReason", new XAttribute("type", "disjunctiveAllomorph"),
-							CreateWordElement("Word", (Word) failureObj, false)));
+							CreateAllomorphElement((Allomorph) failureObj)));
 					break;
 
 				case FailureReason.PartialParse:


### PR DESCRIPTION
This failed trying to cast an Allomorph to a Word.  I fixed it by casting it to an Allomorph instead.  All of the callers of Failed with FailureReason.DisjunctiveAllomorph have failureObj as an Allomorph.  I'm not sure why it was being cast to a Word.