### PR TITLE
Fix LT-22011: Adding slots lead to crash

### DIFF
--- a/Src/Common/Controls/DetailControls/DataTree.cs
+++ b/Src/Common/Controls/DetailControls/DataTree.cs
@@ -553,8 +553,11 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			//	return;
 			if (m_monitoredProps.Contains(Tuple.Create(hvo, tag)))
 			{
-				RefreshList(false);
-				OnFocusFirstPossibleSlice(null);
+				// If we call RefreshList now, it causes a crash in the invoker
+				// because some slice data structures that are being used by the invoker
+				// get disposed by RefreshList (LT-21980, LT-22011).  So we postpone calling
+				// RefreshList until the work is done.
+				this.BeginInvoke(new Action(PostponedRefreshList));
 			}
 			// Note, in LinguaLinks import we don't have an action handler when we hit this.
 			else if (m_cache.DomainDataByFlid.GetActionHandler() != null && m_cache.DomainDataByFlid.GetActionHandler().IsUndoOrRedoInProgress)
@@ -578,6 +581,15 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				// some FieldSlices (e.g. combo slices)may want to Update their display
 				// if its field changes during an Undo/Redo (cf. LT-4861).
 				RefreshList(hvo, tag);
+			}
+		}
+
+		private void PostponedRefreshList()
+		{
+			if (!IsDisposed)
+			{
+				RefreshList(false);
+				OnFocusFirstPossibleSlice(null);
 			}
 		}
 

--- a/Src/Common/Controls/DetailControls/MSAReferenceComboBoxSlice.cs
+++ b/Src/Common/Controls/DetailControls/MSAReferenceComboBoxSlice.cs
@@ -99,8 +99,6 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				m_MSAPopupTreeManager = new MSAPopupTreeManager(m_tree, m_cache, list,
 					m_tree.WritingSystemCode, true, m_mediator, m_propertyTable,
 					m_propertyTable.GetValue<Form>("window"));
-				m_MSAPopupTreeManager.BeforeChange += m_MSAPopupTreeManager_BeforeChange;
-				m_MSAPopupTreeManager.AfterChange += m_MSAPopupTreeManager_AfterChange;
 				m_MSAPopupTreeManager.AfterSelect += m_MSAPopupTreeManager_AfterSelect;
 				m_MSAPopupTreeManager.Sense = m_obj as ILexSense;
 				m_MSAPopupTreeManager.PersistenceProvider = m_persistProvider;
@@ -223,33 +221,6 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 		protected override void UpdateDisplayFromDatabase()
 		{
 			// What do we need to do here, if anything?
-		}
-
-		public void m_MSAPopupTreeManager_BeforeChange(object sender, TreeViewEventArgs e)
-		{
-			if (!ContainingDataTree.DoNotRefresh)
-			{
-				// Postpone refreshing the screen until m_MSAPopupTreeManager_AfterChange (LT-21980).
-				ContainingDataTree.DoNotRefresh = true;
-				m_forceRefresh = true;
-			}
-		}
-
-		public void m_MSAPopupTreeManager_AfterChange(object sender, TreeViewEventArgs e)
-		{
-			if (m_forceRefresh)
-			{
-				m_forceRefresh = false;
-				// We can't call RefreshDataTree directly,
-				// since that will cause Windows to crash accessing a disposed object.
-				// So, we queue it on the UI thread instead.
-				this.BeginInvoke(new Action(RefreshDataTree));
-			}
-		}
-
-		public void RefreshDataTree()
-		{
-			ContainingDataTree.DoNotRefresh = false;
 		}
 
 		private void m_MSAPopupTreeManager_AfterSelect(object sender, TreeViewEventArgs e)

--- a/Src/LexText/LexTextControls/MSAPopupTreeManager.cs
+++ b/Src/LexText/LexTextControls/MSAPopupTreeManager.cs
@@ -44,9 +44,6 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		#region Events
 
-		public event TreeViewEventHandler BeforeChange;
-		public event TreeViewEventHandler AfterChange;
-
 		#endregion Events
 
 		/// <summary>
@@ -422,19 +419,11 @@ namespace SIL.FieldWorks.LexText.Controls
 					m_sense.MorphoSyntaxAnalysisRA.Hvo, true, m_sEditGramFunc);
 				if (dlg.ShowDialog(ParentForm) == DialogResult.OK)
 				{
-					if (BeforeChange != null)
-					{
-						BeforeChange(this, null);
-					}
 					Cache.DomainDataByFlid.BeginUndoTask(String.Format(LexTextControls.ksUndoSetX, FieldName),
 						String.Format(LexTextControls.ksRedoSetX, FieldName));
 					m_sense.SandboxMSA = dlg.SandboxMSA;
 					Cache.DomainDataByFlid.EndUndoTask();
 					LoadPopupTree(m_sense.MorphoSyntaxAnalysisRA.Hvo);
-					if (AfterChange != null)
-					{
-						AfterChange(this, null);
-					}
 					return true;
 				}
 			}


### PR DESCRIPTION
This was another issue where a display object got disposed prematurely.  I came up with a more general solution to the problem by changing DataTree.PropChanged to use BeginInvoke to postpone the change until the invoker is done.  I also removed the fix to https://jira.sil.org/browse/LT-21980 since it is covered by the general solution.  The general solution should work, but I wonder if it is too general.  Jason, could this cause a problem?  Also, should we make this even more general by postponing all of DataTree.PropChanged?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/239)
<!-- Reviewable:end -->
