### PR TITLE
Fixes LT-21934: FLEx freezes when clicking "Close" if parser is running

### DIFF
--- a/Src/LexText/ParserCore/ParseFiler.cs
+++ b/Src/LexText/ParserCore/ParseFiler.cs
@@ -161,9 +161,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					if (work.CheckParser)
 					{
 						// This was just a test.  Don't update data.
-						string testform = work.Wordform.Form.BestVernacularAlternative.Text;
-						using (new TaskReport(String.Format(ParserCoreStrings.ksTestX, testform), m_taskUpdateHandler))
-						{ }
 						FireWordformUpdated(work.Wordform, work.Priority, work.ParseResult, work.CheckParser);
 						continue;
 					}

--- a/Src/LexText/ParserCore/ParserCoreStrings.Designer.cs
+++ b/Src/LexText/ParserCore/ParserCoreStrings.Designer.cs
@@ -142,6 +142,15 @@ namespace SIL.FieldWorks.WordWorks.Parser {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parsing {0}.
+        /// </summary>
+        internal static string ksParsingX {
+            get {
+                return ResourceManager.GetString("ksParsingX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ???.
         /// </summary>
         internal static string ksQuestions {
@@ -174,15 +183,6 @@ namespace SIL.FieldWorks.WordWorks.Parser {
         internal static string ksStarted {
             get {
                 return ResourceManager.GetString("ksStarted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Tested {0}.
-        /// </summary>
-        internal static string ksTestX {
-            get {
-                return ResourceManager.GetString("ksTestX", resourceCulture);
             }
         }
         

--- a/Src/LexText/ParserCore/ParserCoreStrings.resx
+++ b/Src/LexText/ParserCore/ParserCoreStrings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -186,8 +186,8 @@
   <data name="ksUnknownNaturalClass" xml:space="preserve">
     <value>Unknown Natural Class!</value>
   </data>
-  <data name="ksTestX" xml:space="preserve">
-    <value>Tested {0}</value>
+  <data name="ksParsingX" xml:space="preserve">
+    <value>Parsing {0}</value>
   </data>
   <data name="ksMaxElementsInRule" xml:space="preserve">
     <value>A rule can't have more than one element in its left-hand side or its right-hand side.</value>

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -141,8 +141,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			CheckNeedsUpdate();
 			var normalizer = CustomIcu.GetIcuNormalizer(FwNormalizationMode.knmNFD);
 			var word = normalizer.Normalize(form.Text.Replace(' ', '.'));
+			ParseResult result = null;
 			var stopWatch = System.Diagnostics.Stopwatch.StartNew();
-			ParseResult result = m_parser.ParseWord(word);
+			using (var task = new TaskReport(String.Format(ParserCoreStrings.ksParsingX, word), m_taskUpdateHandler))
+			{
+				result = m_parser.ParseWord(word);
+			}
 			stopWatch.Stop();
 			result.ParseTime = stopWatch.ElapsedMilliseconds;
 
@@ -160,8 +164,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				if (m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(text, out lcWordform))
 				{
 					var lcWord = normalizer.Normalize(sLower.Replace(' ', '.'));
+					ParseResult lcResult = null;
 					stopWatch.Start();
-					var lcResult = m_parser.ParseWord(lcWord);
+					using (var task = new TaskReport(String.Format(ParserCoreStrings.ksParsingX, word), m_taskUpdateHandler))
+					{
+						lcResult = m_parser.ParseWord(lcWord);
+					}
 					stopWatch.Stop();
 					lcResult.ParseTime = stopWatch.ElapsedMilliseconds;
 					if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)

--- a/Src/XCore/xWindow.cs
+++ b/Src/XCore/xWindow.cs
@@ -1929,6 +1929,8 @@ namespace XCore
 		{
 			CheckDisposed();
 
+			if (Mediator != null)
+				Mediator.SendMessage("StopParser", null);
 			this.Close();
 
 			return true;


### PR DESCRIPTION
This also improves the user notifications produced when running Run Tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/205)
<!-- Reviewable:end -->
