### PR TITLE
LT-22025: Fix font issues in image captions

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2512,18 +2512,15 @@ namespace SIL.FieldWorks.XWorks
 
 			if (propertyValue is int)
 			{
-				var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.'); ;
-				return settings.ContentGenerator.AddProperty(config, cssClassName, false, propertyValue.ToString());
+				return GenerateContentForSimpleString(config, settings, false, propertyValue.ToString());
 			}
 			if (propertyValue is DateTime)
 			{
-				var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.'); ;
-				return settings.ContentGenerator.AddProperty(config, cssClassName, false, ((DateTime)propertyValue).ToLongDateString());
+				return GenerateContentForSimpleString(config, settings, false, ((DateTime)propertyValue).ToLongDateString());
 			}
 			else if (propertyValue is GenDate)
 			{
-				var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.'); ;
-				return settings.ContentGenerator.AddProperty(config, cssClassName, false, ((GenDate)propertyValue).ToLongString());
+				return GenerateContentForSimpleString(config, settings, false, ((GenDate)propertyValue).ToLongString());
 			}
 			else if (propertyValue is IMultiAccessorBase)
 			{
@@ -2533,8 +2530,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			else if (propertyValue is string)
 			{
-				var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.');
-				return settings.ContentGenerator.AddProperty(config, cssClassName, false, propertyValue.ToString());
+				return GenerateContentForSimpleString(config, settings, false, propertyValue.ToString());
 			}
 			else if (propertyValue is IStText)
 			{
@@ -2570,16 +2566,18 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		private static IFragment WriteElementContents(object propertyValue,
-			ConfigurableDictionaryNode config, GeneratorSettings settings)
+		/// <summary>
+		/// This method will add a property containing the string, using the first selected writing system,
+		/// or the first analysis writing system if no writing system is selected.
+		/// </summary>
+		private static IFragment GenerateContentForSimpleString(ConfigurableDictionaryNode config,
+			GeneratorSettings settings, bool isBlockProperty, string simpleString)
 		{
-			var content = propertyValue.ToString();
-			if (!String.IsNullOrEmpty(content))
-			{
-				return settings.ContentGenerator.AddProperty(config, GetClassNameAttributeForConfig(config), IsBlockProperty(config), content);
-			}
+			var writingSystem = GetLanguageFromFirstOptionOrAnalysis(config.DictionaryNodeOptions as DictionaryNodeWritingSystemOptions,
+				settings.Cache);
+			var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.');
+			return settings.ContentGenerator.AddProperty(config, settings.PropertyTable, cssClassName, false, simpleString, writingSystem);
 
-			return settings.ContentGenerator.CreateFragment();
 		}
 
 		private static IFragment GenerateContentForStrings(IMultiStringAccessor multiStringAccessor, ConfigurableDictionaryNode config,
@@ -3084,6 +3082,30 @@ namespace SIL.FieldWorks.XWorks
 
 		/// <summary>
 		/// This method returns the lang attribute value from the first selected writing system in the given options.
+		/// It defaults to the first analysis writing system if no options are given, and English if no analysis writing system is specified.
+		/// </summary>
+		/// <param name="wsOptions"></param>
+		/// <param name="cache"></param>
+		/// <returns></returns>
+		private static string GetLanguageFromFirstOptionOrAnalysis(DictionaryNodeWritingSystemOptions wsOptions, LcmCache cache)
+		{
+			const string defaultLang = "en";
+			var analWs = cache.WritingSystemFactory.GetStrFromWs(cache.DefaultAnalWs);
+
+			if (wsOptions == null)
+			{
+				if (analWs == null)
+					return defaultLang;
+
+				return analWs;
+			}
+
+			return GetLanguageFromFirstWs(wsOptions, cache);
+		}
+
+		/// <summary>
+		/// This method returns the lang attribute value from the first selected writing system in the given options.
+		/// It defaults to English if no options are given.
 		/// </summary>
 		/// <param name="wsOptions"></param>
 		/// <param name="cache"></param>
@@ -3093,6 +3115,21 @@ namespace SIL.FieldWorks.XWorks
 			const string defaultLang = "en";
 			if (wsOptions == null)
 				return defaultLang;
+			return GetLanguageFromFirstWs(wsOptions, cache);
+		}
+
+		/// <summary>
+		/// This method returns the lang attribute value from the first selected writing system in the given options.
+		/// Returns null if no options are given.
+		/// </summary>
+		/// <param name="wsOptions"></param>
+		/// <param name="cache"></param>
+		/// <returns></returns>
+		private static string GetLanguageFromFirstWs(DictionaryNodeWritingSystemOptions wsOptions, LcmCache cache)
+		{
+			if (wsOptions == null)
+				return null;
+
 			foreach (var option in wsOptions.Options)
 			{
 				if (option.IsEnabled)

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -3089,11 +3089,10 @@ namespace SIL.FieldWorks.XWorks
 		/// <returns></returns>
 		private static string GetLanguageFromFirstOptionOrAnalysis(DictionaryNodeWritingSystemOptions wsOptions, LcmCache cache)
 		{
-			const string defaultLang = "en";
-			var analWs = cache.WritingSystemFactory.GetStrFromWs(cache.DefaultAnalWs);
-
 			if (wsOptions == null)
 			{
+				const string defaultLang = "en";
+				var analWs = cache.WritingSystemFactory.GetStrFromWs(cache.DefaultAnalWs);
 				if (analWs == null)
 					return defaultLang;
 

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -24,7 +24,7 @@ namespace SIL.FieldWorks.XWorks
 			Func<object, ConfigurableDictionaryNode, DictionaryPublicationDecorator, ConfiguredLcmGenerator.GeneratorSettings, IFragment> childContentGenerator);
 		IFragment AddSenseData(ConfigurableDictionaryNode config, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first);
 		IFragment AddCollectionItem(ConfigurableDictionaryNode config, bool isBlock, string collectionItemClass, IFragment content, bool first);
-		IFragment AddProperty(ConfigurableDictionaryNode config, string className, bool isBlockProperty, string content);
+		IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem);
 		IFragment CreateFragment();
 		IFragment CreateFragment(string str);
 		IFragmentWriter CreateWriter(IFragment fragment);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -124,7 +124,7 @@ namespace SIL.FieldWorks.XWorks
 			return fragment;
 		}
 
-		public IFragment AddProperty(ConfigurableDictionaryNode config, string className, bool isBlockProperty, string content)
+		public IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem)
 		{
 			var fragment = new StringFragment($"\"{className}\": \"{content}\",");
 			return fragment;

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -1076,7 +1076,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		public IFragment AddProperty(ConfigurableDictionaryNode config, string className, bool isBlockProperty, string content)
+		public IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem)
 		{
 			var bldr = new StringBuilder();
 			var fragment = new StringFragment(bldr);

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -515,6 +515,13 @@ namespace SIL.FieldWorks.XWorks
 			var fontName = wsFontInfo.m_fontName.ValueIsSet ? wsFontInfo.m_fontName.Value
 				: defaultFontInfo.FontName.ValueIsSet ? defaultFontInfo.FontName.Value : null;
 
+			// If font is explicitly set in FLEx to "<default font>", this gets picked up as the fontname.
+			// In that case, we want to set fontNome to null in the word style so that it can be inherited from the WS.
+			if (fontName == "<default font>")
+			{
+				fontName = null;
+			}
+
 			// fontName still null means not set in Normal Style, then get default fonts from WritingSystems configuration.
 			// Comparison, projectStyle.Name == "Normal", required to limit the font-family definition to the
 			// empty span (ie span[lang="en"]{}. If not included, font-family will be added to many more spans.


### PR DESCRIPTION
Root problem is that some image caption component styles were not based on writing system styles in the Word export.

* Create function "GenerateContentForSimpleString" that gets a writing system and passes it to AddProperty to generate the string property content.
* Use first analysis language as the default writing system for string properties.
* In AddProperty, use AddRun with the writing system to get/create a style that is based on the writing system.
* Delete unused WriteElementContents method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/255)
<!-- Reviewable:end -->
