### PR TITLE
LT-22042: Fix incorrect styles being used in Flex

### DIFF
--- a/Src/xWorks/CssGenerator.cs
+++ b/Src/xWorks/CssGenerator.cs
@@ -58,6 +58,7 @@ namespace SIL.FieldWorks.XWorks
 		private LcmCache _cache;
 		private ReadOnlyPropertyTable _propertyTable;
 		private Dictionary<string, List<StyleRule>> _styleDictionary = new Dictionary<string, List<StyleRule>>();
+		private Dictionary<string, string> _uniqueNodeNames = new Dictionary<string, string>();
 		private StyleSheet _styleSheet = new StyleSheet();
 
 		public void Init(ReadOnlyPropertyTable propertyTable)
@@ -83,61 +84,125 @@ namespace SIL.FieldWorks.XWorks
 			var className = $".{GetClassAttributeForConfig(node)}";
 			lock (_styleDictionary)
 			{
-				var styleContent = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
-				if (!styleContent.Any())
+				// Create a list of nodes for the path, from root to 'node'.
+				List<ConfigurableDictionaryNode> nodes = new List<ConfigurableDictionaryNode>();
+				var pathNode = node;
+				while (pathNode != null)
 				{
-					return className;
+					nodes.Add(pathNode);
+					pathNode = pathNode.Parent;
 				}
-				if (!_styleDictionary.ContainsKey(className))
-				{
-					_styleDictionary[className] = styleContent;
-					return className;
-				}
-				// If the content is the same, then do nothing
-				if (AreStyleRulesListsEquivalent(_styleDictionary[className], styleContent))
-				{
-					return className;
-				}
-				// Otherwise get a unique but useful class name and re-generate the style with the new name
-				className = GetBestUniqueNameForNode(node);
-				return className;
-			}
-		}
+				nodes.Reverse();
 
-		public static bool AreStyleRulesListsEquivalent(List<StyleRule> first,
-			List<StyleRule> second)
-		{
-			return first.Count == second.Count && first.TrueForAll(rule => second.Any(otherrule => otherrule.ToString().Equals(rule.ToString())));
+				// Generate the unique name and css for each node (starting from the root node).
+				string uniqueNodeName = null;
+				string uniqueNodePath = null;
+				for (int ii=0; ii < nodes.Count; ii++)
+				{
+					var workingNode = nodes[ii];
+					string nodePath = GetNodePath(workingNode);
+					var workingClassName = $".{GetClassAttributeForConfig(workingNode)}";
+
+					// If this node is ".subentries" and the next node is ".mainentrysubentries",
+					// then set the uniqueNodeName to ".mainentrysubentry" and skip the next node.
+					if (workingClassName == ".subentries" && (ii + 1 < nodes.Count) &&
+						$".{GetClassAttributeForConfig(nodes[ii + 1])}" == ".mainentrysubentries")
+					{
+						// We need a specificity higher than ".senses-? .subentries-? .subentry" and
+						// because of the way the path to ".mainentrysubentries" is generated we can
+						// get the wrong value for ".sense-?. So add ".sensecontent .sense" to the path.
+						uniqueNodePath = uniqueNodePath + ".sensecontent .sense ";
+						uniqueNodeName = ".mainentrysubentry";
+						ii++;
+					}
+					else
+					{
+						uniqueNodeName = GetUniqueNodeName(nodePath, workingClassName);
+					}
+
+					if (!_styleDictionary.ContainsKey(uniqueNodeName))
+					{
+						var styleRules = GenerateCssFromConfigurationNode(workingNode, uniqueNodeName, _propertyTable).NonEmpty();
+						styleRules = styleRules.Distinct().ToList(); // Remove duplicate rules.
+						AddUniquePathToStyleRules(styleRules, uniqueNodePath);
+						_styleDictionary[uniqueNodeName] = styleRules;
+					}
+					uniqueNodePath = uniqueNodePath + uniqueNodeName + " ";
+				}
+				return uniqueNodeName;
+			}
 		}
 
 		/// <summary>
-		/// Finds an unused class name for the configuration node. This should be called when there are two nodes in the <code>DictionaryConfigurationModel</code>
-		/// have the same class name, but different style content. We want this name to be usefully recognizable.
+		/// Get a path containing Non-Unique names for all the nodes from the root up to and
+		/// including the 'node' passed in.
 		/// </summary>
-		/// <returns></returns>
-		public string GetBestUniqueNameForNode(ConfigurableDictionaryNode node)
+		private string GetNodePath(ConfigurableDictionaryNode node)
 		{
-			Guard.AgainstNull(node.Parent, "There should not be duplicate class names at the top of tree.");
-			// First try appending the parent node classname. Pathway has code that cares about what
-			// the className starts with, so keep the 'node' name first.
-			var className = $".{GetClassAttributeForConfig(node)}-{GetClassAttributeForConfig(node.Parent)}";
-
-			string classNameBase = className;
-			int counter = 0;
-			lock (_styleDictionary)
+			// Generate the node path info from the root to this node.
+			string pathToNode = null;
+			var workingNode = node;
+			while (workingNode != null)
 			{
-				while (_styleDictionary.ContainsKey(className))
-				{
-					var styleContent = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
-					if (AreStyleRulesListsEquivalent(_styleDictionary[className], styleContent))
-					{
-						return className;
-					}
-					className = $"{classNameBase}-{++counter}";
-				}
-				_styleDictionary[className] = GenerateCssFromConfigurationNode(node, className, _propertyTable).NonEmpty();
+				string workingClassName = $".{GetClassAttributeForConfig(workingNode)} ";
+				pathToNode = workingClassName + pathToNode;
+				workingNode = workingNode.Parent;
 			}
-			return className;
+			return pathToNode;
+		}
+
+		/// <summary>
+		/// To avoid problems with one node using the style assigned to a different node with the same
+		/// name, assign a unique name to every node.
+		/// </summary>
+		/// <param name="nodePath">A path containing Non-Unique names for all the nodes.</param>
+		/// <param name="className">The name without an appended unique number.</param>
+		/// <returns></returns>
+		private string GetUniqueNodeName(string nodePath, string className)
+		{
+			if (_uniqueNodeNames.ContainsKey(nodePath))
+			{
+				return _uniqueNodeNames[nodePath];
+			}
+
+			int counter = 0;
+			string uniqueNodeName;
+			do
+			{
+				uniqueNodeName = $"{className}-{++counter}";
+			} while (_styleDictionary.ContainsKey(uniqueNodeName));
+
+			_uniqueNodeNames[nodePath] = uniqueNodeName;
+			return uniqueNodeName;
+		}
+
+		/// <summary>
+		/// To avoid problems with the wrong style being used, add the unique path to the style
+		/// rules.  This increases specificity.
+		/// </summary>
+		/// <param name="styleRules">The rules to be pre-pended with the uniquePath.</param>
+		/// <param name="uniquePath">A path containing Unique names for all the nodes.</param>
+		private void AddUniquePathToStyleRules(List<StyleRule> styleRules, string uniquePath)
+		{
+			if (!string.IsNullOrEmpty(uniquePath))
+			{
+				foreach (var styleRule in styleRules)
+				{
+					string existingRule = styleRule.Value;
+					// If the styleRule already contains the last node on the uniquePath, then don't add the node again.
+					int indexSpace = styleRule.Value.IndexOf(' ');
+					if (indexSpace != -1)
+					{
+						string ruleFirstNode = styleRule.Value.Substring(0, indexSpace + 1 /*intentionally include the space*/);
+						if (uniquePath.EndsWith(ruleFirstNode))
+						{
+							existingRule = styleRule.Value.Substring(indexSpace + 1 /*intentionally exclude the space*/);
+						}
+					}
+
+					styleRule.Value = uniquePath + existingRule;
+				}
+			}
 		}
 
 		public string GetStylesString()
@@ -200,16 +265,10 @@ namespace SIL.FieldWorks.XWorks
 			if (propStyleSheet.Styles.Contains("Normal"))
 				styles.AddRange(GenerateCssForWsSpanWithNormalStyle(propertyTable));
 
-			var entryBaseStyle = ConfiguredLcmGenerator.GetEntryStyle(model);
-			if (propStyleSheet.Styles.Contains(entryBaseStyle))
-				styles.AddRange(GenerateDictionaryNormalParagraphCss(propertyTable, entryBaseStyle));
-
 			if (propStyleSheet.Styles.Contains(LetterHeadingStyleName))
 			{
 				styles.AddRange(GenerateCssForWritingSystems(".letter", LetterHeadingStyleName, propertyTable));
 			}
-
-			styles.AddRange(GenerateDictionaryMinorParagraphCss(propertyTable, model));
 
 			return styles;
 		}
@@ -254,42 +313,6 @@ namespace SIL.FieldWorks.XWorks
 			styles.Add(defaultRule);
 			// Then generate the rules for all the writing system overrides
 			styles.AddRange(GenerateCssForWritingSystems("span", "Normal", propertyTable));
-			return styles;
-		}
-
-		private static List<StyleRule> GenerateDictionaryNormalParagraphCss(ReadOnlyPropertyTable propertyTable, string entryBaseStyle)
-		{
-			var styles = new List<StyleRule>();
-			var dictNormalRule = new StyleRule { Value = "div.entry" };
-			var dictNormalStyle = GenerateCssStyleFromLcmStyleSheet(entryBaseStyle, 0, propertyTable);
-			dictNormalRule.Declarations.Properties.AddRange(GetOnlyParagraphStyle(dictNormalStyle));
-			styles.Add(dictNormalRule);
-			// Then generate the rules for all the writing system overrides
-			styles.AddRange(GenerateCssForWritingSystems("div.entry span", entryBaseStyle, propertyTable));
-			return styles;
-		}
-
-		private static List<StyleRule> GenerateDictionaryMinorParagraphCss(ReadOnlyPropertyTable propertyTable, DictionaryConfigurationModel model)
-		{
-			var styles = new List<StyleRule>();
-			// Use the style set in all the parts following main entry, if no style is specified assume Dictionary-Minor
-			for (var i = 1; i < model.Parts.Count; ++i)
-			{
-				var minorEntryNode = model.Parts[i];
-				if (minorEntryNode.IsEnabled)
-				{
-					var styleName = minorEntryNode.Style;
-					if (string.IsNullOrEmpty(styleName))
-						styleName = DictionaryMinor;
-					var dictionaryMinorStyle = GenerateCssStyleFromLcmStyleSheet(styleName, 0, propertyTable);
-					var minorRule = new StyleRule { Value = string.Format("div.{0}", GetClassAttributeForConfig(minorEntryNode)) };
-					minorRule.Declarations.Properties.AddRange(GetOnlyParagraphStyle(dictionaryMinorStyle));
-					styles.Add(minorRule);
-					// Then generate the rules for all the writing system overrides
-					styles.AddRange(GenerateCssForWritingSystems(string.Format("div.{0} span", GetClassAttributeForConfig(minorEntryNode)), styleName, propertyTable));
-				}
-			}
-
 			return styles;
 		}
 
@@ -421,6 +444,7 @@ namespace SIL.FieldWorks.XWorks
 
 		private static List<StyleRule> GenerateCssForSenses(ConfigurableDictionaryNode configNode, DictionaryNodeSenseOptions senseOptions, ref string baseSelection, ReadOnlyPropertyTable propertyTable)
 		{
+			string baseSelectionOrig = baseSelection;
 			var styleRules = new List<StyleRule>();
 			var selectors = GenerateSelectorsFromNode(configNode, ref baseSelection, propertyTable.GetValue<LcmCache>("cache"), propertyTable);
 			// Insert '> .sensecontent' between '.*senses' and '.*sense' (where * could be 'referring', 'sub', or similar)
@@ -501,6 +525,13 @@ namespace SIL.FieldWorks.XWorks
 				if (!IsEmptyRule(senseContentRule))
 					styleRules.Add(senseContentRule);
 			}
+
+			// Add the ws specific styles.
+			if (!string.IsNullOrEmpty(configNode.Style))
+			{
+				styleRules.AddRange(GenerateCssForWritingSystems(baseSelectionOrig + " span", configNode.Style, propertyTable));
+			}
+
 			return styleRules;
 		}
 
@@ -607,7 +638,8 @@ namespace SIL.FieldWorks.XWorks
 
 		private static IEnumerable<StyleRule> RemoveBeforeAndAfterForNoteInParaRules(IEnumerable<StyleRule> rules)
 		{
-			return rules.Where(rule => rule.Value.Contains("~"));
+			// Return non-before/after rules and before/after rules that contains a '~'.
+			return rules.Where(rule => (!IsBeforeOrAfter(rule) || rule.Value.Contains("~")));
 		}
 
 		/// <summary>

--- a/Src/xWorks/DictionaryConfigurationDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationDlg.cs
@@ -214,7 +214,7 @@ namespace SIL.FieldWorks.XWorks
 			var topLevelClass = CssGenerator.GetClassAttributeForConfig(topLevelConfigNode);
 			foreach (var div in body.GetElementsByTagName("div"))
 			{
-				if (Equals(div.ParentElement, body) && div.GetAttribute("class") == topLevelClass)
+				if (Equals(div.ParentElement, body) && div.GetAttribute("class").StartsWith(topLevelClass))
 					elements.AddRange(FindMatchingSpans(selectedConfigNode, div, topLevelConfigNode, cache));
 			}
 			return elements;

--- a/Src/xWorks/xWorksTests/ConfiguredLcmUsfmGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/ConfiguredLcmUsfmGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace SIL.FieldWorks.XWorks
 	[TestFixture]
 	public class ConfiguredLcmUsfmGeneratorTests : MemoryOnlyBackendProviderRestoredForEachTestTestBase, IDisposable
 	{
-		private const string XPathToUSFMField = "/div[@class='lexentry']/span[@class='usfm-field']";
+		private const string XPathToUSFMField = "/div[@class='lexentry-1']/span[@class='usfm-field-1']";
 		private const string XPathToTitle = XPathToUSFMField + "/table/caption/span";
 		private const string XPathToRow = XPathToUSFMField + "/table/tbody/tr";
 		private const string XPathToCell = XPathToRow + "/td/span";

--- a/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorReversalTests.cs
+++ b/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorReversalTests.cs
@@ -120,21 +120,21 @@ namespace SIL.FieldWorks.XWorks
 			var entry = CreateInterestingEnglishReversalEntry();
 			//SUT
 			string result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings).ToString();
-			const string frenchLexForm = "/div[@class='reversalindexentry']/span[@class='reversalform']/span[@lang='en' and text()='ReversalForm']";
+			const string frenchLexForm = "/div[@class='reversalindexentry-1']/span[@class='reversalform-1']/span[@lang='en' and text()='ReversalForm']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(frenchLexForm, 1);
 		}
 
 		#region PrimareyEntryReferenceTests
 		// Xpath used by PrimaryEntryReference tests
-		private const string senseXpath = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']";
-		private const string entryRefsXpath = senseXpath + "/span[@class='mainentryrefs']";
+		private const string senseXpath = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']";
+		private const string entryRefsXpath = senseXpath + "/span[@class='mainentryrefs-1']";
 		private const string entryRefXpath = entryRefsXpath + "/span[@class='mainentryref']";
-		private const string entryRefTypeBit = "span[@class='entrytypes']/span[@class='entrytype']";
+		private const string entryRefTypeBit = "span[@class='entrytypes-1']/span[@class='entrytype']";
 		private const string entryRefTypeXpath = entryRefsXpath + "/" + entryRefTypeBit;
-		private const string primaryLexemeBit = "/span[@class='primarylexemes']/span[@class='primarylexeme']";
+		private const string primaryLexemeBit = "/span[@class='primarylexemes-1']/span[@class='primarylexeme']";
 		private const string primaryEntryXpath = entryRefXpath + primaryLexemeBit;
 		//private const string primaryEntryXpath = entryRefXpath + "/span[@class='primarylexemes']/span[@class='primarylexeme']";
-		private const string refHeadwordXpath = primaryEntryXpath + "/span[@class='headword']/span[@lang='fr']/a[text()='parole']";
+		private const string refHeadwordXpath = primaryEntryXpath + "/span[@class='headword-2']/span[@lang='fr']/a[text()='parole']";
 
 		[Test]
 		public void GenerateXHTMLForEntry_PrimaryEntryReferencesWork_ComplexFormOfEntry()
@@ -147,12 +147,12 @@ namespace SIL.FieldWorks.XWorks
 			CXGTests.CreateComplexForm(Cache, paroleEntry, sense.Owner as ILexEntry, true);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(reversalEntry, mainRevEntryNode, null, DefaultSettings).ToString();
-			const string headwordXpath = senseXpath + "/span[@class='headword']/span[@lang='fr']//a[text()='porte-parole']";
+			const string headwordXpath = senseXpath + "/span[@class='headword-1']/span[@lang='fr']//a[text()='porte-parole']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordXpath, 1);
-			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation']/span[@lang='en' and text()='comp. of']";
+			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation-1']/span[@lang='en' and text()='comp. of']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refTypeXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refHeadwordXpath, 1);
-			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='summDefn']";
+			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='summDefn']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(glossOrSummDefXpath, 1);
 		}
 
@@ -166,10 +166,10 @@ namespace SIL.FieldWorks.XWorks
 			CXGTests.CreateComplexForm(Cache, paroleEntry.SensesOS[0], sense.Owner as ILexEntry, true);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(reversalEntry, mainRevEntryNode, null, DefaultSettings).ToString();
-			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation']/span[@lang='en' and text()='comp. of']";
+			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation-1']/span[@lang='en' and text()='comp. of']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refTypeXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refHeadwordXpath, 1);
-			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='speech']";
+			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='speech']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(glossOrSummDefXpath, 1);
 		}
 
@@ -183,10 +183,10 @@ namespace SIL.FieldWorks.XWorks
 			CXGTests.CreateVariantForm(Cache, paroleEntry.SensesOS[0], variantEntry, "Spelling Variant");
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(reversalEntry, mainRevEntryNode, null, DefaultSettings).ToString();
-			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation']/span[@lang='en' and text()='sp. var. of']";
+			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation-1']/span[@lang='en' and text()='sp. var. of']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refTypeXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refHeadwordXpath, 1);
-			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='speech']";
+			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='speech']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(glossOrSummDefXpath, 1);
 		}
 
