### PR TITLE
Fix LT-22000: "Move" vs. "Move Field"

### DIFF
--- a/DistFiles/Language Explorer/Configuration/CommonDataTreeInclude.xml
+++ b/DistFiles/Language Explorer/Configuration/CommonDataTreeInclude.xml
@@ -38,7 +38,7 @@
 				  behavior="singlePropertySequenceValue" property="SelectedWritingSystemHvosForCurrentContextMenu" defaultPropertyValue=""/>
 			<item command="CmdDataTree-WritingSystemMenu-Configure"/>
 		</menu>
-		<menu id="mnuMove" label="Move">
+		<menu id="mnuMove" label="Move Field">
 			<item command="CmdDataTree-MoveFieldUp"/>
 			<item command="CmdDataTree-MoveFieldDown"/>
 		</menu>


### PR DESCRIPTION
Beth noticed that some menus say "Move" and some say "Move Field".  This is because multistrings have a separate menu that includes a menu item for changing the writing system.  This did not get changed when Jason changed the name of the "Move" menu item for the menu for generic objects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/229)
<!-- Reviewable:end -->
