### PR TITLE
Word Export LT-21673: Add support for bidi text

### DIFF
--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -41,6 +41,27 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// Finds a StyleElement from the uniqueDisplayName.
+		/// </summary>
+		/// <param name="uniqueDisplayName">The style name that uniquely identifies a style.</param>
+		public StyleElement GetStyleElement(string uniqueDisplayName)
+		{
+			lock (styleDictionary)
+			{
+				// Get an enumerator to the flattened list of all StyleElements.
+				var styleElementsEnumerator = styleDictionary.Values.SelectMany(x => x);
+				foreach (var styleElement in styleElementsEnumerator)
+				{
+					if (styleElement.Style.StyleId == uniqueDisplayName)
+					{
+						return styleElement;
+					}
+				}
+			}
+			return null;
+		}
+
+		/// <summary>
 		/// Clears the collection.
 		/// </summary>
 		public void Clear()
@@ -116,6 +137,45 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// Adds a character style to the collection.
+		/// If a style with the identical style information is already in the collection then just return
+		/// the unique name.
+		/// If the identical style is not already in the collection then generate a unique name,
+		/// update the style name values (with the unique name), and return the unique name.
+		/// </summary>
+		/// <param name="style">The style to add to the collection. (It's name might get modified.)</param>
+		/// <param name="nodeStyleName">The unique FLEX style name, typically comes from node.Style.</param>
+		/// <param name="displayNameBase">The base name that will be used to create the unique display name
+		/// for the style.  The root of this name typically comes from the node.DisplayLabel but it can have
+		/// additional information if it is based on other styles and/or has a writing system.</param>
+		/// <param name="wsId">The writing system id associated with this style.</param>
+		/// <param name="wsIsRtl">True if the writing system is right to left.</param>
+		/// <returns>The unique display name. The name that should be referenced in a Run.</returns>
+		public string AddCharacterStyle(Style style, string nodeStyleName, string displayNameBase, int wsId, bool wsIsRtl)
+		{
+			return AddStyle(style, nodeStyleName, displayNameBase, null, wsId, wsIsRtl);
+		}
+
+		/// <summary>
+		/// Adds a paragraph style to the collection.
+		/// If a style with the identical style information is already in the collection then just return
+		/// the unique name.
+		/// If the identical style is not already in the collection then generate a unique name,
+		/// update the style name values (with the unique name), and return the unique name.
+		/// </summary>
+		/// <param name="style">The style to add to the collection. (It's name might get modified.)</param>
+		/// <param name="nodeStyleName">The unique FLEX style name, typically comes from node.Style.</param>
+		/// <param name="displayNameBase">The base name that will be used to create the unique display name
+		/// for the style.  The root of this name typically comes from the node.DisplayLabel but it can have
+		/// additional information if it is based on other styles and/or has a writing system.</param>
+		/// <param name="bulletInfo">Bullet and Numbering info used by some paragraph styles.</param>
+		/// <returns>The unique display name.</returns>
+		public string AddParagraphStyle(Style style, string nodeStyleName, string displayNameBase, BulletInfo? bulletInfo)
+		{
+			return AddStyle(style, nodeStyleName, displayNameBase, bulletInfo, WordStylesGenerator.DefaultStyle, false);
+		}
+
+		/// <summary>
 		/// Adds a style to the collection.
 		/// If a style with the identical style information is already in the collection then just return
 		/// the unique name.
@@ -127,9 +187,11 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="displayNameBase">The base name that will be used to create the unique display name
 		/// for the style.  The root of this name typically comes from the node.DisplayLabel but it can have
 		/// additional information if it is based on other styles and/or has a writing system.</param>
-		/// <param name="bulletInfo">Bullet and Numbering info used by some paragraph styles. Not used for character styles. </param>
+		/// <param name="bulletInfo">Bullet and Numbering info used by some paragraph styles. Not used for character styles.</param>
+		/// <param name="wsId">The writing system id associated with this style.</param>
+		/// <param name="wsIsRtl">True if the writing system is right to left.</param>
 		/// <returns>The unique display name. The name that should be referenced in a Run.</returns>