@@ -201,10 +201,10 @@ namespace SIL.FieldWorks.XWorks
 			CXGTests.CreateVariantForm(Cache, paroleEntry, variantEntry, "Spelling Variant");
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(reversalEntry, mainRevEntryNode, null, DefaultSettings).ToString();
-			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation']/span[@lang='en' and text()='sp. var. of']";
+			const string refTypeXpath = entryRefTypeXpath + "/span[@class='abbreviation-1']/span[@lang='en' and text()='sp. var. of']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refTypeXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(refHeadwordXpath, 1);
-			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='summDefn']";
+			const string glossOrSummDefXpath = primaryEntryXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='summDefn']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(glossOrSummDefXpath, 1);
 		}
 
@@ -229,10 +229,10 @@ namespace SIL.FieldWorks.XWorks
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(reversalEntry, mainRevEntryNode, null, DefaultSettings).ToString(); // SUT
 				var assertIt = AssertThatXmlIn.String(result);
 				assertIt.HasSpecifiedNumberOfMatchesForXpath(entryRefTypeXpath, 3); // should be one Complex Form Type and two Variant Types.
-				const string headwordBit = "/span[@class='headword']/span[@lang='fr']/a[text()='{1}']";
+				const string headwordBit = "/span[@class='headword-2']/span[@lang='fr']/a[text()='{1}']";
 				const string entryRefWithSiblingXpath = entryRefsXpath + "/span[@class='mainentryref' and preceding-sibling::";
 				const string typeAndHeadwordXpath = entryRefWithSiblingXpath
-					+ entryRefTypeBit + "/span[@class='abbreviation']/span[@lang='en' and text()='{0}']]" + primaryLexemeBit + headwordBit;
+					+ entryRefTypeBit + "/span[@class='abbreviation-1']/span[@lang='en' and text()='{0}']]" + primaryLexemeBit + headwordBit;
 				var adjacentHeadwordXpath = entryRefWithSiblingXpath
 					+ "span[@class='mainentryref']" + primaryLexemeBit + headwordBit.Replace("{1}", "{0}") + "]" + primaryLexemeBit + headwordBit;
 				// check for proper headings on each referenced headword
@@ -402,7 +402,7 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(rie, reversalNode, null, DefaultSettings).ToString();
-			var reversalFormDataPath = string.Format("/div[@class='reversalindexentry']/span[@class='reversalform']/span[text()='{0}']",
+			var reversalFormDataPath = string.Format("/div[@class='reversalindexentry-1']/span[@class='reversalform-1']/span[text()='{0}']",
 				TsStringUtils.Compose(rie.LongName));
 			var entryDataPath = string.Format("//span[text()='{0}']", entryHeadWord.get_NormalizedForm(FwNormalizationMode.knmNFC).Text);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(reversalFormDataPath, 1);
@@ -462,14 +462,14 @@ namespace SIL.FieldWorks.XWorks
 			AddSenseToReversaEntry(testEntry, "second gloss", m_wsEn, Cache);
 			//SUT
 			var xhtml = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings).ToString();
-			const string senseNumberOne = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
-			const string senseNumberTwo = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss']";
+			const string senseNumberOne = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
+			const string senseNumberTwo = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss']";
 			//This assert is dependent on the specific entry data created in CreateInterestingEnglishReversalEntry
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(senseNumberTwo, 1);
 
-			const string headwordOne = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword']/span[@lang='fr' and child::span[@lang='fr']/a[text()='1']]/span[@lang='fr' and a[text()='Citation']]";
-			const string headwordTwo = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword']/span[@lang='fr' and child::span[@lang='fr']/a[text()='2']]/span[@lang='fr' and a[text()='Citation']]";
+			const string headwordOne = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword-1']/span[@lang='fr' and child::span[@lang='fr']/a[text()='1']]/span[@lang='fr' and a[text()='Citation']]";
+			const string headwordTwo = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword-1']/span[@lang='fr' and child::span[@lang='fr']/a[text()='2']]/span[@lang='fr' and a[text()='Citation']]";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(headwordOne, 1);
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(headwordTwo, 1);
 		}
@@ -525,7 +525,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings).ToString();
 			// REVIEW (Hasso) 2016.03: we should probably do something about the leading space in the Sense Number Run, as it is currently in addition to the "between" space.
-			const string subSenseOneOne = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword']/span/span/a[text()='1.1']";
+			const string subSenseOneOne = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword-1']/span/span/a[text()='1.1']";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(subSenseOneOne, 1);
 		}
 
@@ -586,7 +586,7 @@ namespace SIL.FieldWorks.XWorks
 			var testEntry = CreateInterestingEnglishSubReversalEntryWithSubSense();
 			//SUT
 			var xhtml = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings).ToString();
-			const string subSenseOneOne = "/div[@class='reversalindexentry']/span[@class='subentries']/span[@class='subentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword']/span/span/a[text()='1.1']";
+			const string subSenseOneOne = "/div[@class='reversalindexentry-1']/span[@class='subentries-1']/span[@class='subentry']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='headword-1']/span/span/a[text()='1.1']";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(subSenseOneOne, 1);
 		}
 
@@ -706,8 +706,8 @@ namespace SIL.FieldWorks.XWorks
 			var xhtml = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 			// check that the sense gram info appears once before the rest of the sense information.
 			Assert.That(xhtml, Is.Not.Null.Or.Empty);
-			const string sharedGramInfo = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis']/span[@class='partofspeech']/span[@lang='en' and text()='n']";
-			const string separateGramInfo = "/div[@class='reversalindexentry']/span[@class='sensesrs']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='morphosyntaxanalysis']/span[@class='partofspeech']/span[@lang='en']";
+			const string sharedGramInfo = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis-1']/span[@class='partofspeech-1']/span[@lang='en' and text()='n']";
+			const string separateGramInfo = "/div[@class='reversalindexentry-1']/span[@class='sensesrs-1']/span[@class='sensecontent']/span[@class='sensesr']/span[@class='morphosyntaxanalysis-1']/span[@class='partofspeech-1']/span[@lang='en']";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(sharedGramInfo, 1);
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(separateGramInfo, 0);
 

--- a/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
@@ -167,7 +167,7 @@ namespace SIL.FieldWorks.XWorks
 			ConfiguredLcmGenerator.Init();
 		}
 
-		const string xpathThruSense = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']";
+		const string xpathThruSense = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']";
 		private const string TestVariantName = "Crazy Variant";
 
 		[Test]
@@ -190,7 +190,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, new ReadOnlyPropertyTable(m_propertyTable), false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string frenchHeadwordOfHeadwordTest = "/div[@class='lexentry']/span[@class='headword']/span[@lang='fr']/a[text()='HeadWordTest']";
+			const string frenchHeadwordOfHeadwordTest = "/div[@class='lexentry-1']/span[@class='headword-1']/span[@lang='fr']/a[text()='HeadWordTest']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(frenchHeadwordOfHeadwordTest, 1);
 		}
 
@@ -213,7 +213,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, new ReadOnlyPropertyTable(m_propertyTable), false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string invalidCharsHeadwordTest = "/div[@class='lexentry']/span[@class='headword']/span[text()='\u0fff\u0fff\u0fff']";
+			const string invalidCharsHeadwordTest = "/div[@class='lexentry-1']/span[@class='headword-1']/span[text()='\u0fff\u0fff\u0fff']";
 			// change Headword back to something legal so that we don't crash trying to save bad data into the cache.
 			AddHeadwordToEntry(entry, "notbadanymore", Cache.DefaultVernWs);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(invalidCharsHeadwordTest, 1);
@@ -280,7 +280,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, new ReadOnlyPropertyTable(m_propertyTable), false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string frenchLexForm = "/div[@class='lexentry']/span[@class='lexemeformoa']/span[@lang='fr']/a[text()='LexemeFormTest']";
+			const string frenchLexForm = "/div[@class='lexentry-1']/span[@class='lexemeformoa-1']/span[@lang='fr']/a[text()='LexemeFormTest']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(frenchLexForm, 1);
 		}
 
@@ -325,7 +325,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string hereLocation = "/div[@class='lexentry']/span[@class='pronunciations']/span[@class='pronunciation']/span[@class='location']/span[@class='name']/span[@lang='fr' and text()='Here!']";
+			const string hereLocation = "/div[@class='lexentry-1']/span[@class='pronunciations-1']/span[@class='pronunciation']/span[@class='location-1']/span[@class='name-1']/span[@lang='fr' and text()='Here!']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(hereLocation, 1);
 		}
 
@@ -393,13 +393,14 @@ namespace SIL.FieldWorks.XWorks
 
 			const string movieCameraChar = "\U0001f3a5";
 			const string movieCamSearch = "/a/text()['" + movieCameraChar + "']";
-			const string entryPart = "/div[@class='lexentry']";
-			const string pronunciationsPart = "/span[@class='pronunciations']/span[@class='pronunciation']";
-			const string mediaFilePart = "/span[@class='mediafiles']/span[@class='mediafile']";
-			const string mediaFileAnchor1 = entryPart + pronunciationsPart + mediaFilePart + movieCamSearch;
-			const string variantsPart = "/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']";
-			const string varPronPart = "/span[@class='variantpronunciations']/span[@class='variantpronunciation']";
-			const string mediaFileAnchor2 = entryPart + variantsPart + varPronPart + mediaFilePart + movieCamSearch;
+			const string entryPart = "/div[@class='lexentry-1']";
+			const string pronunciationsPart = "/span[@class='pronunciations-1']/span[@class='pronunciation']";
+			const string mediaFilePart1 = "/span[@class='mediafiles-1']/span[@class='mediafile']";
+			const string mediaFileAnchor1 = entryPart + pronunciationsPart + mediaFilePart1 + movieCamSearch;
+			const string variantsPart = "/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']";
+			const string varPronPart = "/span[@class='variantpronunciations-1']/span[@class='variantpronunciation']";
+			const string mediaFilePart2 = "/span[@class='mediafiles-2']/span[@class='mediafile']";
+			const string mediaFileAnchor2 = entryPart + variantsPart + varPronPart + mediaFilePart2 + movieCamSearch;
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
@@ -482,9 +483,9 @@ namespace SIL.FieldWorks.XWorks
 			XHTMLStringBuilder.Append(result);
 			XHTMLStringBuilder.AppendLine("</TESTWRAPPER>");
 
-			var entryWithHomograph = "/TESTWRAPPER/div[@class='lexentry']/span[@class='homographnumber' and text()='1']";
+			var entryWithHomograph = "/TESTWRAPPER/div[@class='lexentry-1']/span[@class='homographnumber-1' and text()='1']";
 			AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(entryWithHomograph, 1);
-			entryWithHomograph = entryWithHomograph.Replace('1', '2');
+			entryWithHomograph = "/TESTWRAPPER/div[@class='lexentry-1']/span[@class='homographnumber-1' and text()='2']";
 			AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(entryWithHomograph, 1);
 		}
 
@@ -585,9 +586,9 @@ namespace SIL.FieldWorks.XWorks
 			XHTMLStringBuilder.Append(result);
 			XHTMLStringBuilder.AppendLine("</TESTWRAPPER>");
 			result = XHTMLStringBuilder.ToString();
-			var entryOneHasSensesSpan = "/TESTWRAPPER/div[@class='lexentry' and @id='g" + entryOneId + "']/span[@class='senses']";
-			var entryTwoExists = "/TESTWRAPPER/div[@class='lexentry' and @id='g" + entryTwoId + "']";
-			var entryTwoHasNoSensesSpan = "/TESTWRAPPER/div[@class='lexentry' and @id='g" + entryTwoId + "']/span[@class='senses']";
+			var entryOneHasSensesSpan = "/TESTWRAPPER/div[@class='lexentry-1' and @id='g" + entryOneId + "']/span[@class='senses-1']";
+			var entryTwoExists = "/TESTWRAPPER/div[@class='lexentry-1' and @id='g" + entryTwoId + "']";
+			var entryTwoHasNoSensesSpan = "/TESTWRAPPER/div[@class='lexentry-1' and @id='g" + entryTwoId + "']/span[@class='senses-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(entryOneHasSensesSpan, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(entryTwoExists, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(entryTwoHasNoSensesSpan, 0);
@@ -603,7 +604,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, dictionaryModel.Parts[0], DefaultDecorator, settings).ToString();
-			var entryExists = "/div[@class='entry' and @id='g" + entry.Guid + "']";
+			var entryExists = "/div[@class='entry-1' and @id='g" + entry.Guid + "']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(entryExists, 1);
 		}
 
@@ -640,8 +641,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string sensesThatShouldNotBe = "/div[@class='entry']/span[@class='senses']";
-			const string headwordThatShouldNotBe = "//span[@class='gloss']";
+			const string sensesThatShouldNotBe = "/div[@class='entry-1']/span[@class='senses-1']";
+			const string headwordThatShouldNotBe = "//span[@class='gloss-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(sensesThatShouldNotBe, 0);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordThatShouldNotBe, 0);
 		}
@@ -729,8 +730,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var xhtmlString = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string sharedGramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sharedgrammaticalinfo']";
-			const string gramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas']/span[@class='mlpartofspeech']";
+			const string sharedGramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sharedgrammaticalinfo']";
+			const string gramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas-1']/span[@class='mlpartofspeech-1']";
 			AssertThatXmlIn.String(xhtmlString).HasNoMatchForXpath(gramInfoPath);
 			AssertThatXmlIn.String(xhtmlString).HasSpecifiedNumberOfMatchesForXpath(sharedGramInfoPath, 1);
 		}
@@ -814,8 +815,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var xhtmlString = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, mainDictionaryDecorator, settings).ToString();
-			const string sharedGramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sharedgrammaticalinfo']";
-			const string gramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='msa']/span[@class='mlpartofspeech']";
+			const string sharedGramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sharedgrammaticalinfo']";
+			const string gramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='msa']/span[@class='mlpartofspeech-1']";
 			AssertThatXmlIn.String(xhtmlString).HasNoMatchForXpath(gramInfoPath);
 			AssertThatXmlIn.String(xhtmlString).HasSpecifiedNumberOfMatchesForXpath(sharedGramInfoPath, 1);
 		}
@@ -879,8 +880,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var xhtmlString = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string sharedGramInfoPath = "//div[@class='lexentry']/span[@class='sensesos']/span[@class='sharedgrammaticalinfo']";
-			const string gramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas']/span[@class='mlpartofspeech']";
+			const string sharedGramInfoPath = "//div[@class='lexentry-1']/span[@class='sensesos']/span[@class='sharedgrammaticalinfo']";
+			const string gramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas-1']/span[@class='mlpartofspeech-1']";
 			AssertThatXmlIn.String(xhtmlString).HasSpecifiedNumberOfMatchesForXpath(gramInfoPath, 2);
 			AssertThatXmlIn.String(xhtmlString).HasNoMatchForXpath(sharedGramInfoPath);
 		}
@@ -928,8 +929,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var xhtmlString = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string sharedGramInfoPath = "//div[@class='lexentry']/span[@class='sensesos']/span[@class='sharedgrammaticalinfo']";
-			const string gramInfoPath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas']/span[@class='mlpartofspeech']";
+			const string sharedGramInfoPath = "//div[@class='lexentry-1']/span[@class='sensesos']/span[@class='sharedgrammaticalinfo']";
+			const string gramInfoPath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='msas-1']/span[@class='mlpartofspeech-1']";
 			AssertThatXmlIn.String(xhtmlString).HasNoMatchForXpath(gramInfoPath);
 			AssertThatXmlIn.String(xhtmlString).HasNoMatchForXpath(sharedGramInfoPath);
 		}
@@ -988,7 +989,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string morphTypePath = "//span[@class='morphosyntaxanalysis']/span[@class='morphtypes']/span[@class='morphtype']/span[@class='abbreviation']/span[@lang='en' and text()='sfx']";
+			const string morphTypePath = "//span[@class='morphosyntaxanalysis-1']/span[@class='morphtypes-1']/span[@class='morphtype']/span[@class='abbreviation-1']/span[@lang='en' and text()='sfx']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(morphTypePath, 1);
 		}
 
@@ -1028,7 +1029,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis']";
+			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramInfoPath, 1);
 		}
 
@@ -1079,7 +1080,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis']";
+			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramInfoPath, 0);
 		}
 
@@ -1113,7 +1114,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis']";
+			const string gramInfoPath = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramInfoPath, 0);
 		}
 
@@ -1204,10 +1205,10 @@ namespace SIL.FieldWorks.XWorks
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
 
-			const string gramAbbr1 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearabbrtss']/span[@lang='fr']/span[@lang='fr' and text()='Blah']";
-			const string gramAbbr2 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearabbrtss']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
-			const string gramName1 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearnametss']/span[@lang='fr']/span[@lang='fr' and text()='Blah']";
-			const string gramName2 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearnametss']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
+			const string gramAbbr1 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearabbrtss-1']/span[@lang='fr']/span[@lang='fr' and text()='Blah']";
+			const string gramAbbr2 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearabbrtss-1']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
+			const string gramName1 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearnametss-1']/span[@lang='fr']/span[@lang='fr' and text()='Blah']";
+			const string gramName2 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearnametss-1']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramAbbr1, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramAbbr2, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramName1, 1);
@@ -1267,10 +1268,10 @@ namespace SIL.FieldWorks.XWorks
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
 
