### PR TITLE
Word Export: RTL – Set first column to be on the right

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -140,6 +140,11 @@ namespace SIL.FieldWorks.XWorks
 					new Columns() { EqualWidth = true, ColumnCount = 2 },
 					new SectionType() { Val = SectionMarkValues.Continuous }
 					);
+				// Set the section to BiDi so the columns are displayed right to left.
+				if (IsBidi)
+				{
+					sectProps.Append(new BiDi());
+				}
 				fragment.DocBody.Append(sectProps);
 
 				if (progress != null)
@@ -329,6 +334,11 @@ namespace SIL.FieldWorks.XWorks
 							new Columns() { EqualWidth = true, ColumnCount = 2 },
 							new SectionType() { Val = SectionMarkValues.Continuous }
 						);
+						// Set the section to BiDi so the columns are displayed right to left.
+						if (IsBidi)
+						{
+							sectProps2.Append(new BiDi());
+						}
 						docFrag.DocBody.AppendChild(new WP.Paragraph(new WP.ParagraphProperties(sectProps2)));
 					}
 
@@ -349,6 +359,11 @@ namespace SIL.FieldWorks.XWorks
 						new Columns() { EqualWidth = true, ColumnCount = 1 },
 						new SectionType() { Val = SectionMarkValues.Continuous }
 					);
+					// Set the section to BiDi so the columns are displayed right to left.
+					if (IsBidi)
+					{
+						sectProps1.Append(new BiDi());
+					}
 					docFrag.DocBody.AppendChild(new WP.Paragraph(new WP.ParagraphProperties(sectProps1)));
 				}
 				return docFrag;


### PR DESCRIPTION
For right to left documents this sets every section so that the column on the right is filled first.
With this change the user no longer needs to do the following steps in the Word document:
  In the Layout tab, click the icon at the lower right of the
  Page Setup section, and in the dialog that comes up, set
  Section direction: to Right-to-left. This is critical for RTL
  documents so that the first column on the page is on the right
  side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/234)
<!-- Reviewable:end -->
