### PR TITLE
Lt 21934b: FLEx freezes when closing Try a Word if it is parsing

### DIFF
--- a/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
+++ b/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
@@ -556,6 +556,15 @@ namespace SIL.FieldWorks.LexText.Controls {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Stopping the Parser (may take up to a minute).
+        /// </summary>
+        public static string ksStoppingParser {
+            get {
+                return ResourceManager.GetString("ksStoppingParser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Text.
         /// </summary>
         public static string ksText {

--- a/Src/LexText/ParserUI/ParserUIStrings.resx
+++ b/Src/LexText/ParserUI/ParserUIStrings.resx
@@ -344,4 +344,7 @@
   <data name="ksEnterComment" xml:space="preserve">
     <value>Please enter a comment for the parser report</value>
   </data>
+  <data name="ksStoppingParser" xml:space="preserve">
+    <value>Stopping the Parser (may take up to a minute)</value>
+  </data>
 </root>

--- a/Src/LexText/ParserUI/TryAWordDlg.cs
+++ b/Src/LexText/ParserUI/TryAWordDlg.cs
@@ -369,6 +369,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_persistProvider.PersistWindowSettings(PersistProviderID, this);
 			if (m_parserListener.Connection != null)
 			{
+				this.Text = ParserUIStrings.ksStoppingParser;
 				m_parserListener.Connection.TryAWordDialogIsRunning = false;
 				m_parserListener.DisconnectFromParser();
 			}

--- a/Src/XCore/xWindow.cs
+++ b/Src/XCore/xWindow.cs
@@ -1929,8 +1929,6 @@ namespace XCore
 		{
 			CheckDisposed();
 
-			if (Mediator != null)
-				Mediator.SendMessage("StopParser", null);
 			this.Close();
 
 			return true;


### PR DESCRIPTION
FLEx freezes because it is waiting for the parser to finish parsing.  It aborts after one minute, but the user doesn't know that.  I added code to change the Try a Word window to say "Stopping parser (this may take up to a minute)".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/208)
<!-- Reviewable:end -->
