### PR TITLE
LT-21818: Fix cutoff diacritics in Word Export

### DIFF
--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -280,16 +280,16 @@ namespace SIL.FieldWorks.XWorks
 					else
 					{
 						// Note: In Flex a user can set 'at least' or 'exactly' for line heights. These are differentiated using negative and positive
-						// values in LineSpacing.m_lineHeight -- negative value means at least line height, otherwise it's exactly line height
+						// values in LineSpacing.m_lineHeight -- positive value means at least line height, otherwise it's exact line height
 						var lineHeight = exportStyleInfo.LineSpacing.m_lineHeight;
-						if (lineHeight < 0)
+						if (lineHeight >= 0)
 						{
-							lineHeight = MilliPtToTwentiPt(Math.Abs(exportStyleInfo.LineSpacing.m_lineHeight));
+							lineHeight = MilliPtToTwentiPt(lineHeight);
 							parProps.Append(new SpacingBetweenLines() { Line = lineHeight.ToString(), LineRule = LineSpacingRuleValues.AtLeast });
 						}
 						else
 						{
-							lineHeight = MilliPtToTwentiPt(exportStyleInfo.LineSpacing.m_lineHeight);
+							lineHeight = MilliPtToTwentiPt(Math.Abs(lineHeight));
 							parProps.Append(new SpacingBetweenLines() { Line = lineHeight.ToString(), LineRule = LineSpacingRuleValues.Exact });
 						}
 					}
@@ -516,7 +516,7 @@ namespace SIL.FieldWorks.XWorks
 				: defaultFontInfo.FontName.ValueIsSet ? defaultFontInfo.FontName.Value : null;
 
 			// If font is explicitly set in FLEx to "<default font>", this gets picked up as the fontname.
-			// In that case, we want to set fontNome to null in the word style so that it can be inherited from the WS.
+			// In that case, we want to set fontName to null in the word style so that it can be inherited from the WS.
 			if (fontName == "<default font>")
 			{
 				fontName = null;


### PR DESCRIPTION
Diacritics are cutoff because Word uses exact line spacing when
FLEx specifies at least line spacing.

Fix logic for determining at least and exact line spacing
in the Word Export.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/259)
<!-- Reviewable:end -->
