### PR TITLE
LT-21982: Make default between/after empty for picture nodes

### DIFF
--- a/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Hybrid.fwdictconfig
+++ b/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Hybrid.fwdictconfig
@@ -1109,7 +1109,7 @@
 			</ComplexFormOptions>
 			<ReferenceItem>MainEntrySubentries</ReferenceItem>
 		</ConfigurationItem>
-		<ConfigurationItem name="Pictures" isEnabled="true" style="Dictionary-Pictures" before="" between="  " after="" field="PicturesOfSenses">
+		<ConfigurationItem name="Pictures" isEnabled="true" style="Dictionary-Pictures" before="" between="" after="" field="PicturesOfSenses">
 			<PictureOptions minimumHeight="0" maximumHeight="1" minimumWidth="0" maximumWidth="0" pictureLocation="right" stackPictures="false" />
 			<ConfigurationItem name="Thumbnail" isEnabled="true" before=" " between=" " after="" field="PictureFileRA" cssClassNameOverride="thumbnail" />
 			<ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -2113,7 +2113,7 @@
 		</ConfigurationItem>
 		<ConfigurationItem name="Date Created" isEnabled="false" before="  Created on: " after="" field="DateCreated" />
 		<ConfigurationItem name="Date Modified" isEnabled="false" before=" Modified on: " after="" field="DateModified" />
-		<ConfigurationItem name="Pictures" between="  " after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+		<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 			<PictureOptions minimumHeight="0" maximumHeight="1" maximumWidth="0" minimumWidth="0" pictureLocation="right" stackPictures="false" />
 			<ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 			<ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -3628,7 +3628,7 @@
 			</ConfigurationItem>
 			<ConfigurationItem name="Date Created" before="  Created on: " after="" isEnabled="false" field="DateCreated"/>
 			<ConfigurationItem name="Date Modified" before=" Modified on: " after="" isEnabled="false" field="DateModified"/>
-			<ConfigurationItem name="Pictures" between="  " after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+			<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 				<PictureOptions minimumHeight="0" maximumHeight="1" minimumWidth="0" maximumWidth="0" pictureLocation="right" stackPictures="false" />
 				<ConfigurationItem name="Thumbnail" after=" " isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 				<ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">

--- a/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Lexeme.fwdictconfig
+++ b/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Lexeme.fwdictconfig
@@ -998,7 +998,7 @@
 		</WritingSystemOptions>
 	  </ConfigurationItem>
 	</ConfigurationItem>
-	<ConfigurationItem name="Pictures" before=" " between="  " after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	<ConfigurationItem name="Pictures" before="" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 	  <PictureOptions minimumHeight="0" maximumHeight="1" minimumWidth="0" maximumWidth="0" pictureLocation="right" stackPictures="false" />
 	  <ConfigurationItem name="Thumbnail" before=" " isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 	  <ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -1949,7 +1949,7 @@
 		</WritingSystemOptions>
 	  </ConfigurationItem>
 	</ConfigurationItem>
-	<ConfigurationItem name="Pictures" between="  " after=" " style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 	  <PictureOptions minimumHeight="0" maximumHeight="1" maximumWidth="0" minimumWidth="0" pictureLocation="right" stackPictures="false" />
 	  <ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 	  <ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">

--- a/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Root.fwdictconfig
+++ b/DistFiles/Language Explorer/DefaultConfigurations/Dictionary/Root.fwdictconfig
@@ -865,7 +865,7 @@
 		</ConfigurationItem>
 	  </ConfigurationItem>
 	</ConfigurationItem>
-	<ConfigurationItem name="Pictures" between="  " after=" " style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 	  <PictureOptions minimumHeight="0" maximumHeight="1" maximumWidth="0" minimumWidth="0" pictureLocation="right" stackPictures="false" />
 	  <ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 	  <ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -1919,7 +1919,7 @@
 		</WritingSystemOptions>
 	  </ConfigurationItem>
 	</ConfigurationItem>
-	<ConfigurationItem name="Pictures" between="  " after=" " style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 	  <PictureOptions minimumHeight="0" maximumHeight="1" maximumWidth="0" minimumWidth="0" pictureLocation="right" stackPictures="false" />
 	  <ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 	  <ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -2956,7 +2956,7 @@
 		</WritingSystemOptions>
 	  </ConfigurationItem>
 	</ConfigurationItem>
-	<ConfigurationItem name="Pictures" between="  " after=" " style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	<ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 	  <PictureOptions minimumHeight="0" maximumHeight="1" maximumWidth="0" minimumWidth="0" pictureLocation="right" stackPictures="false" />
 	  <ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 	  <ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">
@@ -4405,7 +4405,7 @@
 		  </ConfigurationItem>
 		</ConfigurationItem>
 	  </ConfigurationItem>
-	  <ConfigurationItem name="Pictures" between="  " after=" " style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
+	  <ConfigurationItem name="Pictures" between="" after="" style="Dictionary-Pictures" isEnabled="true" field="PicturesOfSenses" cssClassNameOverride="pictures">
 		<PictureOptions minimumHeight="0" maximumHeight="1" minimumWidth="0" maximumWidth="0" pictureLocation="right" stackPictures="false" />
 		<ConfigurationItem name="Thumbnail" after="" isEnabled="true" field="PictureFileRA" cssClassNameOverride="thumbnail"/>
 		<ConfigurationItem name="Caption (or Headword)" between=" " isEnabled="false" field="CaptionOrHeadword">


### PR DESCRIPTION
Change-Id: I86a23c955d0198e007a3ed0479d54a051c97db22

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/206)
<!-- Reviewable:end -->
