### PR TITLE
Fix LT-21971: Crash adding a Feature Set

### DIFF
--- a/Src/LexText/Lexicon/MsaInflectionFeatureListDlgLauncherSlice.cs
+++ b/Src/LexText/Lexicon/MsaInflectionFeatureListDlgLauncherSlice.cs
@@ -105,6 +105,12 @@ namespace SIL.FieldWorks.XWorks.LexEd
 		{
 			if (m_obj != null)
 			{
+				if (m_obj.ClassID != MoStemMsaTags.kClassId
+					&& m_obj.ClassID != MoInflAffMsaTags.kClassId
+					&& m_obj.ClassID != MoDerivAffMsaTags.kClassId)
+					// Avoid creating a unit of work if there is nothing to be done.
+					// This prevents "Can't start new task, while broadcasting PropChanges." (LT-21971)
+					return;
 				NonUndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW(m_cache.ServiceLocator.GetInstance<IActionHandler>(), () =>
 				{
 					switch (m_obj.ClassID)


### PR DESCRIPTION
The crash occurred in RemoveFeatureStructureFromMSA because it tried to create a new non-undoable unit of work inside a PropChanges broadcast.  The property change was caused when DefaultCreateNewUIObject  created a new object inside an undoable unit of work.  DataTree.PropChanged called DataTree.RefreshList, which removed the existing slices which removed an existing feature structure.

I noticed that there was nothing to be done in the non-undoble unit of work because m_obj's ClassID didn't match.  So, I changed the code to avoid creating the non-undoable unit of work in this case.  This allowed the feature structure to be created without crashing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/195)
<!-- Reviewable:end -->
