### PR TITLE
LT-21882: Webonary: Fix style names

### DIFF
--- a/Src/xWorks/CssGenerator.cs
+++ b/Src/xWorks/CssGenerator.cs
@@ -99,8 +99,7 @@ namespace SIL.FieldWorks.XWorks
 					return className;
 				}
 				// Otherwise get a unique but useful class name and re-generate the style with the new name
-				className = GetBestUniqueNameForNode(_styleDictionary, node);
-				_styleDictionary[className] = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
+				className = GetBestUniqueNameForNode(node);
 				return className;
 			}
 		}
@@ -116,8 +115,7 @@ namespace SIL.FieldWorks.XWorks
 		/// have the same class name, but different style content. We want this name to be usefully recognizable.
 		/// </summary>
 		/// <returns></returns>
-		public static string GetBestUniqueNameForNode(Dictionary<string, List<StyleRule>> styles,
-			ConfigurableDictionaryNode node)
+		public string GetBestUniqueNameForNode(ConfigurableDictionaryNode node)
 		{
 			Guard.AgainstNull(node.Parent, "There should not be duplicate class names at the top of tree.");
 			// First try appending the parent node classname. Pathway has code that cares about what
@@ -126,10 +124,16 @@ namespace SIL.FieldWorks.XWorks
 
 			string classNameBase = className;
 			int counter = 0;
-			while (styles.ContainsKey(className))
+			while (_styleDictionary.ContainsKey(className))
 			{
+				var styleContent = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
+				if (AreStyleRulesListsEquivalent(_styleDictionary[className], styleContent))
+				{
+					return className;
+				}
 				className = $"{classNameBase}-{++counter}";
 			}
+			_styleDictionary[className] = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
 			return className;
 		}
 

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -579,8 +579,14 @@ namespace SIL.FieldWorks.XWorks
 				var readOnlyPropertyTable = new ReadOnlyPropertyTable(propertyTable);
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(cache, readOnlyPropertyTable, true, true, Path.GetDirectoryName(jsonPath),
 					ConfiguredLcmGenerator.IsEntryStyleRtl(readOnlyPropertyTable, configuration), Path.GetFileName(cssPath) == "configured.css") { ContentGenerator = new LcmJsonGenerator(cache)};
+				settings.StylesGenerator.AddGlobalStyles(configuration, readOnlyPropertyTable);
 				var displayXhtmlSettings = new ConfiguredLcmGenerator.GeneratorSettings(cache, readOnlyPropertyTable, true, true, Path.GetDirectoryName(jsonPath),
 						ConfiguredLcmGenerator.IsEntryStyleRtl(readOnlyPropertyTable, configuration), Path.GetFileName(cssPath) == "configured.css");
+				// Use the same StyleGenerator for both GeneratorSettings to prevent having two that
+				// could contain different data for unique names. The unique names can be generated
+				// in different orders.
+				displayXhtmlSettings.StylesGenerator = settings.StylesGenerator;
+
 				var entryContents = new Tuple<ICmObject, StringBuilder, StringBuilder>[entryCount];
 				var entryActions = new List<Action>();
 				// For every entry in the page generate an action that will produce the xhtml document fragment for that entry
@@ -642,7 +648,7 @@ namespace SIL.FieldWorks.XWorks
 				if (progress != null)
 					progress.Message = xWorksStrings.ksGeneratingStyleInfo;
 
-				cssWriter.Write(CssGenerator.GenerateCssFromConfiguration(configuration, readOnlyPropertyTable));
+				cssWriter.Write(((CssGenerator)settings.StylesGenerator).GetStylesString());
 				cssWriter.Flush();
 
 				entryIds = entryIdsList.ToArray();


### PR DESCRIPTION
References to styles in the xhtml were not matching up with the correct style names in the css.

- In the Json generator we were not using the _styleDictionary to generate the css.  Instead we were re-generating the css from the configuration. Now use the _styleDictionary to generate the css.
- In the Json generator there were two _styleDictionaries being used. They were filled at different times and could have different values because of unique name generation. Now use one _styleDictionary.
- In many situations we were still generating styles with unique names when an existing style was identical.  Changed the code to re-use existing styles that had unique names. (This change was not necessary to fix the problems described in this defect but resulted in a substantial size reduction in the css file size. The Jii-entries project that is attached to the defect, and the Sena 3 project both result in a css file that is less than 10% of the old size.)

Change-Id: I457674ca44b37ed966cb1d8995011a0a19df4cca