-			const string gramAbbr1 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearabbrtss']/span[@lang='fr']/span[@lang='fr' and text()='<Not Sure>']";
-			const string gramAbbr2 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearabbrtss']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
-			const string gramName1 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearnametss']/span[@lang='fr']/span[@lang='fr' and text()='<Not Sure>']";
-			const string gramName2 = xpathThruSense + "/span[@class='morphosyntaxanalysis']/span[@class='interlinearnametss']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
+			const string gramAbbr1 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearabbrtss-1']/span[@lang='fr']/span[@lang='fr' and text()='<Not Sure>']";
+			const string gramAbbr2 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearabbrtss-1']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
+			const string gramName1 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearnametss-1']/span[@lang='fr']/span[@lang='fr' and text()='<Not Sure>']";
+			const string gramName2 = xpathThruSense + "/span[@class='morphosyntaxanalysis-1']/span[@class='interlinearnametss-1']/span[@lang='fr']/span[@lang='en' and text()=':Any']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramAbbr1, 0);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramAbbr2, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(gramName1, 0);
@@ -1315,7 +1316,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string captionOrHeadwordContainsCaption = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[text()='captionEn']";
+			const string captionOrHeadwordContainsCaption = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[text()='captionEn']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(captionOrHeadwordContainsCaption, 1);
 		}
@@ -1358,7 +1359,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string captionOrHeadwordContainsHeadword = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[text()='HeadwordEn']";
+			const string captionOrHeadwordContainsHeadword = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[text()='HeadwordEn']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(captionOrHeadwordContainsHeadword, 1);
 		}
@@ -1402,8 +1403,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string captionOrHeadwordContainsCaptionEn = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[@lang='en' and text()='captionEn']";
-			const string captionOrHeadwordContainsHeadwordFr = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[@lang='fr' and text()='HeadwordFr']";
+			const string captionOrHeadwordContainsCaptionEn = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[@lang='en' and text()='captionEn']";
+			const string captionOrHeadwordContainsHeadwordFr = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='captionorheadword']//span[@lang='fr' and text()='HeadwordFr']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(captionOrHeadwordContainsCaptionEn, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(captionOrHeadwordContainsHeadwordFr, 1);
@@ -1433,7 +1434,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string senseWithdefinitionOrGloss = "//span[@class='sense']/span[@class='definitionorgloss']/span[text()='gloss']";
+			const string senseWithdefinitionOrGloss = "//span[@class='sense']/span[@class='definitionorgloss-1']/span[text()='gloss']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithdefinitionOrGloss, 1);
 		}
 
@@ -1464,7 +1465,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
 			const string senseWithdefinitionOrGloss =
-				"//span[@class='sense']/span[@class='definitionorgloss']/span[@class='writingsystemprefix' and normalize-space(text())='Eng']";
+				"//span[@class='sense']/span[@class='definitionorgloss-1']/span[@class='writingsystemprefix' and normalize-space(text())='Eng']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithdefinitionOrGloss, 1);
 		}
 
@@ -1492,7 +1493,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string senseWithdefinitionOrGlossTwoWs = "//span[@class='sense']/span[@class='definitionorgloss' and span[1]='gloss' and span[2]='definition']";
+			const string senseWithdefinitionOrGlossTwoWs = "//span[@class='sense']/span[@class='definitionorgloss-1' and span[1]='gloss' and span[2]='definition']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithdefinitionOrGlossTwoWs, 1);
 		}
 
@@ -1555,17 +1556,17 @@ namespace SIL.FieldWorks.XWorks
 			// set of xpaths and required number of matches.
 			var checkthis = new Dictionary<string, int>()
 				{
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='definitionA1']", 1 },
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='definitionA2']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='definitionA1']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='definitionA2']", 1 },
 
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='glossB1']", 1 },
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='glossB2']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='glossB1']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='glossB2']", 1 },
 
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='definitionC1']", 1 },
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='glossC2']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='definitionC1']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='glossC2']", 1 },
 
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='glossD1']", 1 },
-					{ "/div/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss']/span[.='definitionD2']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='glossD1']", 1 },
+					{ "/div/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='definitionorgloss-1']/span[.='definitionD2']", 1 },
 				};
 			foreach (var thing in checkthis)
 			{
@@ -1625,10 +1626,10 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='complexformsnotsubentries']/span[@class='complexformtypes']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
+				"//span[@class='complexformsnotsubentries-1']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
 					complexRefAbbr);
 			var revNameXpath = string.Format(
-				"//span[@class='complexformsnotsubentries']/span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='reverseabbr']/span[@lang='en' and text()='{0}']",
+				"//span[@class='complexformsnotsubentries-1']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='reverseabbr-1']/span[@lang='en' and text()='{0}']",
 					complexRefRevAbbr);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(fwdNameXpath);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
@@ -1661,7 +1662,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string senseWithHyphenSuffix = "//span[@class='senses_test-one']/span[@class='sense_test-one']";
+			const string senseWithHyphenSuffix = "//span[@class='senses_test-one-1']/span[@class='sense_test-one']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithHyphenSuffix, 1);
 		}
 
@@ -1692,7 +1693,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string senseWithHyphenSuffix = "//span[@class='senses_-test']/span[@class='sense_-test']";
+			const string senseWithHyphenSuffix = "//span[@class='senses_-test-1']/span[@class='sense_-test']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithHyphenSuffix, 1);
 		}
 
@@ -1723,7 +1724,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string senseWithHyphenSuffix = "//span[@class='senses_-test-']/span[@class='sense_-test-']";
+			const string senseWithHyphenSuffix = "//span[@class='senses_-test--1']/span[@class='sense_-test-']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseWithHyphenSuffix, 1);
 		}
 
@@ -1782,7 +1783,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			var headwordMatch = string.Format("//span[@class='{0}']//span[@class='{1}']/span[text()='{2}']",
+			var headwordMatch = string.Format("//span[@class='{0}-1']//span[@class='{1}-1']/span[text()='{2}']",
 				nters, headWord, entryThreeForm);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordMatch, 1);
 		}
@@ -1836,9 +1837,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, settings).ToString();
-			const string etymologyWithArabicSrcLanguage = "//span[@class='etymologies']/span[@class='etymology']/span[@class='languages']/span[@class='language']/span[@class='abbreviation']/span[@lang='en' and text()='ar']";
+			const string etymologyWithArabicSrcLanguage = "//span[@class='etymologies-1']/span[@class='etymology']/span[@class='languages-1']/span[@class='language']/span[@class='abbreviation-1']/span[@lang='en' and text()='ar']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(etymologyWithArabicSrcLanguage, 1);
-			const string etymologyWithGeorgianNotes = "//span[@class='etymologies']/span[@class='etymology']/span[@class='languagenotes']/span[@lang='en' and text()='Georgian']";
+			const string etymologyWithGeorgianNotes = "//span[@class='etymologies-1']/span[@class='etymology']/span[@class='languagenotes-1']/span[@lang='en' and text()='Georgian']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(etymologyWithGeorgianNotes, 1);
 		}
 
@@ -1859,7 +1860,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(mainEntry, configModel, DefaultDecorator, m_propertyTable);
 				// this test relies on specific test data from CreateInterestingConfigurationModel
-				const string xpath = "/html[@dir='rtl']/body[@dir='rtl']/div[@class='lexentry']/span[@class='entry']";
+				const string xpath = "/html[@dir='rtl']/body[@dir='rtl']/div[@class='lexentry-1']/span[@class='entry-1']";
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(xpath, 1);
 			}
 			finally
@@ -1883,7 +1884,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(minorEntry, configModel, DefaultDecorator, m_propertyTable);
 			// this test relies on specific test data from CreateInterestingConfigurationModel
-			const string xpath = "/html/body/div[@class='minorentry']/span[@class='entry']";
+			const string xpath = "/html/body/div[@class='minorentry-1']/span[@class='entry-1']";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(xpath, 1);
 		}
 
@@ -1900,7 +1901,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(minorEntry, configModel, DefaultDecorator, m_propertyTable);
 			// this test relies on specific test data from CreateInterestingConfigurationModel
-			const string xpath = "/html/body/div[@class='minorentry']/span[@class='entry']";
+			const string xpath = "/html/body/div[@class='minorentry-1']/span[@class='entry-1']";
 			// only the variant is selected, so the other minor entry should not have been generated
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(xpath, 0);
 		}
@@ -1917,7 +1918,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(minorEntry, configModel, DefaultDecorator, m_propertyTable);
 			// this test relies on specific test data from CreateInterestingConfigurationModel
-			const string xpath = "/div[@class='minorentry']/span[@class='entry']";
+			const string xpath = "/div[@class='minorentry-1']/span[@class='entry-1']";
 			AssertThatXmlIn.String(xhtml).HasNoMatchForXpath(xpath);
 		}
 
@@ -1939,7 +1940,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(minorEntry, configModel, DefaultDecorator, m_propertyTable);
 			// this test relies on specific test data from CreateInterestingConfigurationModel
-			const string xpath = "/html/body/div[@class='minorentry']/span[@class='entry']";
+			const string xpath = "/html/body/div[@class='minorentry-1']/span[@class='entry-1']";
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(xpath, 1);
 		}
 
@@ -1958,7 +1959,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var xhtml = LcmXhtmlGenerator.GenerateEntryHtmlWithStyles(complexEntry, configModel, DefaultDecorator, m_propertyTable);
 			// this test relies on specific test data from CreateInterestingConfigurationModel
-			const string xpath = "/html/body/div[@class='minorentry']/span[@class='entry']";
+			const string xpath = "/html/body/div[@class='minorentry-1']/span[@class='entry-1']";
 			// only the variant is selected, so the other minor entry should not have been generated
 			AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(xpath, 0);
 		}
@@ -2009,8 +2010,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			string senseNumberOne = $"/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and @lang='{homographWs}' and text()='1']]//span[@lang='en' and text()='gloss']";
-			string senseNumberTwo = $"/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and @lang='{homographWs}' and  text()='2']]//span[@lang='en' and text()='second gloss']";
+			string senseNumberOne = $"/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and @lang='{homographWs}' and text()='1']]//span[@lang='en' and text()='gloss']";
+			string senseNumberTwo = $"/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and @lang='{homographWs}' and  text()='2']]//span[@lang='en' and text()='second gloss']";
 			string senseNumberTen = $"//span[@class='sensecontent']/spansenses/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and @lang='{homographWs}' and  text()='{tenthSenseNumber}']]//span[@lang='en' and text()='10']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
@@ -2171,7 +2172,7 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(testEntry.AllSenses.First().AllSenses.Count, Is.EqualTo(1), "Test not set up correctly. There should be no subsenses.");
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]/span[@lang='en' and text()='gloss']";
+			const string senseNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]/span[@lang='en' and text()='gloss']";
 			// This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(senseNumberOne);
 
@@ -2239,7 +2240,7 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(testEntry.AllSenses.First().AllSenses.Count, Is.EqualTo(3), "Test not set up correctly.");
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberXpath = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sensenumber']";
+			const string senseNumberXpath = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sensenumber']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(senseNumberXpath); // Should not have a sense number on top sense.
 
 			// Piggy-back a test for ShouldThisSenseBeNumbered
@@ -2306,7 +2307,7 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(testEntry.AllSenses.First().AllSenses.Count, Is.EqualTo(3), "Test not set up correctly.");
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberXpath = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sensenumber']";
+			const string senseNumberXpath = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sensenumber']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(senseNumberXpath); // Should not have a sense number on top sense.
 
 			// Piggy-back a test for ShouldThisSenseBeNumbered
@@ -2373,7 +2374,7 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(testEntry.AllSenses.First().AllSenses.Count, Is.EqualTo(3), "Test not set up correctly.");
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberXpath = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sensenumber']";
+			const string senseNumberXpath = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sensenumber']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberXpath, 1); // Should have sense number on top sense.
 
 			// Piggy-back a test for ShouldThisSenseBeNumbered
@@ -2423,7 +2424,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string SenseOneSubSense = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]/span[@class='senses']/span[@class='sensecontent']//span[@lang='en' and text()='gloss1.1']";
+			const string SenseOneSubSense = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]/span[@class='senses-2']/span[@class='sensecontent']//span[@lang='en' and text()='gloss1.1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(SenseOneSubSense, 1);
 		}
 
@@ -2480,10 +2481,10 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]//span[@lang='en' and text()='gloss']";
-			const string senseNumberTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='B']]//span[@lang='en' and text()='second gloss']";
-			const string subSensesNumberTwoOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='I']]//span[@lang='en' and text()='second gloss2.1']";
-			const string subSenseNumberTwoTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='II']]//span[@lang='en' and text()='second gloss2.2']";
+			const string senseNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]//span[@lang='en' and text()='gloss']";
+			const string senseNumberTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='B']]//span[@lang='en' and text()='second gloss']";
+			const string subSensesNumberTwoOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='I']]//span[@lang='en' and text()='second gloss2.1']";
+			const string subSenseNumberTwoTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='II']]//span[@lang='en' and text()='second gloss2.2']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberTwo, 1);
@@ -2545,10 +2546,10 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]//span[@lang='en' and text()='gloss']";
-			const string senseNumberTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='B']]//span[@lang='en' and text()='second gloss']";
-			const string subSensesNumberTwoOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
-			const string subSenseNumberTwoTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
+			const string senseNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]//span[@lang='en' and text()='gloss']";
+			const string senseNumberTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='B']]//span[@lang='en' and text()='second gloss']";
+			const string subSensesNumberTwoOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
+			const string subSenseNumberTwoTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberTwo, 1);
@@ -2597,7 +2598,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberXpath = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sensenumber']";
+			const string senseNumberXpath = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sensenumber']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberXpath, 0); // Should not have produced sense number if style said not to number it.
 
 			// Piggy-back a test for ShouldThisSenseBeNumbered
@@ -2657,8 +2658,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string subSensesNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
-			const string subSenseNumberTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
+			const string subSensesNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
+			const string subSenseNumberTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(subSensesNumberOne, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(subSenseNumberTwo, 1);
@@ -2699,10 +2700,10 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
-			const string senseNumberTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss']";
-			const string subSensesNumberTwoOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
-			const string subSenseNumberTwoTwo = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
+			const string senseNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
+			const string senseNumberTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss']";
+			const string subSensesNumberTwoOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='second gloss2.1']";
+			const string subSenseNumberTwoTwo = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]//span[@lang='en' and text()='second gloss2.2']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberTwo, 1);
@@ -2754,9 +2755,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
-			const string subSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2a']]";
-			const string subSubSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2aA']]";
+			const string senseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
+			const string subSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2a']]";
+			const string subSubSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-3']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2aA']]";
 
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumber, 1);
@@ -2808,9 +2809,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
-			const string subSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2.a']]";
-			const string subSubSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2.a.A']]";
+			const string senseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
+			const string subSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2.a']]";
+			const string subSubSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-3']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2.a.A']]";
 
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumber, 1);
@@ -2862,9 +2863,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
-			const string subSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='a']]";
-			const string subSubSenseNumber = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]";
+			const string senseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='2']]";
+			const string subSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='a']]";
+			const string subSubSenseNumber = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-3']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='A']]";
 
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumber, 1);
@@ -2986,13 +2987,13 @@ namespace SIL.FieldWorks.XWorks
 				xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new[] { firstEntry.Hvo }, pubEverything, model, m_propertyTable);
 				var xhtml = File.ReadAllText(xhtmlPath);
 				// SUT
-				const string gramInfoPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='n']";
+				const string gramInfoPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis-1']/span[@class='mlpartofspeech-1']/span[@lang='en' and text()='n']";
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(gramInfoPath, 1);
 
-				const string senseNumberPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[2][@class='sensecontent']/span[@class='sensenumber' and text()='1']";
+				const string senseNumberPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[2][@class='sensecontent']/span[@class='sensenumber' and text()='1']";
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(senseNumberPath, 1);
 
-				const string senseTextPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[2][@class='sensecontent']/span[@class='sense']/span[@class='gloss']/span[@lang='en' and text()='man']";
+				const string senseTextPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[2][@class='sensecontent']/span[@class='sense']/span[@class='gloss-1']/span[@lang='en' and text()='man']";
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(senseTextPath, 1);
 			}
 			finally
@@ -3098,9 +3099,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, settings).ToString();
-			const string senseContent = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']";
+			const string senseContent = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']";
 			const string senseNumberOne = senseContent + "/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
-			const string subentrySenseContent = senseContent + "/span[@class='sense']/span[@class='subentries']/span[@class='subentry']/span[@class='senses']/span[@class='sensecontent']";
+			const string subentrySenseContent = senseContent + "/span[@class='sense']/span[@class='subentries-1']/span[@class='subentry']/span[@class='senses-2']/span[@class='sensecontent']";
 			const string subentrySenseNumberOne = subentrySenseContent + "/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='subgloss']";
 			const string subentrySenseNumberOneOne = subentrySenseContent + "/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1.1']]//span[@lang='en']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
@@ -3138,7 +3139,7 @@ namespace SIL.FieldWorks.XWorks
 
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, DefaultSettings).ToString();
-			const string senseNumberOne = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
+			const string senseNumberOne = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and preceding-sibling::span[@class='sensenumber' and text()='1']]//span[@lang='en' and text()='gloss']";
 			// This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseNumberOne, 1);
 
@@ -3168,10 +3169,10 @@ namespace SIL.FieldWorks.XWorks
 
 			// SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, DefaultSettings).ToString();
-			const string senseEntryGuid = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and @entryguid]";
+			const string senseEntryGuid = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and @entryguid]";
 			// This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseEntryGuid, 1);
-			string senseEntryGuidstatsWithG = "/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense' and @entryguid='g" + testEntry.Guid + "']";
+			string senseEntryGuidstatsWithG = "/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense' and @entryguid='g" + testEntry.Guid + "']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseEntryGuidstatsWithG, 1);
 		}
 
@@ -3221,11 +3222,11 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings).ToString();
-			const string xpathThruExample = xpathThruSense + "/span[@class='examplescontents']/span[@class='examplescontent']";
-			var oneSenseWithExample = string.Format(xpathThruExample + "/span[@class='example']/span[@lang='fr' and text()='{0}']", example);
+			const string xpathThruExample = xpathThruSense + "/span[@class='examplescontents-1']/span[@class='examplescontent']";
+			var oneSenseWithExample = string.Format(xpathThruExample + "/span[@class='example-1']/span[@lang='fr' and text()='{0}']", example);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithExample, 1);
 			var oneExampleSentenceTranslation = string.Format(xpathThruExample +
-				"/span[@class='translationcontents']/span[@class='translationcontent']/span[@class='translation']/span[@lang='en' and text()='{0}']", translation);
+				"/span[@class='translationcontents-1']/span[@class='translationcontent']/span[@class='translation-1']/span[@lang='en' and text()='{0}']", translation);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneExampleSentenceTranslation, 1);
 		}
 
