### PR TITLE
Fix LT-21999: Improve saving of parser test reports

### DIFF
--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -619,8 +619,8 @@ namespace SIL.FieldWorks.LexText.Controls
 					ReadParserReports();
 					// Write an empty parser report.
 					var parserReport = CreateParserReport();
-					AddParserReport(parserReport);
-					ShowParserReport(parserReport, m_mediator, m_cache);
+					ParserReportViewModel viewModel = AddParserReport(parserReport);
+					ShowParserReport(viewModel, m_mediator, m_cache);
 				}
 			}
 			m_parserConnection.UpdateWordforms(wordforms, priority, checkParser);
@@ -670,8 +670,8 @@ namespace SIL.FieldWorks.LexText.Controls
 				ReadParserReports();
 				// Convert parse results into ParserReport.
 				var parserReport = CreateParserReport();
-				AddParserReport(parserReport);
-				ShowParserReport(parserReport, m_mediator, m_cache);
+				ParserReportViewModel viewModel = AddParserReport(parserReport);
+				ShowParserReport(viewModel, m_mediator, m_cache);
 			}
 		}
 
@@ -701,15 +701,18 @@ namespace SIL.FieldWorks.LexText.Controls
 			return parserReport;
 		}
 
-		public static void SaveParserReport(ParserReport report, LcmCache cache, string defaultComment)
+		public static void SaveParserReport(ParserReportViewModel reportViewModel, LcmCache cache, string defaultComment)
 		{
 			Form inputBox = CreateInputBox(ParserUIStrings.ksEnterComment, ref defaultComment);
 			DialogResult result = inputBox.ShowDialog();
 			if (result == DialogResult.OK)
 			{
+				ParserReport report = reportViewModel.ParserReport;
 				Control textBox = inputBox.Controls["input"];
 				report.Comment = textBox.Text;
+				report.DeleteJsonFile();
 				report.WriteJsonFile(cache);
+				reportViewModel.UpdateDisplayComment();
 			}
 		}
 
@@ -850,12 +853,14 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// <summary>
 		/// Add parserReport to the list of parser reports.
 		/// </summary>
-		private void AddParserReport(ParserReport parserReport)
+		private ParserReportViewModel AddParserReport(ParserReport parserReport)
 		{
-			m_parserReports.Insert(0, new ParserReportViewModel { ParserReport = parserReport });
+			ParserReportViewModel viewModel = new ParserReportViewModel { ParserReport = parserReport };
+			m_parserReports.Insert(0, viewModel);
 			if (m_parserReportsDialog != null)
 				// Reset ParserReports so that the window gets notified when the new report is selected.
 				((ParserReportsViewModel)m_parserReportsDialog.DataContext).ParserReports = m_parserReports;
+			return viewModel;
 		}
 
 		/// <summary>
@@ -863,7 +868,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// </summary>
 		/// <param name="parserReport"></param>
 		/// <param name="mediator">the mediator is used to call TryAWord</param>
-		public static void ShowParserReport(ParserReport parserReport, Mediator mediator, LcmCache cache)
+		public static void ShowParserReport(ParserReportViewModel parserReport, Mediator mediator, LcmCache cache)
 		{
 			ParserReportDialog dialog = new ParserReportDialog(parserReport, mediator, cache);
 			dialog.Show();

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -15,8 +15,8 @@
 	</Window.Resources>
 	<Grid>
 		<Grid.RowDefinitions>
-			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Height="40">
 			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -14,7 +14,17 @@
 		<local:PositiveIntToRedBrushConverter x:Key="PositiveIntToRedBrushConverter" />
 	</Window.Resources>
 	<Grid>
-		<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParseReports}">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Height="40">
+			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"
+                    ToolTip="{x:Static local:ParserUIStrings.ksSaveReportToolTip}"
+                    Click="SaveParserReport" Width="100" Margin="5"/>
+			<Label x:Name="commentLabel" Content="{Binding DisplayComment, Mode=OneWay}" Height="27"/>
+		</StackPanel>
+		<DataGrid Grid.Row="1" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParseReports}">
 			<DataGrid.Columns>
 				<DataGridTemplateColumn>
 					<DataGridTemplateColumn.CellTemplate>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -15,178 +15,182 @@
 	</Window.Resources>
 	<Grid>
 		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
