### PR TITLE
Fix LT-21999: Disable Save Report on comparison reports

### DIFF
--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -237,6 +237,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			diff.ProjectName = DiffNames(ProjectName, other.ProjectName);
 			diff.SourceText = DiffNames(SourceText, other.SourceText);
 			diff.MachineName = DiffNames(MachineName, other.MachineName);
+			diff.Comment = DiffNames(Comment, other.Comment);
 			diff.Timestamp = Timestamp;
 			diff.DiffTimestamp = other.Timestamp;
 			diff.NumWords = NumWords - other.NumWords;

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -188,6 +188,7 @@
 		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left" Height="40">
 			<Button Content="{x:Static local:ParserUIStrings.ksSaveReport}"
                     ToolTip="{x:Static local:ParserUIStrings.ksSaveReportToolTip}"
+					IsEnabled="{Binding CanSaveReport}"
                     Click="SaveParserReport" Width="100" Margin="5"/>
 			<Label x:Name="commentLabel" Height="27"/>
 			<Label Content="{Binding DisplayComment, Mode=OneWay}" Height="27"/>

--- a/Src/LexText/ParserUI/ParserReportViewModel.cs
+++ b/Src/LexText/ParserUI/ParserReportViewModel.cs
@@ -28,7 +28,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			get
 			{
-				if (ParserReport.Filename == null)
+				if (ParserReport.Filename == null && !ParserReport.IsDiff)
 				{
 					return ParserUIStrings.ksUnsavedParserReport;
 				}
@@ -59,6 +59,9 @@ namespace SIL.FieldWorks.LexText.Controls
 				}
 			}
 		}
+
+		public bool CanSaveReport => !ParserReport.IsDiff;
+
 
 		public ParserReportViewModel()
 		{


### PR DESCRIPTION
Daney reported some problems with saving comparison reports.  I fixed the problems by disabling the Save Report button on comparison reports.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/232)
<!-- Reviewable:end -->