@@ -3275,11 +3276,11 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
-			const string xpathThruExampleSentence = "/div[@class='lexentry']/span[@class='complexformsnotsubentries']/span[@class='complexformsnotsubentry']/span[@class='examplesentences']/span[@class='examplesentence']";
+			const string xpathThruExampleSentence = "/div[@class='lexentry-1']/span[@class='complexformsnotsubentries-1']/span[@class='complexformsnotsubentry']/span[@class='examplesentences-1']/span[@class='examplesentence']";
 			var oneSenseWithExample = string.Format(xpathThruExampleSentence + "//span[@lang='fr' and text()='{0}']", example);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithExample, 1);
 			var oneExampleSentenceTranslation = string.Format(
-				xpathThruExampleSentence + "/span[@class='translations']/span[@class='translation']//span[@lang='en' and text()='{0}']", translation);
+				xpathThruExampleSentence + "/span[@class='translations-1']/span[@class='translation']//span[@lang='en' and text()='{0}']", translation);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneExampleSentenceTranslation, 1);
 		}
 
@@ -3329,11 +3330,11 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
-			const string xpathThruExampleSentence = "/div[@class='lexentry']/span[@class='complexformsnotsubentries']/span[@class='complexformsnotsubentry']/span[@class='examplesentences']/span[@class='examplesentence']";
+			const string xpathThruExampleSentence = "/div[@class='lexentry-1']/span[@class='complexformsnotsubentries-1']/span[@class='complexformsnotsubentry']/span[@class='examplesentences-1']/span[@class='examplesentence']";
 			var oneSenseWithExample = string.Format(xpathThruExampleSentence + "//span[@lang='fr']//br");
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithExample, 1);
 			var oneExampleSentenceTranslation = string.Format(
-				xpathThruExampleSentence + "/span[@class='translations']/span[@class='translation']//span[@lang='en']//br");
+				xpathThruExampleSentence + "/span[@class='translations-1']/span[@class='translation']//span[@lang='en']//br");
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneExampleSentenceTranslation, 1);
 		}
 
@@ -3405,18 +3406,18 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 
-			const string extendedNote = xpathThruSense + "/span[@class='extendednotecontents']/span[@class='extendednotecontent']";
-			var xpathThruNoteType = string.Format(extendedNote + "/span[@class='extendednotetypera_name']/span[@lang='en' and text()='{0}']", noteType);
+			const string extendedNote = xpathThruSense + "/span[@class='extendednotecontents-1']/span[@class='extendednotecontent']";
+			var xpathThruNoteType = string.Format(extendedNote + "/span[@class='extendednotetypera_name-1']/span[@lang='en' and text()='{0}']", noteType);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(xpathThruNoteType, 1);
 
-			var xpathThruDiscussion = string.Format(extendedNote + "/span[@class='discussion']/span[@lang='fr' and text()='{0}']", discussion);
+			var xpathThruDiscussion = string.Format(extendedNote + "/span[@class='discussion-1']/span[@lang='fr' and text()='{0}']", discussion);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(xpathThruDiscussion, 1);
 
-			const string xpathThruExample = extendedNote + "/span[@class='examples']/span[@class='example']";
-			var oneSenseWithExample = string.Format(xpathThruExample + "/span[@class='example']/span[@lang='fr' and text()='{0}']", example);
+			const string xpathThruExample = extendedNote + "/span[@class='examples-1']/span[@class='example']";
+			var oneSenseWithExample = string.Format(xpathThruExample + "/span[@class='example-1']/span[@lang='fr' and text()='{0}']", example);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithExample, 1);
 			var oneExampleSentenceTranslation = string.Format(
-				xpathThruExample + "/span[@class='translations']/span[@class='translation']/span[@class='translation']/span[@lang='en' and text()='{0}']", translation);
+				xpathThruExample + "/span[@class='translations-1']/span[@class='translation']/span[@class='translation-1']/span[@lang='en' and text()='{0}']", translation);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneExampleSentenceTranslation, 1);
 		}
 
@@ -3487,8 +3488,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 
-			const string extendedNote = xpathThruSense + "/span[@class='extendednotecontents']/span[@class='extendednotecontent']";
-			var xpathThruNoteType = string.Format(extendedNote + "/span[@class='extendednotetypera_name']/span[@lang='en' and text()='{0}']", noteType);
+			const string extendedNote = xpathThruSense + "/span[@class='extendednotecontents-1']/span[@class='extendednotecontent']";
+			var xpathThruNoteType = string.Format(extendedNote + "/span[@class='extendednotetypera_name-1']/span[@lang='en' and text()='{0}']", noteType);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(xpathThruNoteType, 0);
 		}
 
@@ -3562,11 +3563,11 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
-			const string xPathThruAllomorph = "/div[@class='lexentry']/span[@class='alternateformsos']/span[@class='alternateformso']";
+			const string xPathThruAllomorph = "/div[@class='lexentry-1']/span[@class='alternateformsos-1']/span[@class='alternateformso']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				xPathThruAllomorph + "/span[@class='form']/span[@lang='fr' and text()='Allomorph']", 1);
+				xPathThruAllomorph + "/span[@class='form-1']/span[@lang='fr' and text()='Allomorph']", 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(xPathThruAllomorph +
-				"/span[@class='allomorphenvironments']/span[@class='allomorphenvironment']/span[@class='stringrepresentation']/span[@lang='en' and text()='phoneyEnv']", 1);
+				"/span[@class='allomorphenvironments-1']/span[@class='allomorphenvironment']/span[@class='stringrepresentation-1']/span[@lang='en' and text()='phoneyEnv']", 1);
 		}
 
 		[Test]
@@ -3600,7 +3601,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"/div[@class='lexentry']/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']//span[@lang='fr']/span[@lang='fr']", 4);
+				"/div[@class='lexentry-1']/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']//span[@lang='fr']/span[@lang='fr']", 4);
 		}
 
 		[Test]
@@ -3652,9 +3653,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"//span[@class='visiblevariantentryrefs']/span[@class='visiblevariantentryref']/span[@class='referencedentries']/span[@class='referencedentry']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]", 2);
+				"//span[@class='visiblevariantentryrefs-1']/span[@class='visiblevariantentryref']/span[@class='referencedentries-1']/span[@class='referencedentry']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']/a[@href]", 2);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"/div[@class='lexentry']/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]", 2);
+				"/div[@class='lexentry-1']/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='headword-2']/span[@lang='fr']/span[@lang='fr']/a[@href]", 2);
 		}
 
 		[Test]
@@ -3751,9 +3752,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(otherMainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='primaryentryrefs']/span[@class='primaryentryref']/span[@class='referencedentries']/span[@class='referencedentry']/span[@class='headword']/span[@lang='fr']/a[@href]", 1);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='primaryentryrefs-1']/span[@class='primaryentryref']/span[@class='referencedentries-1']/span[@class='referencedentry']/span[@class='headword-1']/span[@lang='fr']/a[@href]", 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='primaryentryrefs']/span[@class='primaryentryref']/span[@class='referencedentries']/span[@class='referencedentry']/span[@class='headword']/span[@lang='fr']/a[@href][contains(text(), 'Test')]", 1);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='primaryentryrefs-1']/span[@class='primaryentryref']/span[@class='referencedentries-1']/span[@class='referencedentry']/span[@class='headword-1']/span[@lang='fr']/a[@href][contains(text(), 'Test')]", 1);
 		}
 
 		[Test]
@@ -3798,7 +3799,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]", 4);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']/a[@href]", 4);
 		}
 
 		[Test]
@@ -3849,7 +3850,7 @@ namespace SIL.FieldWorks.XWorks
 
 			var result = ((CssGenerator)settings.StylesGenerator).GetStylesString();
 
-			var pattern = @".configtargets>\s*\.configtarget\s*\+\s*\.configtarget:before\s*\{\s*content:\s*';';\s*\}\s*\.configtargets:before\s*\{\s*content:\s*' ';\s*\}\s*\.configtargets:after\s*\{\s*content:\s*'!';\s*\}";
+			var pattern = @".configtargets-1>\s*\.configtarget\s*\+\s*\.configtarget:before\s*\{\s*content:\s*';';\s*\}\s*\.lexentry-1\s\.minimallexreferences-1\s\.configtargets-1:before\s*\{\s*content:\s*' ';\s*\}\s*\.lexentry-1\s\.minimallexreferences-1\s\.configtargets-1:after\s*\{\s*content:\s*'!';\s*\}";
 
 			CssGeneratorTests.VerifyRegex(result, pattern, "CSS verification failed.");
 		}
@@ -3904,7 +3905,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"//span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr']//a[@href]", 4);
+				"//span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr']//a[@href]", 4);
 		}
 
 		[Test]
@@ -3960,7 +3961,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT-
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']");
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']");
 		}
 
 		[Test]
@@ -4000,9 +4001,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(referencedEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			const string anyNameXpath =
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en']";
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(fwdNameXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(anyNameXpath, 1); // ensure there are no spurious names
 		}
@@ -4045,9 +4046,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			var revNameXpath = string.Format(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeRevName);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeRevName);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(fwdNameXpath, 1);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(revNameXpath);
 		}
@@ -4090,9 +4091,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(referencedEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			var revNameXpath = string.Format(
-				"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeRevName);
+				"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeRevName);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(fwdNameXpath);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
 		}
@@ -4140,9 +4141,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			var revNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeRevName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeRevName);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(fwdNameXpath, 1);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(revNameXpath);
 		}
@@ -4191,7 +4192,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(fwdNameXpath, 1);
 		}
 
@@ -4238,9 +4239,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(referencedEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			var revNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeRevName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeRevName);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(fwdNameXpath);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
 		}
@@ -4292,7 +4293,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
-			const string NameXpath = "//span[@class='minimallexreferences']/span[@class='minimallexreference' and position()='{0}']/span[@class='ownertype_name']/span[@lang='en' and text()='{1}']";
+			const string NameXpath = "//span[@class='minimallexreferences-1']/span[@class='minimallexreference' and position()='{0}']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{1}']";
 			var fwdNameFirstXpath = string.Format(NameXpath, "1", etyRefTypeName);
 			var fwdNameSecondXpath = string.Format(NameXpath, "2", comRefTypeName);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(fwdNameFirstXpath, 1);
@@ -4372,21 +4373,21 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(armEntry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeName);
 			AssertThatXmlIn.String(output).HasNoMatchForXpath(fwdNameXpath);
 			var revNameXpath = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[@lang='en' and text()='{0}']", refTypeRevName);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[@lang='en' and text()='{0}']", refTypeRevName);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
-			var badTarget1 = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='gloss']";
+			var badTarget1 = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='gloss-1']";
 			AssertThatXmlIn.String(output).HasNoMatchForXpath(badTarget1);
 			var badTarget2 = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr' and text()='{0}']", secondWord);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr' and text()='{0}']", secondWord);
 			AssertThatXmlIn.String(output).HasNoMatchForXpath(badTarget2);
 			var badTarget3 = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr' and text()='{0}']", thirdWord);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr' and text()='{0}']", thirdWord);
 			AssertThatXmlIn.String(output).HasNoMatchForXpath(badTarget3);
 			var goodTarget = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr' and text()='{0}']", firstWord);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr' and text()='{0}']", firstWord);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(goodTarget, 1);
 		}
 
@@ -4450,9 +4451,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(firstEntry, mainEntryNode, null, settings).ToString();
 			var goodTarget = string.Format(
-				"//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword']/span[@lang='fr' and text()='{0}']", firstHeadword);
+				"//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='headword-1']/span[@lang='fr' and text()='{0}']", firstHeadword);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(goodTarget, 1);
-			var badTarget = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='gloss']";
+			var badTarget = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='configtargets']/span[@class='configtarget']/span[@class='gloss-1']";
 			AssertThatXmlIn.String(output).HasNoMatchForXpath(badTarget);
 		}
 
@@ -4519,13 +4520,13 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(firstEntry, mainEntryNode, DefaultDecorator, settings).ToString();
 
-			var goodTarget1 = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[text()='Part']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss']/span[@lang='en' and text()='b2']";
+			var goodTarget1 = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[text()='Part']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss-1']/span[@lang='en' and text()='b2']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(goodTarget1, 1);
-			var badTarget1 = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[text()='Part']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss']/span[@lang='en' and text()='b1']";
+			var badTarget1 = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[text()='Part']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss-1']/span[@lang='en' and text()='b1']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(badTarget1);
-			var goodTarget2 = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[text()='Whole']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss']/span[@lang='en' and text()='b1']";
+			var goodTarget2 = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[text()='Whole']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss-1']/span[@lang='en' and text()='b1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(goodTarget2, 1);
-			var badTarget2 = "//span[@class='lexsensereferences']/span[@class='lexsensereference']/span[@class='ownertype_name']/span[text()='Whole']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss']/span[@lang='en' and text()='b2']";
+			var badTarget2 = "//span[@class='lexsensereferences-1']/span[@class='lexsensereference']/span[@class='ownertype_name-1']/span[text()='Whole']/ancestor::span[1]/following-sibling::node()//span[@class='configtarget']/span[@class='gloss-1']/span[@lang='en' and text()='b2']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(badTarget2);
 		}
 
@@ -4952,7 +4953,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@lang='fr']", 0);
+				"/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@lang='fr']", 0);
 		}
 
 		[Test]
@@ -5003,7 +5004,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']//span[@lang='fr']/span[@lang='fr']", 2);
+				"/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']//span[@lang='fr']/span[@lang='fr']", 2);
 		}
 
 		[Test]
@@ -5060,8 +5061,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				"/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='referencedentries']" +
-				"/span[@class='referencedentry']/span[@class='headword']/span[@lang='fr']/span[@lang='fr' and text()='Citation']", 1);
+				"/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='referencedentries-1']" +
+				"/span[@class='referencedentry']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr' and text()='Citation']", 1);
 		}
 
 		[Test]
@@ -5102,7 +5103,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				xpathThruSense + "/span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']//span[@lang='fr']/span[@lang='fr']", 4);
+				xpathThruSense + "/span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']//span[@lang='fr']/span[@lang='fr']", 4);
 		}
 
 		[Test]
@@ -5304,8 +5305,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-			const string oneSenseWithPicture = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/img[@class='photo' and @id]";
-			const string oneSenseWithPictureCaption = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='caption']//span[text()='caption']";
+			const string oneSenseWithPicture = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/img[@class='photo-1' and @id]";
+			const string oneSenseWithPictureCaption = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='caption-1']//span[text()='caption']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithPicture, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithPictureCaption, 1);
@@ -5411,8 +5412,8 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-			const string oneSenseWithPicture = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/img[@class='photo' and @id]";
-			const string oneSenseWithPictureCaption = "/div[@class='lexentry']/span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='creator' and text()='Jason Naylor']";
+			const string oneSenseWithPicture = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/img[@class='photo-1' and @id]";
+			const string oneSenseWithPictureCaption = "/div[@class='lexentry-1']/span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='creator-1' and text()='Jason Naylor']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithPicture, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithPictureCaption, 1);
@@ -5443,7 +5444,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-			var pictureWithComposedPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[contains(@src, '" + composedPath + "')]";
+			var pictureWithComposedPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[contains(@src, '" + composedPath + "')]";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 1);
 		}
 
