### PR TITLE
Fix LT-20850: RTL hides text

### DIFF
--- a/Src/LexText/LexTextControls/LinkMSADlg.resx
+++ b/Src/LexText/LexTextControls/LinkMSADlg.resx
@@ -195,7 +195,7 @@
 	<value>102, 32</value>
   </data>
   <data name="m_panel1.Size" type="System.Drawing.Size, System.Drawing">
-	<value>208, 20</value>
+	<value>300, 20</value>
   </data>
   <data name="&gt;&gt;m_panel1.Name" xml:space="preserve">
 	<value>m_panel1</value>


### PR DESCRIPTION
I widened a box so that the RTL text would show.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/241)
<!-- Reviewable:end -->
