### PR TITLE
Word Export LT-21673: bidi problem with switching run order

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -491,30 +491,6 @@ namespace SIL.FieldWorks.XWorks
 				else
 				{
 					lastPar = GetLastParagraph();
-
-					// If the project is bidi and
-					// the run we are adding is not rtl and
-					// the paragraph already contains runs and
-					// the previous run is not rtl
-					// then add a run between them that is rtl and contains a rtl character.
-					// This is needed to get the runs to switch their order in Word.
-					if (IsBidi && run.RunProperties?.RightToLeftText == null)
-					{
-						var childRuns = lastPar.Elements<Run>();
-						if(childRuns.Any())
-						{
-							var previousRun = childRuns.Last();
-							if (previousRun.RunProperties?.RightToLeftText == null)
-							{
-								// Add a unicode RTL mark between two runs that are not rtl.
-								var rtlRun = new WP.Run();
-								rtlRun.AppendChild(new WP.Text("\u200f"));
-								rtlRun.RunProperties = new RunProperties();
-								rtlRun.RunProperties.RightToLeftText = new RightToLeftText();
-								lastPar.AppendChild(rtlRun);
-							}
-						}
-					}
 				}
 
 				// Deep clone the run b/c of its tree of properties and to maintain styles.


### PR DESCRIPTION
To be consistent with how FLEX displays consecutive left-to-right runs, we do not want to switch their order. Remove the code that was doing the switching and causing the display to be different between Word and FLEX.

Change-Id: I396a54c88e9952112e396f0157f6420723282dff

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/194)
<!-- Reviewable:end -->