-		public string AddStyle(Style style, string nodeStyleName, string displayNameBase, BulletInfo? bulletInfo = null)
+		public string AddStyle(Style style, string nodeStyleName, string displayNameBase, BulletInfo? bulletInfo, int wsId, bool wsIsRtl)
 		{
 			lock (styleDictionary)
 			{
@@ -185,7 +247,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 
 				// Add the style element to the collection.
-				var styleElement = new StyleElement(nodeStyleName, style, bulletInfo);
+				var styleElement = new StyleElement(nodeStyleName, style, bulletInfo, wsId, wsIsRtl);
 				stylesWithSameDisplayNameBase.Add(styleElement);
 
 				return uniqueDisplayName;
@@ -218,17 +280,22 @@ namespace SIL.FieldWorks.XWorks
 		///         Grammatical Info.2 : Category Info.[lang='en']
 		///         Subentries : Grammatical Info.2 : Category Info.[lang='en']
 		/// </param>
-		/// <param name="bulletInfo">Bullet and Numbering info used by some paragraph styles. Not used
-		/// for character styles. </param>
-		internal StyleElement(string nodeStyleName, Style style, BulletInfo? bulletInfo)
+		/// <param name="bulletInfo">Bullet and Numbering info used by some paragraph styles. Not used for character styles.</param>
+		/// <param name="wsId">The writing system id associated with this style.</param>
+		/// <param name="wsIsRtl">True if the writing system is right to left.</param>
+		internal StyleElement(string nodeStyleName, Style style, BulletInfo? bulletInfo, int wsId, bool wsIsRtl)
 		{
 			this.NodeStyleName = nodeStyleName;
 			this.Style = style;
+			this.WritingSystemId = wsId;
+			this.WritingSystemIsRtl = wsIsRtl;
 			this.BulletInfo = bulletInfo;
 			NumberingFirstNumUniqueIds = new List<int>();
 		}
 		internal string NodeStyleName { get; }
 		internal Style Style { get; }
+		internal int WritingSystemId { get; }
+		internal bool WritingSystemIsRtl { get; }
 
 		/// <summary>
 		/// Bullet and Numbering info used by some (not all) paragraph styles. Not used

--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -48,17 +48,9 @@ namespace SIL.FieldWorks.XWorks
 		{
 			lock (styleDictionary)
 			{
-				// Get an enumerator to the flattened list of all StyleElements.
-				var styleElementsEnumerator = styleDictionary.Values.SelectMany(x => x);
-				foreach (var styleElement in styleElementsEnumerator)
-				{
-					if (styleElement.Style.StyleId == uniqueDisplayName)
-					{
-						return styleElement;
-					}
-				}
+				return styleDictionary.Values.SelectMany(x => x)
+					.FirstOrDefault(styleElement => styleElement.Style.StyleId == uniqueDisplayName);
 			}
-			return null;
 		}
 
 		/// <summary>

--- a/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
@@ -357,7 +357,7 @@ namespace SIL.FieldWorks.XWorks
 			// 2. Sense number before text:		BEF
 			// 3. Sense number:					2
 			// 4. Sense number after text:		AFT
-			const string senseNumberTwoRun = "<w:r><w:rPr><w:rStyle w:val=\"Sense Number[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">BEF</w:t><w:t xml:space=\"preserve\">2</w:t><w:t xml:space=\"preserve\">AFT</w:t></w:r>";
+			const string senseNumberTwoRun = "<w:t xml:space=\"preserve\">BEF</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Sense Number[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">AFT</w:t></w:r>";
 			Assert.True(result.mainDocPart.RootElement.OuterXml.Contains(senseNumberTwoRun));
 		}
 


### PR DESCRIPTION
- Use the default vernacular writing system for before/after/between content.  This causes the order of many runs to be correct and causes characters like parentheses to be display correctly.
- For situations where two runs that are both lt2 we now add a run between them that is rtl.  This causes the order to be switched so they appear the same as in FLEX.
- Sense numbers now generate before/after content the same as all other before/after content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/192)
<!-- Reviewable:end -->