-		<StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Height="40">
-			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"
-                    ToolTip="{x:Static local:ParserUIStrings.ksSaveReportToolTip}"
-                    Click="SaveParserReport" Width="100" Margin="5"/>
-			<Label x:Name="commentLabel" Content="{Binding DisplayComment, Mode=OneWay}" Height="27"/>
-		</StackPanel>
-		<DataGrid Grid.Row="1" AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding ParseReports}">
-			<DataGrid.Columns>
-				<DataGridTemplateColumn>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<Button Content="{x:Static local:ParserUIStrings.ksShowAnalyses}"
+		<ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+			<DataGrid Name="DataGrid" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" SelectionChanged="DataGrid_SelectionChanged"
+					  MouseDoubleClick="DataGrid_MouseDoubleClick" ItemsSource="{Binding ParseReports}">
+				<DataGrid.Columns>
+					<DataGridTemplateColumn>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<Button Content="{x:Static local:ParserUIStrings.ksShowAnalyses}"
 									ToolTip="{x:Static local:ParserUIStrings.ksShowAnalysesToolTip}"
 							Click="ShowWordAnalyses"
 							CommandParameter="{Binding}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTemplateColumn>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<Button Content="{x:Static local:ParserUIStrings.ksReparse}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTemplateColumn>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<Button Content="{x:Static local:ParserUIStrings.ksReparse}"
 									ToolTip="{x:Static local:ParserUIStrings.ksReparseToolTip}"
 							Click="ReparseWord"
 							CommandParameter="{Binding}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTextColumn Binding="{Binding Word}">
-					<DataGridTextColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksWord}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTextColumn Binding="{Binding Word}">
+						<DataGridTextColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksWord}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksWordToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumWordsParsedToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumWordsParsedToolTip}"
 								   Text="{Binding DataContext.ParserReport.NumWords, RelativeSource={RelativeSource AncestorType=DataGrid}}"></TextBlock>
-						</StackPanel>
-					</DataGridTextColumn.Header>
-				</DataGridTextColumn>
-				<DataGridTemplateColumn SortMemberPath="NoParse" CanUserSort="True">
-					<DataGridTemplateColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksNumZeroParses}"
+							</StackPanel>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
+					<DataGridTemplateColumn SortMemberPath="NoParse" CanUserSort="True">
+						<DataGridTemplateColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumZeroParses}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksNumZeroParsesToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumZeroParsesToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumZeroParsesToolTip}"
 									   Text="{Binding DataContext.ParserReport.NumZeroParses, RelativeSource={RelativeSource AncestorType=DataGrid}}"
 									   Foreground="{Binding DataContext.ParserReport.NumZeroParses,
 												RelativeSource={RelativeSource AncestorType=DataGrid},
 												Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</StackPanel>
-					</DataGridTemplateColumn.Header>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<TextBlock Text="{Binding NoParse}"
+							</StackPanel>
+						</DataGridTemplateColumn.Header>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<TextBlock Text="{Binding NoParse}"
 									   Foreground="{Binding NoParse, Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTemplateColumn SortMemberPath="NumUserApprovedAnalysesMissing" CanUserSort="True">
-					<DataGridTemplateColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksNumMissingAnalyses}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTemplateColumn SortMemberPath="NumUserApprovedAnalysesMissing" CanUserSort="True">
+						<DataGridTemplateColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumMissingAnalyses}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksNumMissingAnalysesToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalMissingAnalysesToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalMissingAnalysesToolTip}"
 									   Text="{Binding DataContext.ParserReport.TotalUserApprovedAnalysesMissing, RelativeSource={RelativeSource AncestorType=DataGrid}}"
 									   Foreground="{Binding DataContext.ParserReport.TotalUserApprovedAnalysesMissing,
 												RelativeSource={RelativeSource AncestorType=DataGrid},
 												Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</StackPanel>
