### PR TITLE
Word Export: support Before/After/Between unique styles

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -692,30 +692,16 @@ namespace SIL.FieldWorks.XWorks
 			/// </summary>
 			public void AddRun(LcmCache cache, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string writingSystem, bool first)
 			{
-				// Add Between text, if it is not the first item.
-				if (!first &&
-					config != null &&
-					!string.IsNullOrEmpty(config.Between))
-				{
-					var betweenRun = CreateBeforeAfterBetweenRun(config.Between);
-					WordFragment.DocBody.Append(betweenRun);
-				}
-
 				var run = new WP.Run();
-				WordFragment.DocBody.AppendChild(run);
+				string uniqueDisplayName = null;
+				string displayNameBase = (config == null || writingSystem == null) ?
+					null : DocFragment.GetWsStyleName(cache, config, writingSystem);
 
-				if (config == null || writingSystem == null)
-				{
-					return;
-				}
-
-				string displayNameBase = DocFragment.GetWsStyleName(cache, config, writingSystem);
 				if (!string.IsNullOrEmpty(displayNameBase))
 				{
 					// The calls to TryGetStyle() and AddStyle() need to be in the same lock.
 					lock (s_styleCollection)
 					{
-						string uniqueDisplayName = null;
 						if (s_styleCollection.TryGetStyle(config.Style, displayNameBase, out StyleElement existingStyle))
 						{
 							uniqueDisplayName = existingStyle.Style.StyleId;
@@ -735,14 +721,15 @@ namespace SIL.FieldWorks.XWorks
 									// If we hit this assert, then we might end up referencing a style that
 									// does not get created.
 									Debug.Assert(false);
-									return;
 								}
-
-								style.Append(new BasedOn() { Val = wsString });
-								style.StyleId = displayNameBase;
-								style.StyleName.Val = style.StyleId;
-								bool wsIsRtl = IsWritingSystemRightToLeft(cache, wsId);
-								uniqueDisplayName = s_styleCollection.AddCharacterStyle(style, config.Style, style.StyleId, wsId, wsIsRtl);
+								else
+								{
+									style.Append(new BasedOn() { Val = wsString });
+									style.StyleId = displayNameBase;
+									style.StyleName.Val = style.StyleId;
+									bool wsIsRtl = IsWritingSystemRightToLeft(cache, wsId);
+									uniqueDisplayName = s_styleCollection.AddCharacterStyle(style, config.Style, style.StyleId, wsId, wsIsRtl);
+								}
 							}
 							// There is no style name defined in the config so generate a style that is identical to the writing system style
 							// except that it contains a display name that the user wants to see in the Word Styles.
@@ -775,10 +762,21 @@ namespace SIL.FieldWorks.XWorks
 								}
 							}
 						}
-
 						run.Append(GenerateRunProperties(uniqueDisplayName));
 					}
 				}
+
+				// Add Between text, if it is not the first item.
+				if (!first &&
+					config != null &&
+					!string.IsNullOrEmpty(config.Between))
+				{
+					var betweenRun = CreateBeforeAfterBetweenRun(config.Between, uniqueDisplayName);
+					WordFragment.DocBody.Append(betweenRun);
+				}
+
+				// Add the run.
+				WordFragment.DocBody.AppendChild(run);
 			}
 		}
 		#endregion WordFragmentWriter class
@@ -811,7 +809,7 @@ namespace SIL.FieldWorks.XWorks
 					if (runProps != null)
 					{
 						RunStyle runStyle = runProps.OfType<RunStyle>().FirstOrDefault();
-						if (runStyle != null && runStyle.Val == WordStylesGenerator.BeforeAfterBetweenDisplayName)
+						if (runStyle != null && runStyle.Val.ToString().StartsWith(WordStylesGenerator.BeforeAfterBetweenDisplayName))
 						{
 							((DocFragment)content).DocBody.InsertAfter(abbrevRun, firstRun);
 							abbrevAdded = true;
@@ -858,19 +856,20 @@ namespace SIL.FieldWorks.XWorks
 			bool eachInAParagraph = config != null &&
 								  config.DictionaryNodeOptions is IParaOption &&
 								  ((IParaOption)(config.DictionaryNodeOptions)).DisplayEachInAParagraph;
+			string styleDisplayName = GetUniqueDisplayName(config, elementContent);
 
 
 			// Add Before text, if it is not going to be displayed in a paragraph.
 			if (!eachInAParagraph && !string.IsNullOrEmpty(config.Before))
 			{
-				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before, styleDisplayName);
 				((DocFragment)elementContent).DocBody.PrependChild(beforeRun);
 			}
 
 			// Add After text, if it is not going to be displayed in a paragraph.
 			if (!eachInAParagraph && !string.IsNullOrEmpty(config.After))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				var afterRun = CreateBeforeAfterBetweenRun(config.After, styleDisplayName);
 				((DocFragment)elementContent).DocBody.Append(afterRun);
 			}
 