@@ -5472,7 +5473,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var pictureRelativePath = Path.Combine("pictures", Path.GetFileName(filePath));
-				var pictureWithComposedPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[starts-with(@src, '" + pictureRelativePath + "')]";
+				var pictureWithComposedPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[starts-with(@src, '" + pictureRelativePath + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 1);
 				// that src starts with a string, and escaping any Windows path separators
@@ -5509,7 +5510,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var pictureRelativePath = Path.Combine("pictures", Path.GetFileName(filePath));
-				var pictureWithComposedPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[starts-with(@src, '" + pictureRelativePath + "')]";
+				var pictureWithComposedPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[starts-with(@src, '" + pictureRelativePath + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 1);
 				// that src starts with a string, and escaping any Windows path separators
@@ -5564,14 +5565,14 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var pictureRelativePath = Path.Combine("pictures", Path.GetFileName(fileName));
-				var pictureWithComposedPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[contains(@src, '" + pictureRelativePath + "')]";
+				var pictureWithComposedPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[contains(@src, '" + pictureRelativePath + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 1);
 				// that src contains a string, and escaping any Windows path separators
 				AssertRegex(result, string.Format("src=\"[^\"]*{0}[^\"]*\"", pictureRelativePath.Replace(@"\", @"\\")), 1);
 				// The second file with the same name should have had something appended to the end of the filename but the initial filename should match both entries
 				var filenameWithoutExtension = Path.GetFileNameWithoutExtension(pictureRelativePath);
-				var pictureStartsWith = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[contains(@src, '" + filenameWithoutExtension + "')]";
+				var pictureStartsWith = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[contains(@src, '" + filenameWithoutExtension + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureStartsWith, 2);
 				// that src contains a string
@@ -5619,7 +5620,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var pictureRelativePath = Path.Combine("pictures", Path.GetFileName(fileName));
-				const string pictureXPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img";
+				const string pictureXPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img";
 				var pictureWithComposedPath = pictureXPath + "[contains(@src, '" + pictureRelativePath + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 2);
@@ -5761,7 +5762,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var pictureRelativePath = Path.Combine("pictures", Path.GetFileName(fileName));
-				var pictureWithComposedPath = "/div[@class='lexentry']/span[@class='pictures']/span[@class='picture']/img[contains(@src, '" + pictureRelativePath + "')]";
+				var pictureWithComposedPath = "/div[@class='lexentry-1']/span[@class='pictures-1']/span[@class='picture']/img[contains(@src, '" + pictureRelativePath + "')]";
 				if (!Platform.IsUnix)
 					AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(pictureWithComposedPath, 2);
 				// that src starts with string, and escaping Windows directory separators
@@ -5802,7 +5803,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='lexentry']/span[@class='customstring']/span[text()='{0}']", customData);
+				var customDataPath = string.Format("/div[@class='lexentry-1']/span[@class='customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -5839,7 +5840,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = $"/div[@class='lexentry']/span[@class='grouping_customgroup']/span[@class='customstring']/span[text()='" + customData + "']";
+				var customDataPath = $"/div[@class='lexentry-1']/span[@class='grouping_customgroup-1']/span[@class='customstring-1']/span[text()='" + customData + "']";
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -5888,8 +5889,8 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				const string grpXPath = "/span[@class='grouping_customgroup']";
-				var customDataPath = $"/div[@class='lexentry']{grpXPath}{grpXPath}{grpXPath}/span[@class='customstring']/span[text()='{customData}']";
+				const string grpXPath = "/span[@class='grouping_customgroup-1']/span[@class='grouping_customgroup-2']/span[@class='grouping_customgroup-3']";
+				var customDataPath = $"/div[@class='lexentry-1']{grpXPath}/span[@class='customstring-1']/span[text()='{customData}']";
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -5956,7 +5957,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='l']/span[@class='es']/span[@class='e']/span[@class='customstring']/span[text()='{0}']", customData);
+				var customDataPath = string.Format("/div[@class='l-1']/span[@class='es-1']/span[@class='e']/span[@class='customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6003,7 +6004,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var customDataPath = string.Format(
-					"/div[@class='l']/span[@class='es']//span[@class='xs']/span[@class='x']/span[@class='customstring']/span[text()='{0}']", customData);
+					"/div[@class='l-1']/span[@class='es-1']//span[@class='xs-1']/span[@class='x']/span[@class='customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6042,7 +6043,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
 				var customDataPath = string.Format(
-					"/div[@class='l']/span[@class='as']/span[@class='a']/span[@class='customstring']/span[text()='{0}']", customData);
+					"/div[@class='l-1']/span[@class='as-1']/span[@class='a']/span[@class='customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6073,7 +6074,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='lexentry']/span[@class='customstring']/span[text()='{0}']", customData);
+				var customDataPath = string.Format("/div[@class='lexentry-1']/span[@class='customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6135,9 +6136,9 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var entryDataPath = string.Format("/div[@class='lexentry']/span[@class='mlrs']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='entrycstring']/span[text()='{0}']", entryCustomData);
+				var entryDataPath = string.Format("/div[@class='lexentry-1']/span[@class='mlrs-1']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='entrycstring-1']/span[text()='{0}']", entryCustomData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(entryDataPath, 1);
-				var senseDataPath = string.Format("/div[@class='lexentry']/span[@class='mlrs']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='sensecstring']/span[text()='{0}']", senseCustomData);
+				var senseDataPath = string.Format("/div[@class='lexentry-1']/span[@class='mlrs-1']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='sensecstring']/span[text()='{0}']", senseCustomData);
 				AssertThatXmlIn.String(result).HasNoMatchForXpath(senseDataPath, message: "Ref is to Entry; should be no Sense Custom Data");
 			}
 		}
@@ -6199,9 +6200,9 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var entryDataPath = string.Format("/div[@class='lexentry']/span[@class='mlrs']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='entrycstring']/span[text()='{0}']", entryCustomData);
+				var entryDataPath = string.Format("/div[@class='lexentry-1']/span[@class='mlrs-1']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='entrycstring-1']/span[text()='{0}']", entryCustomData);
 				AssertThatXmlIn.String(result).HasNoMatchForXpath(entryDataPath, message: "Ref is to Sense; should be no Entry Custom Data");
-				var senseDataPath = string.Format("/div[@class='lexentry']/span[@class='mlrs']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='sensecstring']/span[text()='{0}']", senseCustomData);
+				var senseDataPath = string.Format("/div[@class='lexentry-1']/span[@class='mlrs-1']/span[@class='mlr']/span[@class='configtargets']/span[@class='configtarget']/span[@class='sensecstring-1']/span[text()='{0}']", senseCustomData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseDataPath, 1);
 			}
 		}
@@ -6239,7 +6240,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='lexentry']/span[@class='vars']/span[@class='var']/span[@class='owningentry_customstring']/span[text()='{0}']", customData);
+				var customDataPath = string.Format("/div[@class='lexentry-1']/span[@class='vars-1']/span[@class='var']/span[@class='owningentry_customstring-1']/span[text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6275,7 +6276,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-			var definitionXpath = "//div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='definition']/span[@lang='en']";
+			var definitionXpath = "//div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='definition-1']/span[@lang='en']";
 			var str1Xpath = string.Format(definitionXpath + "/span[@lang='en' and text()='{0}']", multirunContent[0]);
 			var str2Xpath = string.Format(definitionXpath + "/span[@lang='fr' and text()='{0}']", multirunContent[1]);
 			var str3Xpath = string.Format(definitionXpath + "/span[@lang='en' and text()='{0}']", multirunContent[2]);
@@ -6323,7 +6324,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				const string customDataPath = "/div[@class='lexentry']/span[@class='customlistitem']/span[@class='name']/span[text()='Djbuti']";
+				const string customDataPath = "/div[@class='lexentry-1']/span[@class='customlistitem-1']/span[@class='name-1']/span[text()='Djbuti']";
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6364,8 +6365,8 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				const string customDataPath1 = "/div[@class='lexentry']/span[@class='customlistitems']/span[@class='customlistitem']/span[@class='name']/span[text()='Dallas']";
-				const string customDataPath2 = "/div[@class='lexentry']/span[@class='customlistitems']/span[@class='customlistitem']/span[@class='name']/span[text()='Barcelona']";
+				const string customDataPath1 = "/div[@class='lexentry-1']/span[@class='customlistitems-1']/span[@class='customlistitem']/span[@class='name-1']/span[text()='Dallas']";
+				const string customDataPath2 = "/div[@class='lexentry-1']/span[@class='customlistitems-1']/span[@class='customlistitem']/span[@class='name-1']/span[text()='Barcelona']";
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath1, 1);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath2, 1);
 			}
@@ -6396,7 +6397,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='lexentry']/span[@class='customdate' and text()='{0}']", customData.ToLongDateString());
+				var customDataPath = string.Format("/div[@class='lexentry-1']/span[@class='customdate-1' and text()='{0}']", customData.ToLongDateString());
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6426,7 +6427,7 @@ namespace SIL.FieldWorks.XWorks
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, settings).ToString();
-				var customDataPath = string.Format("/div[@class='lexentry']/span[@class='custominteger' and text()='{0}']", customData);
+				var customDataPath = string.Format("/div[@class='lexentry-1']/span[@class='custominteger-1' and text()='{0}']", customData);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 1);
 			}
 		}
@@ -6458,7 +6459,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, rootNode, null, settings).ToString();
 				const string customDataPath =
-					"/div[@class='lexentry']/div/span[text()='First para Custom string'] | /div[@class='lexentry']/div/span[text()='Second para Custom string']";
+					"/div[@class='lexentry-1']/div/span[text()='First para Custom string'] | /div[@class='lexentry-1']/div/span[text()='Second para Custom string']";
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(customDataPath, 2);
 			}
 		}
@@ -6496,7 +6497,7 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, settings).ToString();
 			const string referencedEntries =
-				"//span[@class='visiblevariantentryrefs']/span[@class='visiblevariantentryref']/span[@class='referencedentries']/span[@class='referencedentry']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']";
+				"//span[@class='visiblevariantentryrefs-1']/span[@class='visiblevariantentryref']/span[@class='referencedentries-1']/span[@class='referencedentry']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']";
 			AssertThatXmlIn.String(result)
 				.HasSpecifiedNumberOfMatchesForXpath(referencedEntries, 2);
 		}
@@ -6534,7 +6535,7 @@ namespace SIL.FieldWorks.XWorks
 				@"Src/xWorks/xWorksTests/TestData/LinkedFiles/AudioVisual/" + audioFileName;
 			Assert.That(result, Contains.Substring(audioFileUrl));
 			const string linkTagwithOnClick =
-				"//span[@class='lexemeformoa']/span/a[@class='en-Zxxx-x-audio' and contains(@onclick,'play()')]";
+				"//span[@class='lexemeformoa-1']/span/a[@class='en-Zxxx-x-audio' and contains(@onclick,'play()')]";
 			AssertThatXmlIn.String(result)
 				.HasSpecifiedNumberOfMatchesForXpath(linkTagwithOnClick, 1);
 		}
@@ -6843,7 +6844,7 @@ namespace SIL.FieldWorks.XWorks
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(audioTagwithSource, 1);
 			var audioFileUrl = Path.Combine("AudioVisual", audioFileName);
 			Assert.That(result, Contains.Substring(audioFileUrl));
-			var linkTagwithOnClick = "//span[@class='lexemeformoa']/span/a[@class='en-Zxxx-x-audio'";
+			var linkTagwithOnClick = "//span[@class='lexemeformoa-1']/span/a[@class='en-Zxxx-x-audio'";
 			linkTagwithOnClick += " and @href='#" + safeAudioId + "'";
 			linkTagwithOnClick += " and contains(@onclick,'" + safeAudioId + "') and contains(@onclick,'.play()')]";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(linkTagwithOnClick, 1);
@@ -6973,10 +6974,10 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='sense']/span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
+				"//span[@class='sense']/span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
 					complexRefAbbr);
 			var revNameXpath = string.Format(
-				"//span[@class='sense']/span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='reverseabbr']/span[@lang='en' and text()='{0}']",
+				"//span[@class='sense']/span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='reverseabbr-1']/span[@lang='en' and text()='{0}']",
 					complexRefRevAbbr);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(fwdNameXpath);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
@@ -7021,10 +7022,10 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
 			var fwdNameXpath = string.Format(
-				"//span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
+				"//span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']",
 					complexRefAbbr);
 			var revNameXpath = string.Format(
-				"//span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='reverseabbr']/span[@lang='en' and text()='{0}']",
+				"//span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='reverseabbr-1']/span[@lang='en' and text()='{0}']",
 					complexRefRevAbbr);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(fwdNameXpath);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(revNameXpath, 1);
@@ -7092,11 +7093,11 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
 			const string fwdNameXpath =
-				"//span[@class='subentries']/span[@class='subentry subentry']/span[@class='subentries']/span[@class='subentry subentry']"
-				+ "/span[@class='complexformtypes']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']";
+				"//span[@class='subentries-1']/span[@class='subentry subentry']/span[@class='subentries-3']/span[@class='subentry subentry']"
+				+ "/span[@class='complexformtypes-1']/span[@class='complexformtype']/span/span[@lang='en' and text()='{0}']";
 			const string revNameXpath =
-				"//span[@class='subentries']/span[@class='subentry subentry']/span[@class='subentries']/span[@class='subentry subentry']"
-				+ "/span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='reverseabbr']/span[@lang='en' and text()='{0}']";
+				"//span[@class='subentries-1']/span[@class='subentry subentry']/span[@class='subentries-3']/span[@class='subentry subentry']"
+				+ "/span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='reverseabbr-1']/span[@lang='en' and text()='{0}']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(string.Format(fwdNameXpath, complexRefAbbr));
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(string.Format(revNameXpath, complexRefRevAbbr), 1);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(string.Format(revNameXpath, otherComplexRefRevAbbr),
@@ -7152,7 +7153,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string refTypeXpath = "//span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']";
+			const string refTypeXpath = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(refTypeXpath);
 			StringAssert.DoesNotContain(complexRefAbbr, result);
 		}
@@ -7239,9 +7240,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string refTypeXpath = "//span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='complexformtypes']/span[@class='complexformtype']";
+			const string refTypeXpath = "//span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='complexformtypes-1']/span[@class='complexformtype']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(refTypeXpath);
-			const string headwordXpath = "//span[@class='visiblecomplexformbackrefs']/span[@class='visiblecomplexformbackref']/span[@class='headword']";
+			const string headwordXpath = "//span[@class='visiblecomplexformbackrefs-1']/span[@class='visiblecomplexformbackref']/span[@class='headword-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordXpath, 1);
 		}
 
@@ -7281,9 +7282,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string refTypeXpath = "//span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']";
+			const string refTypeXpath = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(refTypeXpath);
-			const string headwordXpath = "//span[@class='subentries']/span[@class='subentry']/span[@class='headword']";
+			const string headwordXpath = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='headword-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordXpath, 1);
 		}
 
@@ -7321,8 +7322,8 @@ namespace SIL.FieldWorks.XWorks
 			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
 
 			subentryRef.HideMinorEntry = 1;
-			const string withReference = "/div[@class='lexentry']/span[@class='subentries']/span[@class='subentry']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]";
-			const string withoutReference = "/div[@class='lexentry']/span[@class='subentries']/span[@class='subentry']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']";
+			const string withReference = "/div[@class='lexentry-1']/span[@class='subentries-1']/span[@class='subentry']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']/a[@href]";
+			const string withoutReference = "/div[@class='lexentry-1']/span[@class='subentries-1']/span[@class='subentry']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']";
 
 			// When hiding minor entries this should still generate the reference (if not publishing to Webonary).
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null, false, false);
@@ -7426,9 +7427,9 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string refTypeXpath = "//span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='variantentrytypesrs']/span[@class='variantentrytypesr']";
+			const string refTypeXpath = "//span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='variantentrytypesrs']/span[@class='variantentrytypesr']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(refTypeXpath);
-			const string headwordXpath = "//span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='headword']";
+			const string headwordXpath = "//span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='headword-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordXpath, 1);
 		}
 
@@ -7468,11 +7469,11 @@ namespace SIL.FieldWorks.XWorks
 			// try with HideMinorEntry off
 			variantEntryRef.HideMinorEntry = 0;
 			result = ConfiguredLcmGenerator.GenerateContentForEntry(variantEntry, model, null, settings).ToString();
-			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry']/span[@class='headword']", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry-1']/span[@class='headword-1']", 1);
 			// Should get the same results if in Root based view
 			model.IsRootBased = true;
 			result = ConfiguredLcmGenerator.GenerateContentForEntry(variantEntry, model, null, settings).ToString();
-			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry']/span[@class='headword']", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry-1']/span[@class='headword-1']", 1);
 			variantEntryRef.HideMinorEntry = 1;
 			result = ConfiguredLcmGenerator.GenerateContentForEntry(variantEntry, model, null, settings).ToString();
 			Assert.IsEmpty(result);
@@ -7527,7 +7528,7 @@ namespace SIL.FieldWorks.XWorks
 			CssGeneratorTests.PopulateFieldsForTesting(model);
 
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null, false, false);
-			const string withReference = "/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]";
+			const string withReference = "/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']/a[@href]";
 
 			// When not hiding minor entries this should generate the reference.
 			variantEntryRef.HideMinorEntry = 0;
@@ -7590,8 +7591,8 @@ namespace SIL.FieldWorks.XWorks
 			CssGeneratorTests.PopulateFieldsForTesting(model);
 
 			variantEntryRef.HideMinorEntry = 1;
-			const string withReference = "/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']/a[@href]";
-			const string withoutReference = "/div[@class='lexentry']/span[@class='variantformentrybackrefs']/span[@class='variantformentrybackref']/span[@class='headword']/span[@lang='fr']/span[@lang='fr']";
+			const string withReference = "/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']/a[@href]";
+			const string withoutReference = "/div[@class='lexentry-1']/span[@class='variantformentrybackrefs-1']/span[@class='variantformentrybackref']/span[@class='headword-1']/span[@lang='fr']/span[@lang='fr']";
 
 			// When hiding minor entries this should still generate the reference (if not publishing to Webonary).
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null, false, false);
@@ -7645,7 +7646,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string headwordXpath = "//span[@class='reffingsubs']/span[@class='reffingsub sharedsubentry']/span[@class='headword']";
+			const string headwordXpath = "//span[@class='reffingsubs-1']/span[@class='reffingsub sharedsubentry']/span[@class='headword-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(headwordXpath, 1);
 		}
 
@@ -7679,7 +7680,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForMainEntry(idiom, mainEntryNode, null, settings, 0).ToString();
-			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry']/span[@class='headword']", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry-1']/span[@class='headword-1']", 1);
 			var css = ((CssGenerator)settings.StylesGenerator).GetStylesString();
 			// verify that the flow reset css is generated
 			Assert.That(css, Contains.Substring("white-space:pre-wrap"));
@@ -7757,7 +7758,7 @@ namespace SIL.FieldWorks.XWorks
 			var isMinorEntryShowing = isComplexFormShowing || isVariantFormShowing;
 
 			if (isMinorEntryShowing)
-				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry']/span[@class='headword']", 1);
+				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("/div[@class='lexentry-1']/span[@class='headword-1']", 1);
 			else
 				Assert.IsEmpty(result);
 		}
@@ -7984,15 +7985,15 @@ namespace SIL.FieldWorks.XWorks
 			};
 			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
 
-			const string matchFrenchEntry = "//span[@class='entry']/span[@lang='fr']";
-			const string matchFrenchPronunciation = "//span[@class='pronunciations']/span[@class='pronunciation']/span[@class='form']/span[@lang='fr']";
+			const string matchFrenchEntry = "//span[@class='entry-1']/span[@lang='fr']";
+			const string matchFrenchPronunciation = "//span[@class='pronunciations-1']/span[@class='pronunciation']/span[@class='form-1']/span[@lang='fr']";
 			const string matchEnglishDefOrGloss =
-				"//span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='definitionorgloss']/span[@lang='en']";
+				"//span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='definitionorgloss-1']/span[@lang='en']";
 			const string matchFrenchExample =