-					</DataGridTemplateColumn.Header>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<TextBlock Text="{Binding NumUserApprovedAnalysesMissing}"
+							</StackPanel>
+						</DataGridTemplateColumn.Header>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<TextBlock Text="{Binding NumUserApprovedAnalysesMissing}"
 									   Foreground="{Binding NumUserApprovedAnalysesMissing, Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTemplateColumn SortMemberPath="NumUserDisapprovedAnalyses" CanUserSort="True">
-					<DataGridTemplateColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksNumDisapprovedAnalyses}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTemplateColumn SortMemberPath="NumUserDisapprovedAnalyses" CanUserSort="True">
+						<DataGridTemplateColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumDisapprovedAnalyses}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksNumDisapprovedAnalysesToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip="{x:Static local:ParserUIStrings.ksTotalDisapprovedAnalysesToolTip}"
+								<Separator/>
+								<TextBlock ToolTip="{x:Static local:ParserUIStrings.ksTotalDisapprovedAnalysesToolTip}"
 									   Text="{Binding DataContext.ParserReport.TotalUserDisapprovedAnalyses, RelativeSource={RelativeSource AncestorType=DataGrid}}"
 									   Foreground="{Binding DataContext.ParserReport.TotalUserDisapprovedAnalyses,
 												RelativeSource={RelativeSource AncestorType=DataGrid},
 												Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</StackPanel>
-					</DataGridTemplateColumn.Header>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<TextBlock Text="{Binding NumUserDisapprovedAnalyses}"
+							</StackPanel>
+						</DataGridTemplateColumn.Header>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<TextBlock Text="{Binding NumUserDisapprovedAnalyses}"
 									   Foreground="{Binding NumUserDisapprovedAnalyses, Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTemplateColumn SortMemberPath="NumUserNoOpinionAnalyses" CanUserSort="True">
-					<DataGridTemplateColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksNumNoOpinionAnalyses}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTemplateColumn SortMemberPath="NumUserNoOpinionAnalyses" CanUserSort="True">
+						<DataGridTemplateColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumNoOpinionAnalyses}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksNumNoOpinionAnalysesToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalNoOpinionAnalysesToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalNoOpinionAnalysesToolTip}"
 									   Text="{Binding DataContext.ParserReport.TotalUserNoOpinionAnalyses, RelativeSource={RelativeSource AncestorType=DataGrid}}"
 									   Foreground="{Binding DataContext.ParserReport.TotalUserNoOpinionAnalyses,
 												RelativeSource={RelativeSource AncestorType=DataGrid},
 												Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</StackPanel>
-					</DataGridTemplateColumn.Header>
-					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate>
-							<TextBlock Text="{Binding NumUserNoOpinionAnalyses}"
+							</StackPanel>
+						</DataGridTemplateColumn.Header>
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<TextBlock Text="{Binding NumUserNoOpinionAnalyses}"
 									   Foreground="{Binding NumUserNoOpinionAnalyses, Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</DataTemplate>
-					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
-				<DataGridTextColumn Binding="{Binding ErrorMessage}" Width="100">
-					<DataGridTextColumn.ElementStyle>
-						<Style TargetType="{x:Type TextBlock}"
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					<DataGridTextColumn Binding="{Binding ErrorMessage}" Width="100">
+						<DataGridTextColumn.ElementStyle>
+							<Style TargetType="{x:Type TextBlock}"
 							   BasedOn="{StaticResource {x:Type TextBlock}}">
-							<Setter Property="TextWrapping"
+								<Setter Property="TextWrapping"
 									   Value="NoWrap" />
-							<Setter Property="TextTrimming"
+								<Setter Property="TextTrimming"
 									Value="CharacterEllipsis" />
-							<Setter Property="ToolTip"
+								<Setter Property="ToolTip"
 									Value="{Binding ErrorMessage}" />
-						</Style>
-					</DataGridTextColumn.ElementStyle>
-					<DataGridTextColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksErrorMessage}"
+							</Style>
+						</DataGridTextColumn.ElementStyle>
+						<DataGridTextColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksErrorMessage}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksErrorMessageToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumParseErrorsToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksNumParseErrorsToolTip}"
 									   Text="{Binding DataContext.ParserReport.NumParseErrors, RelativeSource={RelativeSource AncestorType=DataGrid}}"
 									   Foreground="{Binding DataContext.ParserReport.NumParseErrors,
 															RelativeSource={RelativeSource AncestorType=DataGrid},
 															Converter={StaticResource PositiveIntToRedBrushConverter}}"/>
