### PR TITLE
Fix LT-21965: Linking words in interlinear is broken

### DIFF
--- a/Src/LexText/Interlinear/FocusBoxController.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.cs
@@ -379,6 +379,9 @@ namespace SIL.FieldWorks.IText
 						SelectedOccurrence.MakePhraseWithNextWord();
 						if (InterlinDoc != null)
 						{
+							// Joining words renumbers the occurrences.
+							// We need to clear the analysis cache to avoid problems (cf LT-21965).
+							InterlinDoc.ResetAnalysisCache();
 							InterlinDoc.RecordGuessIfNotKnown(SelectedOccurrence);
 						}
 					});

--- a/Src/LexText/Interlinear/FocusBoxController.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.cs
@@ -403,6 +403,12 @@ namespace SIL.FieldWorks.IText
 			var cmd = (ICommandUndoRedoText)arg;
 			UndoableUnitOfWorkHelper.Do(cmd.UndoText, cmd.RedoText, Cache.ActionHandlerAccessor,
 				() => SelectedOccurrence.BreakPhrase());
+			if (InterlinDoc != null)
+			{
+				// Breaking phrases renumbers the occurrences.
+				// We need to clear the analysis cache to avoid problems.
+				InterlinDoc.ResetAnalysisCache();
+			}
 			InterlinWordControl.SwitchWord(SelectedOccurrence);
 			UpdateButtonState();
 		}

--- a/Src/LexText/Interlinear/InterlinDocForAnalysis.cs
+++ b/Src/LexText/Interlinear/InterlinDocForAnalysis.cs
@@ -2260,6 +2260,12 @@ namespace SIL.FieldWorks.IText
 			return null;
 		}
 
+		internal void ResetAnalysisCache()
+		{
+			if (Vc != null)
+				Vc.ResetAnalysisCache();
+		}
+
 		internal void RecordGuessIfNotKnown(AnalysisOccurrence selected)
 		{
 			if (Vc != null) // I think this only happens in tests.
@@ -2347,6 +2353,7 @@ namespace SIL.FieldWorks.IText
 				helper.SetSelection(true, true);
 			Update();
 		}
+
 	}
 
 	public class InterlinDocForAnalysisVc : InterlinVc


### PR DESCRIPTION
LT-21965 was introduced in July when I changed the guesser to guess based on occurrence of an analysis rather than just the analysis itself.  An occurrence is just the segment and its index.  Linking two words together changes the indices, hence the problem.  I fixed the bug by resetting the analysis cache after linking words or breaking phrases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/191)
<!-- Reviewable:end -->