-				"//span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='examples']/span[@class='example']/span[@class='examplesentence']/span[@lang='fr']";
+				"//span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='examples-1']/span[@class='example']/span[@class='examplesentence-1']/span[@lang='fr']";
 			const string matchEnglishTranslation =
-				"//span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='examples']/span[@class='example']/span[@class='translations']/span[@class='translation']/span[@class='translatedsentence']/span[@lang='en']";
-			const string matchFrenchPictureCaption = "//span[@class='pictures']/div[@class='picture']/div[@class='captionContent']/span[@class='caption']/span[@lang='fr']";
+				"//span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='examples-1']/span[@class='example']/span[@class='translations-1']/span[@class='translation']/span[@class='translatedsentence-1']/span[@lang='en']";
+			const string matchFrenchPictureCaption = "//span[@class='pictures-1']/div[@class='picture']/div[@class='captionContent']/span[@class='caption-1']/span[@lang='fr']";
 
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
@@ -8018,7 +8019,7 @@ namespace SIL.FieldWorks.XWorks
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchEnglishTranslation, 1);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchFrenchPictureCaption, 1);
 			const string matchBodyIsBig =
-				"//span[@class='examples']/span[@class='example']/span[@class='translations']/span[@class='translation']/span[@class='translatedsentence']/span[@lang='en' and text()='The body is big.']";
+				"//span[@class='examples-1']/span[@class='example']/span[@class='translations-1']/span[@class='translation']/span[@class='translatedsentence-1']/span[@lang='en' and text()='The body is big.']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchBodyIsBig, 1);
 
 			//SUT
@@ -8032,7 +8033,7 @@ namespace SIL.FieldWorks.XWorks
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchEnglishTranslation, 1);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchFrenchPictureCaption, 0);
 			const string matchCorpseIsDead =
-				"//span[@class='examples']/span[@class='example']/span[@class='translations']/span[@class='translation']/span[@class='translatedsentence']/span[@lang='en' and text()='The corpse is dead.']";
+				"//span[@class='examples-1']/span[@class='example']/span[@class='translations-1']/span[@class='translation']/span[@class='translatedsentence-1']/span[@lang='en' and text()='The corpse is dead.']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchCorpseIsDead, 1);
 
 			//SUT
@@ -8093,10 +8094,10 @@ namespace SIL.FieldWorks.XWorks
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchFrenchExample, 1);
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchEnglishTranslation, 1);
 
-			const string matchFrenchSubentry = "//span[@class='subentries']/span[@class='subentry']/span[@class='subentry']/span[@lang='fr']";
-			const string matchMainsubentry = "//span[@class='subentries']/span[@class='subentry']/span[@class='subentry']/span[@lang='fr'and text()='mainsubentry']";
-			const string matchTestsubentry = "//span[@class='subentries']/span[@class='subentry']/span[@class='subentry']/span[@lang='fr'and text()='testsubentry']";
-			const string matchVariantRef = "//span[@class='variantentrytypes']/span[@class='variantentrytype']/span[@class='name']/span[@lang='en']";
+			const string matchFrenchSubentry = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='subentry-1']/span[@lang='fr']";
+			const string matchMainsubentry = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='subentry-1']/span[@lang='fr'and text()='mainsubentry']";
+			const string matchTestsubentry = "//span[@class='subentries-1']/span[@class='subentry']/span[@class='subentry-1']/span[@lang='fr'and text()='testsubentry']";
+			const string matchVariantRef = "//span[@class='variantentrytypes-1']/span[@class='variantentrytype']/span[@class='name-1']/span[@lang='en']";
 
 			//SUT
 			output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, pubMain, settings).ToString();
@@ -8175,7 +8176,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 				var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, null, settings).ToString();
-				const string matchVariantRef = "//span[@class='variantentrytypes']/span[@class='variantentrytype']/span[@class='name']/span[@lang='en']";
+				const string matchVariantRef = "//span[@class='variantentrytypes-1']/span[@class='variantentrytype']/span[@class='name-1']/span[@lang='en']";
 				AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchVariantRef, 2);
 			}
 		}
@@ -8238,9 +8239,9 @@ namespace SIL.FieldWorks.XWorks
 			CreateVariantForm(Cache, entryEntry, ve2, "Spelling Variant"); // unique Type; UnChecked
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, null, settings).ToString();
-			const string matchFreeVariantRef = "//span[@class='variantentrytypes']/span[@class='variantentrytype']/span[@class='name']/span[@lang='en' and text()='Free Variant']";
+			const string matchFreeVariantRef = "//span[@class='variantentrytypes-1']/span[@class='variantentrytype']/span[@class='name-1']/span[@lang='en' and text()='Free Variant']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchFreeVariantRef, 1);
-			const string matchSpellingVariantRef = "//span[@class='variantentrytypes']/span[@class='variantentrytype']/span[@class='name']/span[@lang='en' and text()='Spelling Variant']";
+			const string matchSpellingVariantRef = "//span[@class='variantentrytypes-1']/span[@class='variantentrytype']/span[@class='name-1']/span[@lang='en' and text()='Spelling Variant']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchSpellingVariantRef, 0);
 		}
 
@@ -8301,7 +8302,7 @@ namespace SIL.FieldWorks.XWorks
 
 			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, pubMain, DefaultSettings).ToString();
-			const string matchComplexFormRef = "//span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='name']/span[@lang='en']";
+			const string matchComplexFormRef = "//span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='name-1']/span[@lang='en']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchComplexFormRef, 1);
 		}
 
@@ -8364,11 +8365,11 @@ namespace SIL.FieldWorks.XWorks
 
 			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, pubMain, DefaultSettings).ToString();
-			const string matchComplexFormTypeCompound = "//span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='name']/span[@lang='en' and text()='Compound']";
+			const string matchComplexFormTypeCompound = "//span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='name-1']/span[@lang='en' and text()='Compound']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchComplexFormTypeCompound, 1);
-			const string matchComplexFormTypeIdiom = "//span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='name']/span[@lang='en' and text()='Idiom']";
+			const string matchComplexFormTypeIdiom = "//span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='name-1']/span[@lang='en' and text()='Idiom']";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchComplexFormTypeIdiom, 1);
-			const string matchComplexFormName = "//span[@class='visiblecomplexformbackref']/span[@class='headword']/span[@lang='fr']/a";
+			const string matchComplexFormName = "//span[@class='visiblecomplexformbackref']/span[@class='headword-1']/span[@lang='fr']/a";
 			AssertThatXmlIn.String(output).HasSpecifiedNumberOfMatchesForXpath(matchComplexFormName, 4);
 		}
 
@@ -8417,9 +8418,9 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, DefaultSettings).ToString();
-			const string senseXpath = "div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='gloss']/span[@lang='en' and text()='gloss']";
+			const string senseXpath = "div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='gloss-1']/span[@lang='en' and text()='gloss']";
 			var paracontinuationxpath = string.Format(
-				"div[@class='lexentry']//span[@class='subentries']/span[@class='subentry']/span[@class='complexformtypes']/span[@class='complexformtype']/span[@class='reverseabbr']/span[@lang='en' and text()='{0}']",
+				"div[@class='lexentry-1']//span[@class='subentries-1']/span[@class='subentry']/span[@class='complexformtypes-1']/span[@class='complexformtype']/span[@class='reverseabbr-1']/span[@lang='en' and text()='{0}']",
 				complexRefRevAbbr);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseXpath, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(paracontinuationxpath, 1);
@@ -8476,19 +8477,19 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(subentry1, minorEntryNode, null, settings).ToString();
-			const string complexFormEntryRefXpath = "div[@class='minorentrycomplex']/span[@class='complexformentryrefs']/span[@class='complexformentryref']";
-			const string referencedEntriesXpath = "/span[@class='referencedentries']/span[@class='referencedentry']";
-			const string glossOrSummXpath1 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='MainEntrySummaryDefn']";
+			const string complexFormEntryRefXpath = "div[@class='minorentrycomplex-1']/span[@class='complexformentryrefs-1']/span[@class='complexformentryref']";
+			const string referencedEntriesXpath = "/span[@class='referencedentries-1']/span[@class='referencedentry']";
+			const string glossOrSummXpath1 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='MainEntrySummaryDefn']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(glossOrSummXpath1, 1);
 
 			//SUT
 			var result2 = ConfiguredLcmGenerator.GenerateContentForEntry(subentry2, minorEntryNode, null, settings).ToString();
-			const string glossOrSummXpath2 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='gloss2']";
+			const string glossOrSummXpath2 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='gloss2']";
 			AssertThatXmlIn.String(result2).HasSpecifiedNumberOfMatchesForXpath(glossOrSummXpath2, 1);
 
 			//SUT
 			var result3 = ConfiguredLcmGenerator.GenerateContentForEntry(subentry3, minorEntryNode, null, settings).ToString();
-			const string glossOrSummXpath3 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary']/span[@lang='en' and text()='MainEntryS3Defn']";
+			const string glossOrSummXpath3 = complexFormEntryRefXpath + referencedEntriesXpath + "/span[@class='glossorsummary-1']/span[@lang='en' and text()='MainEntryS3Defn']";
 			AssertThatXmlIn.String(result3).HasSpecifiedNumberOfMatchesForXpath(glossOrSummXpath3, 1);
 		}
 
@@ -8519,7 +8520,7 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(lexentry, mainEntryNode, null, settings).ToString();
-			const string senseXpath = "div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='gloss']/span[@lang='en' and text()='gloss']";
+			const string senseXpath = "div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='gloss-1']/span[@lang='en' and text()='gloss']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(senseXpath, 1);
 			Assert.That(result, Does.Not.Match(@"<div class=['""]paracontinuation['""]\s*/>"),
 				"Empty Self closing <div> element should not generated after senses in paragraph");
@@ -8773,7 +8774,7 @@ namespace SIL.FieldWorks.XWorks
 			const string pagesDivXPath = "//div[@class='pages']";
 			const string pageButtonXPath = "//div[@class='pages']/span[@class='pagebutton']";
 			const string pageButtonLastIndexPath = "//div[@class='pages']/span[@class='pagebutton' and @endIndex='20']";
-			const string entryDivXPath = "//div[@class='entry']";
+			const string entryDivXPath = "//div[@class='entry-1']";
 			try
 			{
 				xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(hvos, pubEverything, model, m_propertyTable, entriesPerPage: 10);
@@ -8822,7 +8823,7 @@ namespace SIL.FieldWorks.XWorks
 			const string pageButtonXPath = "//div[@class='pages']/span[@class='pagebutton']";
 			const string firstPageButtonXPath = "//div[@class='pages']/span[@class='pagebutton' and @id='currentPageButton' and @startIndex='0' and @endIndex='7']";
 			const string lastPageButtonXPath = "//div[@class='pages']/span[@class='pagebutton' and @startIndex='16' and @endIndex='20']";
-			const string entryXPath = "//div[@class='entry']";
+			const string entryXPath = "//div[@class='entry-1']";
 			try
 			{
 				xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(hvos, pubEverything, model, m_propertyTable, entriesPerPage: 8);
@@ -9017,14 +9018,16 @@ namespace SIL.FieldWorks.XWorks
 				var xhtml = File.ReadAllText(xhtmlPath);
 				//System.Diagnostics.Debug.WriteLine(String.Format("GENERATED XHTML = \r\n{0}\r\n=====================", xhtml));
 				// SUT
-				const string allCategsPath = "//span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en']";
-				const string firstCategPath = "/html/body/div[@class='lexentry']/span[@class='senses']//span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='n']";
-				const string secondCategPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='n']";
-				const string thirdCategPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='adj']";
-				const string fourthCategPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='adj']";
-				const string fifthCategPath = "/html/body/div[@class='lexentry']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis']/span[@class='mlpartofspeech']/span[@lang='en' and text()='n']";
+				const string allCategsPath1 = "//span[@class='morphosyntaxanalysis-1']/span[@class='mlpartofspeech-1']/span[@lang='en']";
+				const string allCategsPath2 = "//span[@class='morphosyntaxanalysis-2']/span[@class='mlpartofspeech-2']/span[@lang='en']";
+				const string firstCategPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']//span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis-2']/span[@class='mlpartofspeech-2']/span[@lang='en' and text()='n']";
+				const string secondCategPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis-1']/span[@class='mlpartofspeech-1']/span[@lang='en' and text()='n']";
+				const string thirdCategPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sharedgrammaticalinfo']/span[@class='morphosyntaxanalysis-1']/span[@class='mlpartofspeech-1']/span[@lang='en' and text()='adj']";
+				const string fourthCategPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis-2']/span[@class='mlpartofspeech-2']/span[@lang='en' and text()='adj']";
+				const string fifthCategPath = "/html/body/div[@class='lexentry-1']/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='senses-2']/span[@class='sensecontent']/span[@class='sense']/span[@class='morphosyntaxanalysis-2']/span[@class='mlpartofspeech-2']/span[@lang='en' and text()='n']";
 
-				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(allCategsPath, 5);
+				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(allCategsPath1, 3);
+				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(allCategsPath2, 2);
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(firstCategPath, 1);
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(secondCategPath, 2);
 				AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(thirdCategPath, 1);
@@ -9105,8 +9108,8 @@ namespace SIL.FieldWorks.XWorks
 			entry.Bibliography.set_String(m_wsFr, multiRunString);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings).ToString();
-			const string nestedEn = "/div[@class='lexentry']/span[@class='bib']/span[@lang='fr']/span[@lang='en']";
-			const string nestedFr = "/div[@class='lexentry']/span[@class='bib']/span[@lang='fr']/span[@lang='fr']";
+			const string nestedEn = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='fr']/span[@lang='en']";
+			const string nestedFr = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='fr']/span[@lang='fr']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedEn, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedFr, 2);
 		}
@@ -9132,9 +9135,9 @@ namespace SIL.FieldWorks.XWorks
 			entry.Bibliography.set_String(wsHe, multiRunString);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings).ToString();
-			const string nestedEn = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@dir='rtl']/span[@lang='en']/span[@dir='ltr']";
-			const string nestedHe = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@dir='rtl']/span[@lang='he']";
-			const string extraDirection = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@dir='rtl']/span[@lang='he']/span[@dir='rtl']";
+			const string nestedEn = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@dir='rtl']/span[@lang='en']/span[@dir='ltr']";
+			const string nestedHe = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@dir='rtl']/span[@lang='he']";
+			const string extraDirection = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@dir='rtl']/span[@lang='he']/span[@dir='rtl']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedEn, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedHe, 2);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(extraDirection);
@@ -9162,10 +9165,10 @@ namespace SIL.FieldWorks.XWorks
 			var settings = new ConfiguredLcmGenerator.GeneratorSettings(Cache, m_propertyTable, false, false, null, true); // Right-to-Left
 																															 //SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings).ToString();
-			const string nestedEn = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@lang='en']/span[@dir='ltr']";
-			const string nestedHe = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@lang='he']";
-			const string extraDirection0 = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@dir='rtl']";
-			const string extraDirection1 = "/div[@class='lexentry']/span[@class='bib']/span[@lang='he']/span[@lang='he']/span[@dir='rtl']";
+			const string nestedEn = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@lang='en']/span[@dir='ltr']";
+			const string nestedHe = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@lang='he']";
+			const string extraDirection0 = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@dir='rtl']";
+			const string extraDirection1 = "/div[@class='lexentry-1']/span[@class='bib-1']/span[@lang='he']/span[@lang='he']/span[@dir='rtl']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedEn, 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedHe, 1);
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(extraDirection0);
@@ -9200,28 +9203,28 @@ namespace SIL.FieldWorks.XWorks
 		  entry.Bibliography.set_String(m_wsFr, stringBldr.GetString());
 		  // SUT
 		  var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings).ToString();
-		  string nestedLink = $"/div[@class='lexentry']/span[@class='bib']/span/span/a[@href='{testUrl}']";
+		  string nestedLink = $"/div[@class='lexentry-1']/span[@class='bib-1']/span/span/a[@href='{testUrl}']";
 		  AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(nestedLink, 1);
 	  }
 
 	  private const string crossRefOwnerTypeXpath =
