### PR TITLE
Fix LT-21980: Crash changing or modifying grammatical info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Bin/_setLatestBuildConfig.bat
 Bin/_setroot.bat
 Lib/debug/DebugProcs.lib
 Lib/debug/Generic.lib
+Lib/debug/System.ValueTuple.dll
 Lib/debug/unit++.*
 Lib/release/DebugProcs.lib
 Lib/release/Generic.lib

--- a/Src/LexText/LexTextControls/MSAPopupTreeManager.cs
+++ b/Src/LexText/LexTextControls/MSAPopupTreeManager.cs
@@ -44,6 +44,9 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		#region Events
 
+		public event TreeViewEventHandler BeforeChange;
+		public event TreeViewEventHandler AfterChange;
+
 		#endregion Events
 
 		/// <summary>
@@ -419,11 +422,19 @@ namespace SIL.FieldWorks.LexText.Controls
 					m_sense.MorphoSyntaxAnalysisRA.Hvo, true, m_sEditGramFunc);
 				if (dlg.ShowDialog(ParentForm) == DialogResult.OK)
 				{
+					if (BeforeChange != null)
+					{
+						BeforeChange(this, null);
+					}
 					Cache.DomainDataByFlid.BeginUndoTask(String.Format(LexTextControls.ksUndoSetX, FieldName),
 						String.Format(LexTextControls.ksRedoSetX, FieldName));
 					m_sense.SandboxMSA = dlg.SandboxMSA;
 					Cache.DomainDataByFlid.EndUndoTask();
 					LoadPopupTree(m_sense.MorphoSyntaxAnalysisRA.Hvo);
+					if (AfterChange != null)
+					{
+						AfterChange(this, null);
+					}
 					return true;
 				}
 			}


### PR DESCRIPTION
I created BeforeChange and AfterChange events to delay the refresh of the data tree.  BeforeChange sets DoNotRefresh and AfterChange adds RefreshDataTree to the UI thread's queue.  I tried using BeforeSelect and AfterSelect, but there are actually two calls to AfterSelect and it wasn't clear that I could catch only the second call.  Also, it would force a refresh of the data tree even if nothing was changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/235)
<!-- Reviewable:end -->
