### PR TITLE
Fix LT-21915: Additional glitches in Move up/Move down options

### DIFF
--- a/Src/Common/Controls/DetailControls/Slice.cs
+++ b/Src/Common/Controls/DetailControls/Slice.cs
@@ -2804,7 +2804,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				}
 				else
 				{
-					swapWith = NextPartSibling(fieldRef.NextSibling);
+					swapWith = NextPartSibling(fieldRef);
 				}
 
 				var parent = fieldRef.ParentNode;


### PR DESCRIPTION
One small bug in the Move Down code explained all of the weird behaviors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/196)
<!-- Reviewable:end -->