-			"//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']";
+			"//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']";
 
 		private static string CrossRefOwnerTypeXpath(string type)
 		{
-			return string.Format("//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='ownertype_name']" +
+			return string.Format("//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='ownertype_name-1']" +
 				"/span[@lang='en' and text()='{0}']", type);
 		}
 
 		private static string HeadwordOrderInCrossRefsXpath(int position, string headword)
 		{
-			return string.Format("//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']" +
+			return string.Format("//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']" +
 				"/span[@class='configtarget' and position()='{0}']/span/span/a[text()='{1}']", position, headword);
 		}
 
 		private static string HeadwordWsInCrossRefsXpath(string ws, string headword) // REVIEW (Hasso) 2017.04: move these helpers to Helpers?
 		{
-			return string.Format("//span[@class='minimallexreferences']/span[@class='minimallexreference']/span[@class='configtargets']" +
+			return string.Format("//span[@class='minimallexreferences-1']/span[@class='minimallexreference']/span[@class='configtargets']" +
 				"/span[@class='configtarget']/span/span[@lang='{0}']/a[text()='{1}']", ws, headword);
 		}
 
@@ -9456,7 +9459,7 @@ namespace SIL.FieldWorks.XWorks
 				FieldDescription = "LexEntry",
 				Children = new List<ConfigurableDictionaryNode> { relationsNode }
 			};
-			var xpathLexRef = "//div/span[@class='lexrefs']/span[@class='lexref']";
+			var xpathLexRef = "//div/span[@class='lexrefs-1']/span[@class='lexref']";
 			if (usingSubfield)
 			{
 				// If we are testing subfields, insert 'SensesOS->Entry', which returns the same data, but allows us to make LexRefs a subfield.
@@ -9475,18 +9478,18 @@ namespace SIL.FieldWorks.XWorks
 					Children = mainEntryNode.Children
 				};
 				mainEntryNode.Children = new List<ConfigurableDictionaryNode> { senseNode };
-				xpathLexRef = "//div/span[@class='senses']/span[@class='sensecontent']/span[@class='sense']/span[@class='lexrefs']/span[@class='lexref']";
+				xpathLexRef = "//div/span[@class='senses-1']/span[@class='sensecontent']/span[@class='sense']/span[@class='lexrefs-1']/span[@class='lexref']";
 			}
 			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
 			var settings = DefaultSettings;
-			string antAbbrSpan = $"<span class=\"ownertype_abbreviation\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">ant</span></span>";
-			string whSpan = $"<span class=\"ownertype_abbreviation\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">wh</span></span>";
-			string ptSpan = $"<span class=\"ownertype_abbreviation\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">pt</span></span>";
-			string antNameSpan = $"<span class=\"ownertype_name\"><span nodeId=\"{relNameNode.GetHashCode()}\" lang=\"en\">Antonym</span></span>";
-			string femmeSpan = $"<span class=\"headword\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">femme</span></span>";
-			var garçonSpan = TsStringUtils.Compose($"<span class=\"headword\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">garçon</span></span>");
-			var bêteSpan = TsStringUtils.Compose($"<span class=\"headword\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">bête</span></span>");
-			string trucSpan = $"<span class=\"headword\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">truc</span></span>";
+			string antAbbrSpan = $"<span class=\"ownertype_abbreviation-1\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">ant</span></span>";
+			string whSpan = $"<span class=\"ownertype_abbreviation-1\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">wh</span></span>";
+			string ptSpan = $"<span class=\"ownertype_abbreviation-1\"><span nodeId=\"{relAbbrNode.GetHashCode()}\" lang=\"en\">pt</span></span>";
+			string antNameSpan = $"<span class=\"ownertype_name-1\"><span nodeId=\"{relNameNode.GetHashCode()}\" lang=\"en\">Antonym</span></span>";
+			string femmeSpan = $"<span class=\"headword-1\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">femme</span></span>";
+			var garçonSpan = TsStringUtils.Compose($"<span class=\"headword-1\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">garçon</span></span>");
+			var bêteSpan = TsStringUtils.Compose($"<span class=\"headword-1\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">bête</span></span>");
+			string trucSpan = $"<span class=\"headword-1\"><span nodeId=\"{refHeadwordNode.GetHashCode()}\" lang=\"fr\">truc</span></span>";
 			//SUT
 			//Console.WriteLine(LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new[] { manEntry.Hvo, familyEntry.Hvo, girlEntry.Hvo, individualEntry.Hvo }, null,
 			//	new DictionaryConfigurationModel { Parts = new List<ConfigurableDictionaryNode> { mainEntryNode } }, m_mediator)); // full output for diagnostics
@@ -10198,8 +10201,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings).ToString();
 
-			const string oneSenseWithGlossOfGloss = "/div[@class='lexentry']/span[@class='grouping_sensegroup']"
-				+ "/span[@class='senses']/span[@class='sense']//span[@lang='en' and text()='gloss']";
+			const string oneSenseWithGlossOfGloss = "/div[@class='lexentry-1']/span[@class='grouping_sensegroup-1']"
+				+ "/span[@class='senses-1']/span[@class='sense']//span[@lang='en' and text()='gloss']";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(oneSenseWithGlossOfGloss, 1);
 		}

--- a/Src/xWorks/xWorksTests/CssGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/CssGeneratorTests.cs
@@ -185,7 +185,7 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(subEntryHeadwordNode);
 			var cssResult = cssGenerator.GetStylesString();
 			// verify that the css result contains a line similar to: .sharedsubentries .sharedsubentry .headword span{
-			VerifyRegex(cssResult, @"^\s*\.mainheadword-sharedsubentries>\s*span\s*{.*",
+			VerifyRegex(cssResult, @"\.sharedsubentries-.\s\.mainheadword-.>\s*span\s*{.*",
 				"Css for child node(headword) did not generate a match");
 		}
 
@@ -214,7 +214,7 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.Init(m_propertyTable);
 			//SUT
 			cssGenerator.AddStyles(emptyNode);
-			Assert.That(cssGenerator.GetStylesString(), Is.EqualTo(string.Empty));
+			Assert.That(!cssGenerator.GetStylesString().Contains(".nothing"));
 		}
 
 		[Test]
@@ -333,14 +333,14 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(headwordNode);
 			var cssResult = cssGenerator.GetStylesString();
 			// Check the result for before and after rules for the group
-			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg\s*:before\s*{\s*content\s*:\s*'{';\s*}").Success,
+			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg-.\s*:before\s*{\s*content\s*:\s*'{';\s*}").Success,
 							  "css before rule for the grouping node was not generated");
-			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg\s*:after\s*{\s*content\s*:\s*'}';\s*}").Success,
+			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg-.\s*:after\s*{\s*content\s*:\s*'}';\s*}").Success,
 							  "css after rule for the grouping node was not generated");
 			// Check result for before and after rules equivalent to .headword span:first-child{content:'Z';} and .headword span:last-child{content:'A'}
-			Assert.IsTrue(Regex.Match(cssResult, @"\.mh-grouping_hwg>\s*span\s*:\s*first-child:before\s*{\s*content\s*:\s*'Z';\s*}").Success,
+			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg-.\s\.mh-.>\s*span\s*:\s*first-child:before\s*{\s*content\s*:\s*'Z';\s*}").Success,
 							  "css before rule with Z content not found on headword");
-			Assert.IsTrue(Regex.Match(cssResult, @"\.mh-grouping_hwg>\s*span\s*:\s*last-child:after\s*{\s*content\s*:\s*'A';\s*}").Success,
+			Assert.IsTrue(Regex.Match(cssResult, @"\.grouping_hwg-.\s\.mh-.>\s*span\s*:\s*last-child:after\s*{\s*content\s*:\s*'A';\s*}").Success,
 							  "css after rule with A content not found on headword");
 		}
 
@@ -439,9 +439,9 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(headwordNode);
 			var cssResult = cssGenerator.GetStylesString();
 			// Check result for before and after rules equivalent to .headword-subentries span:first-child{content:'Z';} and .headword span:last-child{content:'A'}
-			VerifyRegex(cssResult, @"\.headword-subentries>\s*span\s*:\s*first-child:before\s*{\s*content\s*:\s*'Z';\s*}",
+			VerifyRegex(cssResult, @"\.subentries-.\s\.headword-.>\s*span\s*:\s*first-child:before\s*{\s*content\s*:\s*'Z';\s*}",
 							  "css before rule with Z content not found on headword");
-			VerifyRegex(cssResult, @"\.headword-subentries>\s*span\s*:\s*last-child:after\s*{\s*content\s*:\s*'A';\s*}",
+			VerifyRegex(cssResult, @"\.subentries-.\s\.headword-.>\s*span\s*:\s*last-child:after\s*{\s*content\s*:\s*'A';\s*}",
 							  "css after rule with A content not found on headword");
 		}
 
@@ -1294,8 +1294,8 @@ namespace SIL.FieldWorks.XWorks
 				XHTMLWriter.WriteEndElement();
 				XHTMLWriter.Flush();
 				var result = xhtmResult.ToString();
-				const string positiveTest = "//*[@class='bolo']";
-				const string negativeTest = "//*[@class='lexentry']";
+				const string positiveTest = "//*[@class='bolo-1']";
+				const string negativeTest = "//*[@class='lexentry-1']";
 				AssertThatXmlIn.String(result).HasNoMatchForXpath(negativeTest);
 				AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(positiveTest, 1);
 			}
@@ -1332,8 +1332,8 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(cssResult, Contains.Substring(".tailwind"));
 
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, testParentNode, null, DefaultSettings).ToString();
-			const string positiveTest = "//*[@class='tailwind']";
-			const string negativeTest = "//*[@class='headword']";
+			const string positiveTest = "//*[@class='tailwind-1']";
+			const string negativeTest = "//*[@class='headword-1']";
 			AssertThatXmlIn.String(result).HasNoMatchForXpath(negativeTest);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(positiveTest, 1);
 		}
@@ -1373,7 +1373,7 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(cssResult, Contains.Substring(".gloss"));
 
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, testEntryNode, null, DefaultSettings).ToString();
-			const string positiveTest = "/*[@class='lexentry']/span[@class='senses']/span[@class='sense']/span[@class='gloss']";
+			const string positiveTest = "/*[@class='lexentry-1']/span[@class='senses-1']/span[@class='sense']/span[@class='gloss-1']";
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(positiveTest, 1);
 		}
 
@@ -1936,7 +1936,7 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(headwordMain);
 			cssGenerator.AddStyles(form);
 			var cssResult = cssGenerator.GetStylesString();
-			VerifyRegex(cssResult, @"^\s*\.headword-otherreferencedcomplexforms", "Headword node not generated for non subentry headword");
+			VerifyRegex(cssResult, @"\.otherreferencedcomplexforms-.\s.headword-.", "Headword node not generated for non subentry headword");
 		}
 
 		[Test]
@@ -2009,8 +2009,8 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(senses);
 			cssGenerator.AddStyles(gramInfo);
 			var cssResult = cssGenerator.GetStylesString();
-			VerifyRegex(cssResult, @"^\s*\.morphosyntaxanalysisra", "Style for morphosyntaxanalysisra not generated");
-			VerifyRegex(cssResult, @"^\s*\.morphosyntaxanalysisra\s*{.*font-family\s*:\s*'foofoo'\,serif.*}",
+			VerifyRegex(cssResult, @"\.morphosyntaxanalysisra-.", "Style for morphosyntaxanalysisra not generated");
+			VerifyRegex(cssResult, @"\.morphosyntaxanalysisra-.\s*{.*font-family\s*:\s*'foofoo'\,serif.*}",
 				"Style for morphosyntaxanalysisra not placed correctly");
 		}
 
@@ -3088,6 +3088,7 @@ namespace SIL.FieldWorks.XWorks
 			var testEntryNode = new ConfigurableDictionaryNode
 			{
 				FieldDescription = "LexEntry",
+				Style = "Dictionary-Normal",
 				Children = new List<ConfigurableDictionaryNode> { testSensesNode },
 				CSSClassNameOverride = "entry"
 			};
@@ -3100,13 +3101,13 @@ namespace SIL.FieldWorks.XWorks
 			var cssResult = CssGenerator.GenerateCssFromConfiguration(model, m_propertyTable);
 			Assert.IsTrue(
 				Regex.Match(cssResult,
-					@"div.entry{\s*margin-left:24pt;\s*padding-right:48pt;\s*}",
+					@".entry{\s*margin-left:24pt;\s*padding-right:48pt;\s*",
 					RegexOptions.Singleline).Success,
 				"Dictionary-Normal Paragraph Style not generated when main entry has no style selected.");
 			model.Parts[0].Style = "Dictionary-RTL";
 			cssResult = CssGenerator.GenerateCssFromConfiguration(model, m_propertyTable);
 			Assert.IsTrue(
-				Regex.Match(cssResult, @"div.entry{\s*direction:rtl;\s*}",
+				Regex.Match(cssResult, @".entry{\s*direction:rtl;\s*}",
 					RegexOptions.Singleline).Success,
 				"Main Entry style was not used as the main page style");
 		}
@@ -3127,6 +3128,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				FieldDescription = "LexEntry",
 				CSSClassNameOverride = "minorentry",
+				Style = "Dictionary-Minor",
 				Children = new List<ConfigurableDictionaryNode> { testSensesNode }
 			};
 			var extraEntryNode = new ConfigurableDictionaryNode
@@ -3155,11 +3157,11 @@ namespace SIL.FieldWorks.XWorks
 			model.Parts.ForEach(PopulateFieldsForTesting);
 			//SUT
 			var cssResult = CssGenerator.GenerateCssFromConfiguration(model, m_propertyTable);
-			VerifyRegex(cssResult, @"div.minorentry{\s*margin-left:24pt;\s*padding-right:48pt;\s*}",
+			VerifyRegex(cssResult, @".minorentry{\s*margin-left:24pt;\s*padding-right:48pt;\s*",
 							  "Dictionary-Minor Paragraph Style not generated.");
-			VerifyRegex(cssResult, @"div.specialminorentry{\s*padding-right:32pt;\s*}",
+			VerifyRegex(cssResult, @".specialminorentry{\s*padding-right:32pt;\s*}",
 							  "Dictionary-Minor Paragraph Style for node with style attribute not generated.");
-			VerifyRegex(cssResult, @"div.optionsminorentry{\s*padding-right:16pt;\s*}",
+			VerifyRegex(cssResult, @".optionsminorentry{\s*padding-right:16pt;\s*}",
 							  "Dictionary-Minor Paragraph Style for node with paragraph options not generated.");
 		}
 
@@ -3198,7 +3200,7 @@ namespace SIL.FieldWorks.XWorks
 			// "Then generate the rules for all the writing system overrides"
 			// So I chose to check specifically for one of the default writing systems; DefaultAnalWs would have worked too.
 			var vernStyle = "span[lang='" + vernWs + "']{color:#008000;}";
-			Assert.That(Regex.Replace(cssResult, @"\t|\n|\r", ""), Contains.Substring(@"div.minorentryvariant " + vernStyle),
+			Assert.That(Regex.Replace(cssResult, @"\t|\n|\r", ""), Contains.Substring(@"minorentryvariant " + vernStyle),
 				"Dictionary-Secondary Paragraph Style should be generated.");
 		}
 
@@ -3468,7 +3470,7 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(senses);
 			cssGenerator.AddStyles(subsenses);
 			var cssResult = cssGenerator.GetStylesString();
-			const string regExPected = @".*senses\s>\s.sensecontent:before.*{.*content:'\\25A0';.*font-size:14pt;.*color:Green;.*font-family:Arial;.*font-weight:bold;.*font-style:italic;.*background-color:Brown;.*}";
+			const string regExPected = @".*senses-.\s>\s.sensecontent:before.*{.*content:'\\25A0';.*font-size:14pt;.*color:Green;.*font-family:Arial;.*font-weight:bold;.*font-style:italic;.*background-color:Brown;.*}";
 			Assert.That(Regex.Match(cssResult, regExPected, RegexOptions.Singleline).Success, "Bulleted style for SubSenses not generated.");
 			Assert.That(!Regex.Match(cssResult, regExPected, RegexOptions.Singleline).NextMatch().Success, "Bulleted style for SubSenses not generated.");
 		}
@@ -3514,9 +3516,9 @@ namespace SIL.FieldWorks.XWorks
 			cssGenerator.AddStyles(senses);
 			cssGenerator.AddStyles(subsenses);
 			var cssResult = cssGenerator.GetStylesString();
-			const string regExPectedForSub = @"\.senses-senses\s>\s.sensecontent:before.*{.*content:'\\25A0';.*font-size:14pt;.*color:Green;.*font-family:Arial;.*font-weight:bold;.*font-style:italic;.*background-color:Brown;.*}";
+			const string regExPectedForSub = @"\.senses-.\s\.senses-.\s>\s\.sensecontent:before.*{.*content:'\\25A0';.*font-size:14pt;.*color:Green;.*font-family:Arial;.*font-weight:bold;.*font-style:italic;.*background-color:Brown;.*}";
 			VerifyRegex(cssResult, regExPectedForSub, "Bulleted style for SubSenses not generated.");
-			const string regExPectedForSense = @"\.senses\s>\s\.sensecontent"; // Make sure there is a .sense > .sensecontent rule as well as the bulletted sub-sense
+			const string regExPectedForSense = @"\.senses-.\s>\s\.sensecontent"; // Make sure there is a .sense > .sensecontent rule as well as the bulletted sub-sense
 			VerifyRegex(cssResult, regExPectedForSense, "Non-bulleted style for Senses not generated.");
 		}
 

--- a/Src/xWorks/xWorksTests/LcmJsonGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/LcmJsonGeneratorTests.cs
@@ -158,8 +158,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0).ToString();
 			Console.WriteLine(result);
-			var expectedResult = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""senses"": [{""guid"":""g" + entry.Guid + @""",""gloss"": [{""lang"":""en"",""value"":""gloss""}]},]}";
+			var expectedResult = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""senses-1"": [{""guid"":""g" + entry.Guid + @""",""gloss-1"": [{""lang"":""en"",""value"":""gloss""}]},]}";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResult);
 			VerifyJson(result, expected);
