### PR TITLE
LT-22042: Fix incorrect styles being used for subentries

### DIFF
--- a/Src/xWorks/CssGenerator.cs
+++ b/Src/xWorks/CssGenerator.cs
@@ -105,8 +105,9 @@ namespace SIL.FieldWorks.XWorks
 					var workingClassName = $".{GetClassAttributeForConfig(workingNode)}";
 
 					// If this node is ".subentries" and the next node is ".mainentrysubentries",
-					// then we need to build two sets of rules, one for ".entry-1 .subentries-?"
-					// and one for ".entry-1 .senses-? .subentries-?". We only need to build the two
+					// then we need to build the same set of rules twice, once for ".entry-1 .subentries-?"
+					// and once for ".entry-1 .senses-? .subentries-?", so that the xhtml can choose
+					// the rules associated with the correct path. We only need to build the two
 					// set for the children. The node ".entry-1 .senses-? .subentries-?" does NOT
 					// need a second set of rules.  It's rules will get created through the normal
 					// execution of this method (and could use a different style).


### PR DESCRIPTION
The style information used for the nodes under
MainEntry->Subentries, is also used for
MainEntry->Senses->Subentries.
Fix the problem so that we now use the style information for both node paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/265)
<!-- Reviewable:end -->