@@ -890,6 +889,7 @@ namespace SIL.FieldWorks.XWorks
 			bool eachInAParagraph = config != null &&
 								  config.DictionaryNodeOptions is DictionaryNodeGroupingOptions &&
 								  ((DictionaryNodeGroupingOptions)(config.DictionaryNodeOptions)).DisplayEachInAParagraph;
+			IFragment childContent = null;
 
 			// Display in its own paragraph, so the group style can be applied to all of the runs
 			// contained in it.
@@ -898,17 +898,10 @@ namespace SIL.FieldWorks.XWorks
 				groupPara = new WP.Paragraph();
 			}
 
-			// Add Before text, if it is not going to be displayed in a paragraph.
-			if (!eachInAParagraph && !string.IsNullOrEmpty(config.Before))
-			{
-				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
-				groupData.DocBody.PrependChild(beforeRun);
-			}
-
 			// Add the group data.
 			foreach (var child in config.ReferencedOrDirectChildren)
 			{
-				IFragment childContent = childContentGenerator(field, child, publicationDecorator, settings);
+				childContent = childContentGenerator(field, child, publicationDecorator, settings);
 				if (eachInAParagraph)
 				{
 					var elements = ((DocFragment)childContent).DocBody.Elements().ToList();
@@ -924,10 +917,19 @@ namespace SIL.FieldWorks.XWorks
 				}
 			}
 
+			string styleDisplayName = GetUniqueDisplayName(config, childContent);
+
+			// Add Before text, if it is not going to be displayed in a paragraph.
+			if (!eachInAParagraph && !string.IsNullOrEmpty(config.Before))
+			{
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before, styleDisplayName);
+				groupData.DocBody.PrependChild(beforeRun);
+			}
+
 			// Add After text, if it is not going to be displayed in a paragraph.
 			if (!eachInAParagraph && !string.IsNullOrEmpty(config.After))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				var afterRun = CreateBeforeAfterBetweenRun(config.After, styleDisplayName);
 				groupData.DocBody.Append(afterRun);
 			}
 
@@ -973,7 +975,8 @@ namespace SIL.FieldWorks.XWorks
 				!eachInAParagraph &&
 				!string.IsNullOrEmpty(config.Between))
 			{
-				var betweenRun = CreateBeforeAfterBetweenRun(config.Between);
+				string styleDisplayName = GetUniqueDisplayName(config, senseContent);
+				var betweenRun = CreateBeforeAfterBetweenRun(config.Between, styleDisplayName);
 				senseData.DocBody.Append(betweenRun);
 			}
 
@@ -1032,7 +1035,8 @@ namespace SIL.FieldWorks.XWorks
 				!eachInAParagraph &&
 				!string.IsNullOrEmpty(config.Between))
 			{
-				var betweenRun = CreateBeforeAfterBetweenRun(config.Between);
+				string styleDisplayName = GetUniqueDisplayName(config, content);
+				var betweenRun = CreateBeforeAfterBetweenRun(config.Between, styleDisplayName);
 				((DocFragment)collData).DocBody.Append(betweenRun);
 			}
 
