### PR TITLE
Fix LT-21966: Inflection features not showing correctly in browse

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/LexSenseParts.xml
+++ b/DistFiles/Language Explorer/Configuration/Parts/LexSenseParts.xml
@@ -214,12 +214,12 @@
 			<obj class="LexSense" field="MorphoSyntaxAnalysis" layout="empty">
 				<if is="MoStemMsa">
 					<obj class="MoStemMsa" field="MsFeatures" layout="empty">
-						<string field="ChooserNameTS"/>
+						<string field="LongNameTSS"/>
 					</obj>
 				</if>
 				<if is="MoInflAffMsa">
 					<obj class="MoInflAffMsa" field="InflFeats" layout="empty">
-						<string field="ChooserNameTS"/>
+						<string field="LongNameTSS"/>
 					</obj>
 				</if>
 				<ifnot is="MoStemMsa">


### PR DESCRIPTION
ChooserNameTS works incorrectly for feature structures, so I switched to LongNameTSS.  ChooserNameTS should be fixed in liblcm at some point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/213)
<!-- Reviewable:end -->