@@ -191,8 +191,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0).ToString();
 
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""senses"": [{""guid"":""g" + entry.Guid + @""", ""definitionorgloss"": [{""lang"":""en"",""value"":""gloss""},
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""senses-1"": [{""guid"":""g" + entry.Guid + @""", ""definitionorgloss-1"": [{""lang"":""en"",""value"":""gloss""},
 				{""lang"":""es"",""value"":""definition""}]}]}";
 			//This assert is dependent on the specific entry data created in CreateInterestingLexEntry
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults);
@@ -257,9 +257,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings, 0).ToString();
 			Console.WriteLine(result);
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""msas"": {""mlpartofspeech"": [{""lang"":""en"",""value"":""Blah""}]}, ""senses"": [{""guid"":""g" + entry.Guid + @""",""gloss"": [{""lang"":""en"",""value"":""gloss""}]},
-				{""guid"":""g" + entry.Guid + @""",""gloss"": [{""lang"":""en"",""value"":""second sense""}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""msas-1"": {""mlpartofspeech-1"": [{""lang"":""en"",""value"":""Blah""}]}, ""senses-1"": [{""guid"":""g" + entry.Guid + @""",""gloss-1"": [{""lang"":""en"",""value"":""gloss""}]},
+				{""guid"":""g" + entry.Guid + @""",""gloss-1"": [{""lang"":""en"",""value"":""second sense""}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -297,9 +297,9 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, settings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""pictures"": [{""guid"":""g" + sensePic.Guid + @""",""src"":""pictures/test_auth_copy_license.jpg"",
-				""sensenumber"": [{""lang"":""en"",""value"":""1""}],""caption"": [{""lang"":""en"",""value"":""caption""}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""pictures-1"": [{""guid"":""g" + sensePic.Guid + @""",""src"":""pictures/test_auth_copy_license.jpg"",
+				""sensenumber-1"": [{""lang"":""en"",""value"":""1""}],""caption-1"": [{""lang"":""en"",""value"":""caption""}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -512,12 +512,12 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNode, pubMain, DefaultSettings, 0).ToString();
 			Assert.That(output, Is.Not.Null.Or.Empty);
-			var expectedResults = "{\"xhtmlTemplate\": \"lexentry\",\"guid\":\"g" + entryEntry.Guid + "\",\"letterHead\": \"e\",\"sortIndex\": 0," +
-								  "\"entry\": [{\"lang\":\"fr\",\"value\":\"entry\"}],\"senses\": [{\"guid\":\"g" +
-								  entryEntry.Guid + "\",\"definitionorgloss\": [{\"lang\":\"en\",\"value\":\"entry\"}]}]," +
-								  "\"subentries\": [{\"subentry\": [{\"lang\":\"fr\",\"value\":\"mainsubentry\"}]}]," +
-								  "\"variantformentrybackrefs\": [{\"referenceType\":\"{\\\"name\\\": [{\\\"lang\\\":\\\"en\\\"," +
-								  "\\\"value\\\":\\\"Spelling Variant\\\"}],},\",\"references\":[{\"headword\": [{\"lang\":\"fr\",\"guid\": \"g" +
+			var expectedResults = "{\"xhtmlTemplate\": \"lexentry-1\",\"guid\":\"g" + entryEntry.Guid + "\",\"letterHead\": \"e\",\"sortIndex\": 0," +
+								  "\"entry-1\": [{\"lang\":\"fr\",\"value\":\"entry\"}],\"senses-1\": [{\"guid\":\"g" +
+								  entryEntry.Guid + "\",\"definitionorgloss-1\": [{\"lang\":\"en\",\"value\":\"entry\"}]}]," +
+								  "\"subentries-1\": [{\"subentry-1\": [{\"lang\":\"fr\",\"value\":\"mainsubentry\"}]}]," +
+								  "\"variantformentrybackrefs-1\": [{\"referenceType\":\"{\\\"name-1\\\": [{\\\"lang\\\":\\\"en\\\"," +
+								  "\\\"value\\\":\\\"Spelling Variant\\\"}],},\",\"references\":[{\"headword-1\": [{\"lang\":\"fr\",\"guid\": \"g" +
 								  bizarroVariant.Guid + "\", \"value\":\"bizarre\"}]}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(output, expected);
@@ -582,11 +582,11 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var outputTypeAfter = ConfiguredLcmGenerator.GenerateContentForEntry(entryEntry, mainEntryNodeTypeAfter, pubMain, DefaultSettings, 0).ToString();
 			Assert.That(outputTypeAfter, Is.Not.Null.Or.Empty);
-			var expectedResultsTypeAfter = "{\"xhtmlTemplate\": \"lexentry\",\"guid\":\"g" + entryEntry.Guid + "\",\"letterHead\": \"e\",\"sortIndex\": 0," +
-								  "\"entry\": [{\"lang\":\"fr\",\"value\":\"entry\"}]," +
-								  "\"variantformentrybackrefs\": [{\"references\":[{\"headword\": [{\"lang\":\"fr\",\"guid\": \"g" +
+			var expectedResultsTypeAfter = "{\"xhtmlTemplate\": \"lexentry-1\",\"guid\":\"g" + entryEntry.Guid + "\",\"letterHead\": \"e\",\"sortIndex\": 0," +
+								  "\"entry-1\": [{\"lang\":\"fr\",\"value\":\"entry\"}]," +
+								  "\"variantformentrybackrefs-1\": [{\"references\":[{\"headword-1\": [{\"lang\":\"fr\",\"guid\": \"g" +
 								  bizarroVariant.Guid + "\", \"value\":\"bizarre\"}]}]," +
-								  "\"referenceType\":\"{\\\"name\\\": [{\\\"lang\\\":\\\"en\\\",\\\"value\\\":\\\"Spelling Variant\\\"}],},\"}]}";
+								  "\"referenceType\":\"{\\\"name-1\\\": [{\\\"lang\\\":\\\"en\\\",\\\"value\\\":\\\"Spelling Variant\\\"}],},\"}]}";
 			var expectedTypeAfter = (JObject)JsonConvert.DeserializeObject(expectedResultsTypeAfter, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(outputTypeAfter, expectedTypeAfter);
 		}
@@ -617,8 +617,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, DefaultSettings, 0).ToString();
 
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"": ""g" + entryOne.Guid +
-								  @""",""letterHead"": ""c"",""sortIndex"": 0, ""headword"": [{""guid"": ""g" + entryOne.Guid + @""", ""lang"":""en-Zxxx-x-audio"", ""value"": {""id"": ""gTest_Audi_o"", ""src"": ""AudioVisual/Test Audi'o.wav""}}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"": ""g" + entryOne.Guid +
+								  @""",""letterHead"": ""c"",""sortIndex"": 0, ""headword-1"": [{""guid"": ""g" + entryOne.Guid + @""", ""lang"":""en-Zxxx-x-audio"", ""value"": {""id"": ""gTest_Audi_o"", ""src"": ""AudioVisual/Test Audi'o.wav""}}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -674,9 +674,9 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 			var output = ConfiguredLcmGenerator.GenerateContentForEntry(entryCorps, mainEntryNode, DefaultDecorator, DefaultSettings, 0).ToString();
 			Assert.That(output, Is.Not.Null.Or.Empty);
-			var expectedResults = "{\"xhtmlTemplate\":\"lexentry\",\"guid\":\"g" + entryCorps.Guid + "\",\"letterHead\":\"c\",\"sortIndex\":0," +
-								  "\"entry\": [{\"lang\":\"fr\",\"value\":\"corps\"}]," +
-								  "\"pronunciations\": [{\"mediafiles\": [{\"value\": {\"id\":\"g" + mainMediaFile.Guid + "\",\"src\": \"AudioVisual/fileName.mp4\"}}]}]}";
+			var expectedResults = "{\"xhtmlTemplate\":\"lexentry-1\",\"guid\":\"g" + entryCorps.Guid + "\",\"letterHead\":\"c\",\"sortIndex\":0," +
+								  "\"entry-1\": [{\"lang\":\"fr\",\"value\":\"corps\"}]," +
+								  "\"pronunciations-1\": [{\"mediafiles-1\": [{\"value\": {\"id\":\"g" + mainMediaFile.Guid + "\",\"src\": \"AudioVisual/fileName.mp4\"}}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(output, expected);
 		}
@@ -703,9 +703,9 @@ namespace SIL.FieldWorks.XWorks
 			ConfiguredXHTMLGeneratorTests.AddSenseToEntry(testEntry, "second gloss", m_wsEn, Cache);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, DefaultDecorator, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""senses"":[{""senseNumber"":""1"",
-				""guid"":""g" + testEntry.Guid + @""",""gloss"":[{""lang"":""en"",""value"":""gloss""}]},
-				{""senseNumber"":""2"",""guid"":""g" + testEntry.Guid + @""",""gloss"":[{""lang"":""en"",""value"":""second gloss""}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""senses-1"":[{""senseNumber"":""1"",
+				""guid"":""g" + testEntry.Guid + @""",""gloss-1"":[{""lang"":""en"",""value"":""gloss""}]},
+				{""senseNumber"":""2"",""guid"":""g" + testEntry.Guid + @""",""gloss-1"":[{""lang"":""en"",""value"":""second gloss""}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -732,7 +732,7 @@ namespace SIL.FieldWorks.XWorks
 			entry.Bibliography.set_String(m_wsFr, multiRunString);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""bib"": [{""lang"":""fr"",""value"":""French with ""},
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""bib-1"": [{""lang"":""fr"",""value"":""French with ""},
 				{""lang"":""en"",""value"":""English""},{""lang"":""fr"",""value"":"" embedded""}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
@@ -758,8 +758,8 @@ namespace SIL.FieldWorks.XWorks
 			entry.Bibliography.set_String(m_wsFr, englishStr);
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""bib"": [{""lang"":""en"",""value"":""English\nwith line break""}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""bib-1"": [{""lang"":""en"",""value"":""English\nwith line break""}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -805,8 +805,8 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + mainEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""sensesos"": [{""lexsensereferences"": [{""ownertype_name"": [{""lang"":""en"",""value"":""TestRefType""}]}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + mainEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""sensesos-1"": [{""lexsensereferences-1"": [{""ownertype_name-1"": [{""lang"":""en"",""value"":""TestRefType""}]}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -848,8 +848,8 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(mainEntry, mainEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + mainEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""sensesos"": [{""lexsensereferences"": [{}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + mainEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""sensesos-1"": [{""lexsensereferences-1"": [{}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 		}
@@ -875,13 +875,13 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""homographnumber"": ""1"",
-				""citationform"": [{""lang"":""fr"",""value"":""Citation""}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""homographnumber-1"": ""1"",
+				""citationform-1"": [{""lang"":""fr"",""value"":""Citation""}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 			result = ConfiguredLcmGenerator.GenerateContentForEntry(entryTwo, mainEntryNode, null, DefaultSettings, 0).ToString();
-			expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entryTwo.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""homographnumber"": ""2"",
-				""citationform"": [{""lang"":""fr"",""value"":""Citation""}]}";
+			expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entryTwo.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,""homographnumber-1"": ""2"",
+				""citationform-1"": [{""lang"":""fr"",""value"":""Citation""}]}";
 			expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 
@@ -906,14 +906,14 @@ namespace SIL.FieldWorks.XWorks
 
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, DefaultSettings, 36).ToString();
-			var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": 36,
-				""citationform"": [{""lang"":""fr"",""value"":""Citation""}]}";
+			var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": 36,
+				""citationform-1"": [{""lang"":""fr"",""value"":""Citation""}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 			// default value of -1
 			result = ConfiguredLcmGenerator.GenerateContentForEntry(entryOne, mainEntryNode, null, DefaultSettings).ToString();
-			expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": -1,
-				""citationform"": [{""lang"":""fr"",""value"":""Citation""}]}";
+			expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + entryOne.Guid + @""",""letterHead"": ""c"",""sortIndex"": -1,
+				""citationform-1"": [{""lang"":""fr"",""value"":""Citation""}]}";
 			expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 
@@ -961,8 +961,8 @@ namespace SIL.FieldWorks.XWorks
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, mainEntryNode, null, DefaultSettings, 0).ToString();
 
 				// Bug: The second filename should be different after the export with relative path settings (fix later)
-				var expectedResults = @"{""xhtmlTemplate"": ""lexentry"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-					""pictures"": [{""guid"":""g" + sensePic.Guid + @""",""src"":""pictures/" + fileName + @"""},
+				var expectedResults = @"{""xhtmlTemplate"": ""lexentry-1"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+					""pictures-1"": [{""guid"":""g" + sensePic.Guid + @""",""src"":""pictures/" + fileName + @"""},
 					{""guid"":""g" + sensePic2.Guid + @""",""src"":""pictures/" + fileName + @"""}],}";
 				var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 				VerifyJson(result, expected);
@@ -1025,22 +1025,22 @@ namespace SIL.FieldWorks.XWorks
 ;
 			//SUT
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(subentry1, minorEntryNode, null, DefaultSettings, 0).ToString();
-			var expectedResults = @"{""xhtmlTemplate"":""minorentrycomplex"",""guid"":""g" + subentry1.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""complexformentryrefs"": [{""referencedentries"": [{""glossorsummary"": [{""lang"":""en"",""value"":""MainEntrySummaryDefn""}]}]}]}";
+			var expectedResults = @"{""xhtmlTemplate"":""minorentrycomplex-1"",""guid"":""g" + subentry1.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""complexformentryrefs-1"": [{""referencedentries-1"": [{""glossorsummary-1"": [{""lang"":""en"",""value"":""MainEntrySummaryDefn""}]}]}]}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result, expected);
 
 			//SUT
 			var result2 = ConfiguredLcmGenerator.GenerateContentForEntry(subentry2, minorEntryNode, null, DefaultSettings, 0).ToString();
-			expectedResults = @"{""xhtmlTemplate"":""minorentrycomplex"",""guid"":""g" + subentry2.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""complexformentryrefs"": [{""referencedentries"": [{""glossorsummary"": [{""lang"":""en"",""value"":""gloss2""}]}]}]}";
+			expectedResults = @"{""xhtmlTemplate"":""minorentrycomplex-1"",""guid"":""g" + subentry2.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""complexformentryrefs-1"": [{""referencedentries-1"": [{""glossorsummary-1"": [{""lang"":""en"",""value"":""gloss2""}]}]}]}";
 			expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result2, expected);
 
 			//SUT
 			var result3 = ConfiguredLcmGenerator.GenerateContentForEntry(subentry3, minorEntryNode, null, DefaultSettings, 0).ToString();
-			expectedResults = @"{""xhtmlTemplate"": ""minorentrycomplex"",""guid"":""g" + subentry3.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""complexformentryrefs"": [{""referencedentries"": [{""glossorsummary"": [{""lang"":""en"",""value"":""MainEntryS3Defn""}]}]}]}";
+			expectedResults = @"{""xhtmlTemplate"": ""minorentrycomplex-1"",""guid"":""g" + subentry3.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""complexformentryrefs-1"": [{""referencedentries-1"": [{""glossorsummary-1"": [{""lang"":""en"",""value"":""MainEntryS3Defn""}]}]}]}";
 			expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(result3, expected);
 		}
@@ -1103,11 +1103,11 @@ namespace SIL.FieldWorks.XWorks
 				DefaultDecorator, 1,
 				new DictionaryConfigurationModel { Parts = new List<ConfigurableDictionaryNode> { mainEntryNode } },
 				m_propertyTable, "test.json", null, out int[] _);
-			var expectedResults = @"{""xhtmlTemplate"":""lexentry"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
-				""homographnumber"":""0"",""citationform"":[{""lang"":""fr"",""value"":""Citation""}],
-				""displayXhtml"":""<div class=\""lexentry\"" nodeId=\""" + mainEntryNode.GetHashCode() +
-				@"\"" id=\""g" + testEntry.Guid + @"\""><span class=\""homographnumber\"" nodeId=\""" + homographNum.GetHashCode() +
-				@"\"">0</span><span class=\""citationform\""><span nodeId=\""" + citationForm.GetHashCode() + @"\"" lang=\""fr\"">Citation</span></span></div>""}";
+			var expectedResults = @"{""xhtmlTemplate"":""lexentry-1"",""guid"":""g" + testEntry.Guid + @""",""letterHead"": ""c"",""sortIndex"": 0,
+				""homographnumber-1"":""0"",""citationform-1"":[{""lang"":""fr"",""value"":""Citation""}],
+				""displayXhtml"":""<div class=\""lexentry-1\"" nodeId=\""" + mainEntryNode.GetHashCode() +
+				@"\"" id=\""g" + testEntry.Guid + @"\""><span class=\""homographnumber-1\"" nodeId=\""" + homographNum.GetHashCode() +
+				@"\"">0</span><span class=\""citationform-1\""><span nodeId=\""" + citationForm.GetHashCode() + @"\"" lang=\""fr\"">Citation</span></span></div>""}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(results[0][0].ToString(Formatting.None), expected);
 		}
@@ -1203,8 +1203,8 @@ namespace SIL.FieldWorks.XWorks
 			//SUT
 
 			var json = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings).ToString();
-			var expectedResults = @"{""xhtmlTemplate"":""lexentry"",""guid"":""g" + entry.Guid + @""",""letterHead"":""c"",""sortIndex"":-1,
-				""bib"": [{""lang"":""he"",""value"":""דוד""},{""lang"":""en"",""value"":"" et ""},{""lang"":""he"",""value"":""דניאל""}],}";
+			var expectedResults = @"{""xhtmlTemplate"":""lexentry-1"",""guid"":""g" + entry.Guid + @""",""letterHead"":""c"",""sortIndex"":-1,
+				""bib-1"": [{""lang"":""he"",""value"":""דוד""},{""lang"":""en"",""value"":"" et ""},{""lang"":""he"",""value"":""דניאל""}],}";
 			var expected = (JObject)JsonConvert.DeserializeObject(expectedResults, new JsonSerializerSettings { Formatting = Formatting.None });
 			VerifyJson(json, expected);
 		}
@@ -1233,7 +1233,7 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				var result = ConfiguredLcmGenerator.GenerateContentForEntry(testEntry, rootNode, null, DefaultSettings, 0).ToString();
 
-				var expectedResults = @"{""xhtmlTemplate"":""lexentry"",
+				var expectedResults = @"{""xhtmlTemplate"":""lexentry-1"",
 					""guid"":""g" + testEntry.Guid + @""",
 					""letterHead"":""c"",
 					""sortIndex"":0,


### PR DESCRIPTION
- Keep the node path back to the root in the css file.  This is needed to ensure that styles are applied from the most specific (leaf node) to the lease specific (root node).
- All node names now have a unique identifier.  This is to prevent the wrong style from being used when nodes have the same display name (ie. Headword) but are located at different places in the tree. Without the unique identifier a node without a style could end up using a style from a different node with the same display name. With unique names, a node without a style will look to its parent node for style information, and then it’s grandparent node, … up to the root.
- The change in RemoveBeforeAndAfterForNoteInParaRules(): Changed the method so that we keep non-before/after rules. This fixes a problem with notes that should be in their own paragraph, not displaying correctly in Flex.

Additional cleanup still needed for the .css files (these issues Existed before this PR):

- We are currently creating multiple css entries with the same fields but different values.  In this case we always use the values from the last entry in the file.  We need to figure out why we are doing this and either support the intended behavior in a different way or remove the duplicates.
Example: ‘.subentries .subentry{}’ is written multiple times with the same 12 fields. The only field that ever changes value is ‘margin-left’.

- Sometimes we are removing the last letter from entry names in the css file for ‘between’ content. Need to investigate if this currently works to provide ‘between’ content.
Example: .headword> .headwor+ .headwor:before{	content:', ';}

Change-Id: I9b684c074b59f95b4c8a2b2c2adff73ea352a630

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/262)
<!-- Reviewable:end -->