@@ -1050,18 +1054,12 @@ namespace SIL.FieldWorks.XWorks
 		public IFragment AddProperty(ConfigurableDictionaryNode config, string className, bool isBlockProperty, string content)
 		{
 			var propFrag = new DocFragment();
-
-			// Add Before text.
-			if (!string.IsNullOrEmpty(config.Before))
-			{
-				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
-				propFrag.DocBody.Append(beforeRun);
-			}
+			Run contentRun = null;
+			string styleDisplayName = null;
 
 			// Add the content with the style.
 			if (!string.IsNullOrEmpty(content))
 			{
-				string styleDisplayName = null;
 				if (!string.IsNullOrEmpty(config.Style))
 				{
 					string displayNameBase = !string.IsNullOrEmpty(config.DisplayLabel) ? config.DisplayLabel : config.Style;
@@ -1072,14 +1070,26 @@ namespace SIL.FieldWorks.XWorks
 						styleDisplayName = style.StyleId;
 					}
 				}
-				var contentRun = CreateRun(content, styleDisplayName);
+				contentRun = CreateRun(content, styleDisplayName);
+			}
+
+			// Add Before text.
+			if (!string.IsNullOrEmpty(config.Before))
+			{
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before, styleDisplayName);
+				propFrag.DocBody.Append(beforeRun);
+			}
+
+			// Add the content.
+			if (contentRun != null)
+			{
 				propFrag.DocBody.Append(contentRun);
 			}
 
 			// Add After text.
 			if (!string.IsNullOrEmpty(config.After))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				var afterRun = CreateBeforeAfterBetweenRun(config.After, styleDisplayName);
 				propFrag.DocBody.Append(afterRun);
 			}
 
@@ -1472,10 +1482,11 @@ namespace SIL.FieldWorks.XWorks
 		}
 		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className, IFragment content)
 		{
+			string styleDisplayName = GetUniqueDisplayName(config, content);
 			// Add Before text.
 			if (!string.IsNullOrEmpty(config.Before))
 			{
-				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before, styleDisplayName);
 				((WordFragmentWriter)writer).WordFragment.DocBody.Append(beforeRun);
 			}
 
@@ -1487,7 +1498,7 @@ namespace SIL.FieldWorks.XWorks
 			// Add After text.
 			if (!string.IsNullOrEmpty(config.After))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				var afterRun = CreateBeforeAfterBetweenRun(config.After, styleDisplayName);
 				((WordFragmentWriter)writer).WordFragment.DocBody.Append(afterRun);
 			}
 		}
@@ -1596,7 +1607,7 @@ namespace SIL.FieldWorks.XWorks
 			// Add characters before the number.
 			if (!string.IsNullOrEmpty(beforeNumber))
 			{
-				var beforeRun = CreateBeforeAfterBetweenRun(beforeNumber);
+				var beforeRun = CreateBeforeAfterBetweenRun(beforeNumber, uniqueDisplayName);
 				senseNum.DocBody.AppendChild(beforeRun);
 			}
 
@@ -1610,7 +1621,7 @@ namespace SIL.FieldWorks.XWorks
 			// Add characters after the number.
 			if (!string.IsNullOrEmpty(afterNumber))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(afterNumber);
+				var afterRun = CreateBeforeAfterBetweenRun(afterNumber, uniqueDisplayName);
 				senseNum.DocBody.AppendChild(afterRun);
 			}
 
@@ -1648,7 +1659,8 @@ namespace SIL.FieldWorks.XWorks
 			// Add Between text if it is not the first item in the collection.
 			if (!firstItem && !string.IsNullOrEmpty(node.Between))
 			{
-				var betweenRun = CreateBeforeAfterBetweenRun(node.Between);
+				string styleDisplayName = GetUniqueDisplayName(node, content);
+				var betweenRun = CreateBeforeAfterBetweenRun(node.Between, styleDisplayName);
 				((DocFragment)content).DocBody.PrependChild(betweenRun);
 			}
 		}
@@ -1657,11 +1669,12 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var senseOptions = config?.DictionaryNodeOptions as DictionaryNodeSenseOptions;
 			bool eachInAParagraph = senseOptions?.DisplayEachSenseInAParagraph ?? false;
+			string styleDisplayName = GetUniqueDisplayName(config, sharedGramInfo);
 
 			// Add Before text for the senses if they were not displayed in separate paragraphs.
 			if (!eachInAParagraph && !string.IsNullOrEmpty(config.Before))
 			{
-				var beforeRun = CreateBeforeAfterBetweenRun(config.Before);
+				var beforeRun = CreateBeforeAfterBetweenRun(config.Before, styleDisplayName);
 				((DocFragment)sharedGramInfo).DocBody.PrependChild(beforeRun);
 			}
 
@@ -1671,7 +1684,7 @@ namespace SIL.FieldWorks.XWorks
 			// Add After text for the senses if they were not displayed in separate paragraphs.
 			if (!eachInAParagraph && !string.IsNullOrEmpty(config.After))
 			{
-				var afterRun = CreateBeforeAfterBetweenRun(config.After);
+				var afterRun = CreateBeforeAfterBetweenRun(config.After, styleDisplayName);
 				((DocFragment)sharedGramInfo).DocBody.Append(afterRun);
 			}
 