-						</StackPanel>
-					</DataGridTextColumn.Header>
-				</DataGridTextColumn>
-				<DataGridTextColumn Binding="{Binding NumAnalyses}">
-					<DataGridTextColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksNumAnalyses}"
+							</StackPanel>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
+					<DataGridTextColumn Binding="{Binding NumAnalyses}">
+						<DataGridTextColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumAnalyses}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksNumAnalysesToolTip}"/>
-							<Separator/>
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalAnalysesToolTip}"
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalAnalysesToolTip}"
 								   Text="{Binding DataContext.ParserReport.TotalAnalyses, RelativeSource={RelativeSource AncestorType=DataGrid}}"></TextBlock>
-						</StackPanel>
-					</DataGridTextColumn.Header>
-				</DataGridTextColumn>
-				<DataGridTextColumn Binding="{Binding ParseTime, Converter={StaticResource MillisecondsToTimeSpanConverter}, StringFormat=\{0:g\}}">
-					<DataGridTextColumn.Header>
-						<StackPanel>
-							<Label Content="{x:Static local:ParserUIStrings.ksParseTime}"
+							</StackPanel>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
+					<DataGridTextColumn Binding="{Binding ParseTime, Converter={StaticResource MillisecondsToTimeSpanConverter}, StringFormat=\{0:g\}}">
+						<DataGridTextColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksParseTime}"
 								   ToolTip="{x:Static local:ParserUIStrings.ksParseTimeToolTip}"/>
-							<Separator/>
-							<!-- The following must be a TextBlock for StringFormat to work. -->
-							<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalParseTimeToolTip}"
+								<Separator/>
+								<!-- The following must be a TextBlock for StringFormat to work. -->
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalParseTimeToolTip}"
 								Text="{Binding DataContext.ParserReport.TotalParseTime, RelativeSource={RelativeSource AncestorType=DataGrid},
 								Converter={StaticResource MillisecondsToTimeSpanConverter}, StringFormat=\{0:g\}}"></TextBlock>
-						</StackPanel>
-					</DataGridTextColumn.Header>
-				</DataGridTextColumn>
-			</DataGrid.Columns>
-		</DataGrid>
+							</StackPanel>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
+				</DataGrid.Columns>
+			</DataGrid>
+		</ScrollViewer>
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left" Height="40">
+			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"
+                    ToolTip="{x:Static local:ParserUIStrings.ksSaveReportToolTip}"
+                    Click="SaveParserReport" Width="100" Margin="5"/>
+			<Label x:Name="commentLabel" Height="27"/>
+			<Label Content="{Binding DisplayComment, Mode=OneWay}" Height="27"/>
+		</StackPanel>
 	</Grid>
 </Window>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -18,13 +18,20 @@ namespace SIL.FieldWorks.LexText.Controls
 			InitializeComponent();
 		}
 
-		public ParserReportDialog(ParserReport parserReport, Mediator mediator, LcmCache cache)
+		public ParserReportDialog(ParserReportViewModel parserReport, Mediator mediator, LcmCache cache)
 		{
 			InitializeComponent();
 			Mediator = mediator;
 			Cache = cache;
-			DataContext = new ParserReportViewModel { ParserReport = parserReport };
+			DataContext = parserReport;
 		}
+
+		public void SaveParserReport(object sender, RoutedEventArgs e)
+		{
+			ParserReportViewModel parserReportViewModel = (ParserReportViewModel)DataContext;
+			ParserListener.SaveParserReport(parserReportViewModel, Cache, null);
+		}
+
 
 		public void ReparseWord(object sender, RoutedEventArgs e)
 		{

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -2,8 +2,12 @@ using SIL.FieldWorks.Common.FwUtils;
 using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
 using SIL.LCModel.Core.Text;
+using System.Diagnostics;
+using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
 using XCore;
 
 namespace SIL.FieldWorks.LexText.Controls
@@ -24,6 +28,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			Mediator = mediator;
 			Cache = cache;
 			DataContext = parserReport;
+			commentLabel.Content = ParserUIStrings.ksComment + ":";
 		}
 
 		public void SaveParserReport(object sender, RoutedEventArgs e)
