### PR TITLE
Improve LT-21999: Improve saving of parser test reports

### DIFF
--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -7,7 +7,7 @@
         d:DataContext="{d:DesignInstance Type=local:ParserReportsViewModel, IsDesignTimeCreatable=True}"
         mc:Ignorable="d"
         Title="{x:Static local:ParserUIStrings.ksParserTestReports}" WindowStartupLocation="CenterScreen"
-        SizeToContent="Width" Height="300"
+        Width="1050" Height="300"
         WindowStyle="ThreeDBorderWindow">
 
 	<Window.Resources>


### PR DESCRIPTION
Beth requested that the width of the parser test reports window be limited so that it would fit on a laptop screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/228)
<!-- Reviewable:end -->
