### PR TITLE
Word Export: writing system that is not part of the project

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -749,7 +749,8 @@ namespace SIL.FieldWorks.XWorks
 							else
 							{
 								StyleElement rootElem = s_styleCollection.GetStyleElement(wsString);
-								Style rootStyle = rootElem.Style;
+								// rootElem can be null, see LT-21981.
+								Style rootStyle = rootElem?.Style;
 								if (rootStyle != null)
 								{
 									Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(new Style(), wsString, displayNameBase);


### PR DESCRIPTION
Prevent Word Export from crashing when we encounter a string that uses a writing system that is not part of the current FLEX project. This can happen when using copy/paste from one FLEX project to another, and the projects use different writing systems. See LT-21981.
Pasting table data from a custom field in one project to a custom field in another project reproduced the crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/197)
<!-- Reviewable:end -->