@@ -60,6 +65,36 @@ namespace SIL.FieldWorks.LexText.Controls
 		private string RemoveArrow(string word)
 		{
 			return word.Replace(" => ", string.Empty);
+		}
+
+		private void ScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+		{
+			ScrollViewer scrollViewer = sender as ScrollViewer;
+			if (scrollViewer != null)
+				if (e.Delta > 0)
+					scrollViewer.LineUp();
+				else
+					scrollViewer.LineDown();
+			e.Handled = true;
+		}
+
+		private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+		{
+			if (sender is DataGrid dataGrid)
+			{
+				if (dataGrid.SelectedItem is ParserReportViewModel selectedItem)
+					ParserListener.ShowParserReport(selectedItem, Mediator, Cache);
+			}
+			else
+				Debug.Fail("Type of Contents of DataGrid changed, adjust double click code.");
+		}
+		private void DataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (sender is DataGrid dataGrid)
+			{
+				// Turn off selection in favor of the check box.
+				Dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(() => dataGrid.UnselectAll()));
+			}
 		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportViewModel.cs
@@ -24,6 +24,18 @@ namespace SIL.FieldWorks.LexText.Controls
 			}
 		}
 
+		public string DisplayComment
+		{
+			get
+			{
+				if (ParserReport.Filename == null)
+				{
+					return ParserUIStrings.ksUnsavedParserReport;
+				}
+				return ParserReport.Comment;
+			}
+		}
+
 		public IEnumerable<ParseReport> ParseReports
 		{
 			get
@@ -64,6 +76,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		protected virtual void OnPropertyChanged(string propertyName)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public void UpdateDisplayComment()
+		{
+			OnPropertyChanged("DisplayComment");
 		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -39,7 +39,7 @@
 							<Label Content="{x:Static local:ParserUIStrings.ksText}" ToolTip="{x:Static local:ParserUIStrings.ksTextToolTip}"/>
 						</DataGridTextColumn.Header>
 					</DataGridTextColumn>
-					<DataGridTextColumn Binding="{Binding ParserReport.Comment, Mode=TwoWay}" Width="100">
+					<DataGridTextColumn Binding="{Binding DisplayComment, Mode=OneWay}" Width="100">
 						<DataGridTextColumn.Header>
 							<Label Content="{x:Static local:ParserUIStrings.ksComment}" ToolTip="{x:Static local:ParserUIStrings.ksCommentToolTip}"/>
 						</DataGridTextColumn.Header>
@@ -122,7 +122,7 @@
                     ToolTip="{x:Static local:ParserUIStrings.ksDiffButtonToolTip}"
                     IsEnabled="{Binding CanDiffReports}"
                     Click="DiffParserReports" Width="100" Margin="5" />
-			<Button Content="{Binding DiffButtonContent}"
+			<Button Content="{Binding DeleteButtonContent}"
                     ToolTip="{x:Static local:ParserUIStrings.ksDeleteToolTip}"
                     IsEnabled="{Binding CanDeleteReports}"
                     Click="DeleteParserReport" Width="100" Margin="5" />

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -60,7 +60,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				if (report.IsSelected)
 				{
-					ParserListener.ShowParserReport(report.ParserReport, Mediator, Cache);
+					ParserListener.ShowParserReport(report, Mediator, Cache);
 					break;
 				}
 			}
@@ -72,11 +72,9 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				if (report.IsSelected)
 				{
-					ParserListener.SaveParserReport(report.ParserReport, Cache, DefaultComment);
+					ParserListener.SaveParserReport(report, Cache, DefaultComment);
 				}
 			}
-			// The comment may have been updated.
-			DataGrid.Items.Refresh();
 			((ParserReportsViewModel)DataContext).UpdateButtonStates();
 
 		}
