### PR TITLE
Fix LT-22018: Typing lost in example and translation fields

### DIFF
--- a/Src/Common/Controls/DetailControls/GhostStringSlice.cs
+++ b/Src/Common/Controls/DetailControls/GhostStringSlice.cs
@@ -454,7 +454,19 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				// Make the real object and set the string property we are ghosting. The final PropChanged
 				// will typically dispose this and create a new string slice whose key is our own key
 				// followed by the flid of the string property.
-				int hvoNewObj = MakeRealObject(tssTyped);
+				// To avoid problems, PropChanged must not be postponed (cf. LT-22018).
+				// Copy m_mediator in case 'this' gets disposed.
+				Mediator mediator = m_mediator;
+				int hvoNewObj;
+				try
+				{
+					mediator.SendMessage("PostponePropChanged", false);
+					hvoNewObj = MakeRealObject(tssTyped);
+				}
+				finally
+				{
+					mediator.SendMessage("PostponePropChanged", true);
+				}
 
 				// Now try to make a suitable selection in the slice that replaces this.
 				RestoreSelection(ich, datatree, parentKey, hvoNewObj, flidStringProp, wsToCreate);


### PR DESCRIPTION
This was caused by the fix to https://jira.sil.org/browse/LT-22011.  Basically, most of the time you want to postpone executing DataTree.PropChanged, but sometimes you don't.  Jason should review this to make sure I'm not doing something bad.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/244)
<!-- Reviewable:end -->
