### PR TITLE
Fix loss of sense examples importing from The Combine

### DIFF
--- a/Src/LexText/LexTextControls/LiftMerger.cs
+++ b/Src/LexText/LexTextControls/LiftMerger.cs
@@ -4063,7 +4063,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					setUsed.Add(les.Hvo);
 			}
 			// If we're keeping only the imported data, delete any unused example.
-			if (m_msImport == MergeStyle.MsKeepOnlyNew || m_msImport == MergeStyle.MsTheCombine)
+			if (m_msImport == MergeStyle.MsKeepOnlyNew)
 			{
 				foreach (int hvo in ls.ExamplesOS.ToHvoArray())
 				{


### PR DESCRIPTION
LIFT exports from The Combine don't ever have examples in their senses, so the import into FLEx shouldn't remove existing examples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/248)
<!-- Reviewable:end -->