@@ -130,14 +128,15 @@ namespace SIL.FieldWorks.LexText.Controls
 				parserReport2 = temp;
 			}
 			var diff = parserReport.ParserReport.DiffParserReports(parserReport2.ParserReport);
-			ParserListener.ShowParserReport(diff, Mediator, Cache);
+			ParserReportViewModel viewModel = new ParserReportViewModel() { ParserReport = diff };
+			ParserListener.ShowParserReport(viewModel, Mediator, Cache);
 		}
 		private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
 		{
 			if (sender is DataGrid dataGrid)
 			{
 				if(dataGrid.SelectedItem is ParserReportViewModel selectedItem)
-					ParserListener.ShowParserReport(selectedItem.ParserReport, Mediator, Cache);
+					ParserListener.ShowParserReport(selectedItem, Mediator, Cache);
 			}
 			else
 				Debug.Fail("Type of Contents of DataGrid changed, adjust double click code.");

--- a/Src/LexText/ParserUI/ParserReportsViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportsViewModel.cs
@@ -44,10 +44,9 @@ namespace SIL.FieldWorks.LexText.Controls
 		public bool CanShowReport => ParserReports.Count(report => report.IsSelected) == 1;
 		public bool CanDiffReports => ParserReports.Count(report => report.IsSelected) == 2;
 		public bool CanDeleteReports => ParserReports.Any(report => report.IsSelected);
-		public bool CanSaveReport => ParserReports.Count(report => report.IsSelected) == 1 &&
-									ParserReports.Count(report => report.IsSelected && report.ParserReport.Filename == null) == 1;
+		public bool CanSaveReport => ParserReports.Count(report => report.IsSelected) == 1;
 
-		public string DiffButtonContent => string.Format(ParserUIStrings.ksDelete,
+		public string DeleteButtonContent => string.Format(ParserUIStrings.ksDelete,
 			ParserReports.Count(report => report.IsSelected));
 		public ParserReportsViewModel()
 		{
@@ -88,11 +87,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			if (e.PropertyName == nameof(ParserReportViewModel.IsSelected))
 			{
 				// Notify changes to button state properties
-				OnPropertyChanged(nameof(CanShowReport));
-				OnPropertyChanged(nameof(CanSaveReport));
-				OnPropertyChanged(nameof(CanDiffReports));
-				OnPropertyChanged(nameof(CanDeleteReports));
-				OnPropertyChanged(nameof(DiffButtonContent));
+				UpdateButtonStates();
 			}
 		}
 		protected virtual void OnPropertyChanged(string propertyName)
@@ -104,9 +99,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		public void UpdateButtonStates()
 		{
 			OnPropertyChanged(nameof(CanShowReport));
+			OnPropertyChanged(nameof(CanSaveReport));
 			OnPropertyChanged(nameof(CanDiffReports));
 			OnPropertyChanged(nameof(CanSaveReport));
 			OnPropertyChanged(nameof(CanDeleteReports));
+			OnPropertyChanged(nameof(DeleteButtonContent));
 		}
 	}
 }

--- a/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
+++ b/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
@@ -700,6 +700,15 @@ namespace SIL.FieldWorks.LexText.Controls {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (unsaved).
+        /// </summary>
+        public static string ksUnsavedParserReport {
+            get {
+                return ResourceManager.GetString("ksUnsavedParserReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Word.
         /// </summary>
         public static string ksWord {

--- a/Src/LexText/ParserUI/ParserUIStrings.resx
+++ b/Src/LexText/ParserUI/ParserUIStrings.resx
@@ -344,4 +344,7 @@
   <data name="ksEnterComment" xml:space="preserve">
     <value>Please enter a comment for the parser report</value>
   </data>
+  <data name="ksUnsavedParserReport" xml:space="preserve">
+    <value>(unsaved)</value>
+  </data>
 </root>


### PR DESCRIPTION
This implements https://jira.sil.org/browse/LT-21999 with Jason's permission.
It adds a "Save Report" button to the window for individual parser reports.
It adds the comment as a label right after Save Report button.
It changes saving so that you can change a comment by saving the report again (deleting the old report).
It also fixes a bug that prevented comment fields from being updated properly when comments are changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/224)
<!-- Reviewable:end -->