@@ -2109,17 +2122,49 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Creates a BeforeAfterBetween run using the text provided and using the BeforeAfterBetween style.
+		/// Creates a BeforeAfterBetween run using the text and style provided.
 		/// </summary>
 		/// <param name="text">Text for the run.</param>
+		/// <param name="styleDisplayName">The style name to base on, or the complete style name.</param>
 		/// <returns>The BeforeAfterBetween run.</returns>
-		internal static WP.Run CreateBeforeAfterBetweenRun(string text)
+		internal static WP.Run CreateBeforeAfterBetweenRun(string text, string styleDisplayName)
 		{
-			if(text.Contains("\\A"))
+			// Get the unique display name to use in the run.
+			string uniqueDisplayName = null;
+			// If there is no styleDisplayName then use the default BefAftBet display name.
+			if (string.IsNullOrEmpty(styleDisplayName))
+			{
+				uniqueDisplayName = WordStylesGenerator.BeforeAfterBetweenDisplayName;
+			}
+			// If the styleDisplayName is already a BefAftBet style, then don't create a new style.
+			else if (styleDisplayName.StartsWith(WordStylesGenerator.BeforeAfterBetweenDisplayName))
+			{
+				uniqueDisplayName = styleDisplayName;
+			}
+			// Create a new BefAftBet style similar to the default BefAftBet style but based on styleDisplayName.
+			else
+			{
+				// If the styleDisplayName is a language tag, then no need to add the separator.
+				string displayNameBaseCombined = WordStylesGenerator.BeforeAfterBetweenDisplayName;
+				displayNameBaseCombined += styleDisplayName.StartsWith(WordStylesGenerator.LangTagPre) ?
+					(styleDisplayName) : (WordStylesGenerator.StyleSeparator + styleDisplayName);
+
+				// Get the BeforeAfterBetween style.
+				StyleElement befAftElem = s_styleCollection.GetStyleElement(WordStylesGenerator.BeforeAfterBetweenDisplayName);
+
+				Style basedOnStyle = WordStylesGenerator.GenerateBasedOnCharacterStyle(befAftElem.Style, styleDisplayName, displayNameBaseCombined);
+				if (basedOnStyle != null)
+				{
+					uniqueDisplayName = s_styleCollection.AddCharacterStyle(basedOnStyle, WordStylesGenerator.BeforeAfterBetweenStyleName,
+						basedOnStyle.StyleId, befAftElem.WritingSystemId, befAftElem.WritingSystemIsRtl);
+				}
+			}
+
+			if (text.Contains("\\A"))
 			{
 				var run = new WP.Run()
 				{
-					RunProperties = GenerateRunProperties(WordStylesGenerator.BeforeAfterBetweenDisplayName)
+					RunProperties = GenerateRunProperties(uniqueDisplayName)
 				};
 				// If the before after between text has line break characters return a composite run including the line breaks
 				// Use Regex.Matches to capture both the content and the delimiters
@@ -2134,7 +2179,7 @@ namespace SIL.FieldWorks.XWorks
 				return run;
 			}
 
-			return CreateRun(text, WordStylesGenerator.BeforeAfterBetweenDisplayName);
+			return CreateRun(text, uniqueDisplayName);
 		}
 
 		/// <summary>
