### PR TITLE
Fix LT-21958 (Required Features for Lexeme Form should be visible)

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Lexicon/browseDialogColumns.xml
+++ b/DistFiles/Language Explorer/Configuration/Lexicon/browseDialogColumns.xml
@@ -175,6 +175,7 @@
 		</dynamicloaderinfo>
 	</column>
 			<!--bulkEdit="customCollection" field="MoAffixForm.InflectionClasses" list="" -->
+    <column layout="RequiredFeaturesForLexemeForm" multipara="true" label="Required Features" visibility="dialog"/>
 	<column layout="RequiredFeatures" multipara="true" label="Required Features (Allomorph)" visibility="dialog"/>
 	<column layout="HomographNumberForEntry" label="Homograph number" visibility="dialog" editable="true" sortType="integer" blankPossible="false" /><!-- editable requested by LT-4688 -->
 	<column layout="ComponentsBrowse" label="Components" multipara="true" editable="false" visibility="dialog" ws="$ws=vernacular" />

--- a/DistFiles/Language Explorer/Configuration/Parts/LexEntryParts.xml
+++ b/DistFiles/Language Explorer/Configuration/Parts/LexEntryParts.xml
@@ -367,6 +367,9 @@
 			<obj field="LexemeForm" layout="InflectionClassForLexemeForm"/>
 			<seq field="AlternateForms" layout="InflectionClassForAffix"/>
 		</part>
+        <part id="LexEntry-Jt-RequiredFeaturesForLexemeForm" type="JtView">
+          <obj field="LexemeForm" layout="RequiredFeatures"/>
+        </part>
 		<part id="LexEntry-Jt-RequiredFeatures" type="JtView">
 			<seq field="AlternateForms" layout="RequiredFeatures"/>
 		</part>

--- a/DistFiles/Language Explorer/Configuration/Parts/MorphologyParts.xml
+++ b/DistFiles/Language Explorer/Configuration/Parts/MorphologyParts.xml
@@ -370,7 +370,9 @@
 		</part>
 		<part id="MoForm-Jt-RequiredFeatures" type="JtView">
 			<if is="MoAffixAllomorph">
-				<obj field="MsEnvFeatures" layout="Browse"/>
+                <obj field="MsEnvFeatures" layout="empty">
+                  <string field="LongNameTSS"/>
+                </obj>
 			</if>
 		</part>
 		<part id="MoForm-Jt-SimpleForm" type="JtView">


### PR DESCRIPTION
I added a column for Required Features for Lexemes to the browse view of the Lexicon Entries window.  I also had to change how required features are displayed since the existing code displayed "f" instead of "[nagr: [gen:f]]".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/267)
<!-- Reviewable:end -->
