### PR TITLE
Word Export: LT-22006: RTL - Fix indentation and clipping

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -252,11 +252,7 @@ namespace SIL.FieldWorks.XWorks
 				if (exportStyleInfo.HasLeadingIndent || hangingIndent < 0.0f)
 				{
 					var leadingIndent = CalculateMarginLeft(exportStyleInfo, hangingIndent);
-
-					if (exportStyleInfo.DirectionIsRightToLeft == TriStateBool.triTrue)
-						parProps.Append(new Indentation() { Right = leadingIndent.ToString() });
-					else
-						parProps.Append(new Indentation() { Left = leadingIndent.ToString() });
+					parProps.Append(new Indentation() { Left = leadingIndent.ToString() });
 				}
 
 				if (exportStyleInfo.HasLineSpacing)
@@ -309,11 +305,7 @@ namespace SIL.FieldWorks.XWorks
 
 				if (exportStyleInfo.HasTrailingIndent)
 				{
-					// Check bidirectional flag to determine correct orientation for indent
-					if (exportStyleInfo.DirectionIsRightToLeft == TriStateBool.triTrue)
-						parProps.Append(new Indentation() { Left = MilliPtToTwentiPt(exportStyleInfo.TrailingIndent).ToString() });
-					else
-						parProps.Append(new Indentation() { Right = MilliPtToTwentiPt(exportStyleInfo.TrailingIndent).ToString() });
+					parProps.Append(new Indentation() { Right = MilliPtToTwentiPt(exportStyleInfo.TrailingIndent).ToString() });
 				}
 
 				// If text direction is right to left, add BiDi property to the paragraph.


### PR DESCRIPTION
Word does not expect the indentation direction (left/right) to be flipped for right to left output.  Removed the extra code and output the same indentation direction for both LTR and RTL.

This problem also existed with the single column output, but became more obvious when we switched to double column output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/233)
<!-- Reviewable:end -->
