### PR TITLE
Preserve sense examples, subsenses importing from The Combine

### DIFF
--- a/Src/LexText/LexTextControls/LiftMerger.cs
+++ b/Src/LexText/LexTextControls/LiftMerger.cs
@@ -4003,7 +4003,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					setUsed.Add(lsSub.Hvo);
 			}
 			// If we're keeping only the imported data, delete any unused subsense.
-			if (m_msImport == MergeStyle.MsKeepOnlyNew  || m_msImport == MergeStyle.MsTheCombine)
+			if (m_msImport == MergeStyle.MsKeepOnlyNew)
 			{
 				foreach (int hvo in ls.SensesOS.ToHvoArray())
 				{
@@ -4063,7 +4063,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					setUsed.Add(les.Hvo);
 			}
 			// If we're keeping only the imported data, delete any unused example.
-			if (m_msImport == MergeStyle.MsKeepOnlyNew || m_msImport == MergeStyle.MsTheCombine)
+			if (m_msImport == MergeStyle.MsKeepOnlyNew)
 			{
 				foreach (int hvo in ls.ExamplesOS.ToHvoArray())
 				{
@@ -4297,7 +4297,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					setUsed.Add(ct.Hvo);
 			}
 			// If we're keeping only the imported data, erase any unused existing data first.
-			if (m_msImport == MergeStyle.MsKeepOnlyNew || m_msImport == MergeStyle.MsTheCombine)
+			if (m_msImport == MergeStyle.MsKeepOnlyNew)
 			{
 				foreach (int hvo in les.TranslationsOC.ToHvoArray())
 				{


### PR DESCRIPTION
Replaces #248

Reverts 3 unwanted changes from https://github.com/sillsdev/FieldWorks/commit/768611a9ba957b9c364907beea009cbaab23b0ae#diff-f6a37d69740bb35c88809abf63aca915df7dfba5ee3030dc10ca39d990c59571

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/253)
<!-- Reviewable:end -->