@@ -2176,7 +2221,7 @@ namespace SIL.FieldWorks.XWorks
 					{
 						// If the currentRun has one of the default global character styles then return. We do not
 						// want to create a new style based on these.
-						if (currentRunStyle == WordStylesGenerator.BeforeAfterBetweenDisplayName ||
+						if (currentRunStyle.StartsWith(WordStylesGenerator.BeforeAfterBetweenDisplayName) ||
 							currentRunStyle == WordStylesGenerator.SenseNumberDisplayName ||
 							currentRunStyle == WordStylesGenerator.WritingSystemDisplayName)
 						{
@@ -2184,7 +2229,7 @@ namespace SIL.FieldWorks.XWorks
 						}
 
 						// If the current style is a language tag, then no need to add the separator.
-						string displayNameBaseCombined = currentRunStyle.StartsWith("[") ?
+						string displayNameBaseCombined = currentRunStyle.StartsWith(WordStylesGenerator.LangTagPre) ?
 							(displayNameBase + currentRunStyle) : (displayNameBase + WordStylesGenerator.StyleSeparator + currentRunStyle);
 
 						// The calls to TryGetStyle() and AddStyle() need to be in the same lock.
@@ -2198,7 +2243,7 @@ namespace SIL.FieldWorks.XWorks
 							{
 								// Don't create a new style if the current style already has the same root.
 								int separatorIndex = currentRunStyle.IndexOf(WordStylesGenerator.StyleSeparator);
-								separatorIndex = separatorIndex != -1 ? separatorIndex : currentRunStyle.IndexOf("[");
+								separatorIndex = separatorIndex != -1 ? separatorIndex : currentRunStyle.IndexOf(WordStylesGenerator.LangTagPre);
 								bool hasSameRoot = separatorIndex == -1 ? currentRunStyle.Equals(displayNameBase) :
 									currentRunStyle.Substring(0, separatorIndex).Equals(displayNameBase);
 								if (hasSameRoot)
@@ -2662,6 +2707,11 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="uniqueDisplayName">The style name.</param>
 		public static RunProperties GenerateRunProperties(string uniqueDisplayName)
 		{
+			if (string.IsNullOrEmpty(uniqueDisplayName))
+			{
+				return new RunProperties();
+			}
+
 			var runProp = new RunProperties(new RunStyle() { Val = uniqueDisplayName });
 			if (IsBidi)
 			{
@@ -2676,12 +2726,74 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// Iterate through the runs in the fragment looking for the style that
+		/// most closely matches the node.DisplayLabel.
+		/// </summary>
+		private string GetUniqueDisplayName(ConfigurableDictionaryNode node, IFragment content)
+		{
+			Debug.Assert(!string.IsNullOrEmpty(node.DisplayLabel), "Not expecting a node without a DisplayLabel.");
+			string endRunStyle = null;
+			string beginRunStyle = null;
+			var runs = ((DocFragment)content)?.DocBody.OfType<WP.Run>();
+			if (runs != null)
+			{
+				foreach (var run in runs)
+				{
+					string runStyle = run.RunProperties?.RunStyle?.Val;
+					if (runStyle != null)
+					{
+						// Remove the language tag and any appended numbers.
+						string runName = runStyle;
+						int langTagIndex = runName.IndexOf(WordStylesGenerator.LangTagPre);
+						if (langTagIndex != -1)
+						{
+							runName = runName.Substring(0, langTagIndex);
+						}
+						runName = runName.TrimEnd('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
+
+						// This is the common case: DisplayLabel followed by a possible integer and a language tag.
+						// Definition (or Gloss)[lang='en'] or
+						// Definition (or Gloss)2[lang='en']
+						// If we find this, then there is no need to look further.  This is the style we want.
+						if (runName == node.DisplayLabel)
+						{
+								return runStyle;
+						}
+
+						// The second preference is a style that ends with the DisplayLabel.
+						// Strong : Example Sentence[lang='es'] or
+						// Strong : Example Sentence3[lang='es']
+						if (endRunStyle == null && runName.EndsWith(node.DisplayLabel))
+						{
+							// In this case don't use the complete runStyle.  We want the base style, not
+							// a possible override applied to a specific run.
+							// Return just "Example Sentence[lang='es']" or "Example Sentence3[lang='es']"
+							endRunStyle = runStyle.Substring(runStyle.IndexOf(node.DisplayLabel));
+						}
+
+						// The third preference is a style that begins with the DisplayLabel.
+						// Grammatical Info.2 : Category Info.[lang='en']
+						if (beginRunStyle == null && endRunStyle == null && runStyle.StartsWith(node.DisplayLabel))
+						{
+							// In this case return the complete RunStyle.
+							// Return "Grammatical Info.2 : Category Info.[lang='en']"
+							beginRunStyle = runStyle;
+						}
+					}
+				}
+			}
+			// Default to returning the DisplayLabel if we don't have anything else.
+			// This is a common case for nodes that are collections.
+			return endRunStyle ?? beginRunStyle ?? node.DisplayLabel;
+		}
+
+		/// <summary>
 		/// Gets the unique display name out of a run.
 		/// </summary>
 		/// <returns>The name, or null if the run does not contain the information.</returns>
 		public string GetUniqueDisplayName(Run run)
 		{
-			return run.RunProperties?.RunStyle?.Val;
+			return run?.RunProperties?.RunStyle?.Val;
 		}
 
 		/// <summary>

--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -208,7 +208,7 @@ namespace SIL.FieldWorks.XWorks
 				if (styleCount > 0)
 				{
 					int separatorIndex = uniqueDisplayName.IndexOf(WordStylesGenerator.StyleSeparator);
-					separatorIndex = separatorIndex != -1 ? separatorIndex : uniqueDisplayName.IndexOf("[");
+					separatorIndex = separatorIndex != -1 ? separatorIndex : uniqueDisplayName.IndexOf(WordStylesGenerator.LangTagPre);
 					// Append the number before the basedOn information.
 					// Note: We do not want to append the number to the end of the uniqueDisplayName if
 					// there is basedOn information because that could result in the name not being

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -33,6 +33,8 @@ namespace SIL.FieldWorks.XWorks
 		internal const string WritingSystemStyleName = "Writing System Abbreviation";
 		internal const string WritingSystemDisplayName = "Writing System Abbreviation";
 		internal const string StyleSeparator = " : ";
+		internal const string LangTagPre = "[lang=\'";
+		internal const string LangTagPost = "\']";
 
 		// Globals and default paragraph styles.
 		internal const string NormalParagraphStyleName = "Normal";
@@ -73,7 +75,7 @@ namespace SIL.FieldWorks.XWorks
 			bulletInfo = null;
 
 			// The user can change the style name that is associated with the Main Entry, so look up the node style name using the DisplayLabel.
-			mainEntryNode = model.Parts.Find(node => node.DisplayLabel == MainEntryParagraphDisplayName);
+			mainEntryNode = model?.Parts.Find(node => node.DisplayLabel == MainEntryParagraphDisplayName);
 			if (mainEntryNode != null)
 			{
 				style = GenerateParagraphStyleFromLcmStyleSheet(mainEntryNode.Style, DefaultStyle, propertyTable, out bulletInfo);
@@ -785,7 +787,7 @@ namespace SIL.FieldWorks.XWorks
 
 		public static string GetWsString(string wsId)
 		{
-			return String.Format("[lang=\'{0}\']", wsId);
+			return LangTagPre + wsId + LangTagPost;
 		}
 
 		/// <summary>

--- a/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
@@ -86,6 +86,8 @@ namespace SIL.FieldWorks.XWorks
 				styles.Add(new BaseStyleInfo { Name = DictionaryNormal });
 			if (!styles.Contains("Dictionary-Headword"))
 				styles.Add(new BaseStyleInfo { Name = "Dictionary-Headword", IsParagraphStyle = false});
+			if (!styles.Contains(WordStylesGenerator.BeforeAfterBetweenStyleName))
+				styles.Add(new BaseStyleInfo { Name = WordStylesGenerator.BeforeAfterBetweenStyleName, IsParagraphStyle = false });
 			if (!styles.Contains("Abbreviation"))
 				styles.Add(new BaseStyleInfo { Name = "Abbreviation", IsParagraphStyle = false });
 			if (!styles.Contains("Dictionary-SenseNumber"))
@@ -96,8 +98,12 @@ namespace SIL.FieldWorks.XWorks
 				styles.Add(new BaseStyleInfo { Name = DictionaryGlossStyleName, IsParagraphStyle = false });
 
 			// Add paragraph styles
+			if (!styles.Contains(WordStylesGenerator.NormalParagraphStyleName))
+				styles.Add(new BaseStyleInfo { Name = WordStylesGenerator.NormalParagraphStyleName, IsParagraphStyle = true });
 			if (!styles.Contains(MainEntryParagraphStyleName))
 				styles.Add(new BaseStyleInfo { Name = MainEntryParagraphStyleName, IsParagraphStyle = true });
+			if (!styles.Contains(WordStylesGenerator.LetterHeadingStyleName))
+				styles.Add(new BaseStyleInfo { Name = WordStylesGenerator.LetterHeadingStyleName, IsParagraphStyle = true });
 			if (!styles.Contains(SensesParagraphStyleName))
 				styles.Add(new BaseStyleInfo { Name = SensesParagraphStyleName, IsParagraphStyle = true });
 			if (!styles.Contains(SubSensesParagraphStyleName))
@@ -122,6 +128,7 @@ namespace SIL.FieldWorks.XWorks
 				var bulletStyle = new TestStyle(inherbullet, Cache) { Name = NumberParagraphStyleName, IsParagraphStyle = true };
 				styles.Add(bulletStyle);
 			}
+			DefaultSettings.StylesGenerator.AddGlobalStyles(null, new ReadOnlyPropertyTable(m_propertyTable));
 
 			m_Clerk = CreateClerk();
 			m_propertyTable.SetProperty("ActiveClerk", m_Clerk, false);
@@ -271,6 +278,8 @@ namespace SIL.FieldWorks.XWorks
 			// because other tests may set the gloss Style to some other value; resulting in this
 			// test getting unique style names like "Gloss3[lang='en']".
 			LcmWordGenerator.ClearStyleCollection();
+			// Always re-add the global styles after clearing the collection.
+			DefaultSettings.StylesGenerator.AddGlobalStyles(null, new ReadOnlyPropertyTable(m_propertyTable));
 
 			var wsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "en" });
 			var glossNode = new ConfigurableDictionaryNode
@@ -357,7 +366,7 @@ namespace SIL.FieldWorks.XWorks
 			// 2. Sense number before text:		BEF
 			// 3. Sense number:					2
 			// 4. Sense number after text:		AFT
-			const string senseNumberTwoRun = "<w:t xml:space=\"preserve\">BEF</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Sense Number[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">AFT</w:t></w:r>";
+			const string senseNumberTwoRun = "<w:t xml:space=\"preserve\">BEF</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Sense Number[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context : Sense Number[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">AFT</w:t></w:r>";
 			Assert.True(result.mainDocPart.RootElement.OuterXml.Contains(senseNumberTwoRun));
 		}
 
@@ -435,12 +444,12 @@ namespace SIL.FieldWorks.XWorks
 
 			// After text 'AF2' is after 'second gloss2.2'.
 			const string afterSubSenses =
-				"<w:t xml:space=\"preserve\">second gloss2.2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">AF2</w:t>";
+				"<w:t xml:space=\"preserve\">second gloss2.2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context : SensesOS\" /></w:rPr><w:t xml:space=\"preserve\">AF2</w:t>";
 			Assert.True(outXml.Contains(afterSubSenses));
 
 			// After text 'AF1' is after 'AF2'.
 			const string afterSenses =
-				"<w:t xml:space=\"preserve\">AF2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">AF1</w:t>";
+				"<w:t xml:space=\"preserve\">AF2</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context : SensesOS\" /></w:rPr><w:t xml:space=\"preserve\">AF1</w:t>";
 			Assert.True(outXml.Contains(afterSenses));
 		}
 
@@ -497,7 +506,7 @@ namespace SIL.FieldWorks.XWorks
 
 			// Before text 'BE3' is after the sense number '1' and before the english abbreviation, which is before 'gloss'.
 			const string beforeAbbreviation =
-				"<w:t xml:space=\"preserve\">1</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">BE3</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Writing System Abbreviation\" /></w:rPr><w:t xml:space=\"preserve\">Eng </w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Gloss[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">gloss</w:t>";
+				"<w:t xml:space=\"preserve\">1</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context : Gloss[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">BE3</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Writing System Abbreviation\" /></w:rPr><w:t xml:space=\"preserve\">Eng </w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Gloss[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">gloss</w:t>";
 			Assert.True(outXml.Contains(beforeAbbreviation));
 
 			// Between text 'TW3' is before the spanish abbreviation, which is before 'glossES'.
@@ -507,7 +516,7 @@ namespace SIL.FieldWorks.XWorks
 
 			// After text 'AF3' is after 'glossES'.
 			const string afterAbbreviation =
-				"<w:t xml:space=\"preserve\">glossES</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context\" /></w:rPr><w:t xml:space=\"preserve\">AF3</w:t>";
+				"<w:t xml:space=\"preserve\">glossES</w:t></w:r><w:r><w:rPr><w:rStyle w:val=\"Context : Gloss[lang='en']\" /></w:rPr><w:t xml:space=\"preserve\">AF3</w:t>";
 			Assert.True(outXml.Contains(afterAbbreviation));
 		}
 


### PR DESCRIPTION
Instead of all BefAftBet content using the same style we now use a style that we get from the content and node.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/204)
<!-- Reviewable:end -->
