### PR TITLE
Fix LT-21953: Sort Reversal Subentries crash when subentry missing form

### DIFF
--- a/Src/ManagedLgIcuCollator/LgIcuCollator.cs
+++ b/Src/ManagedLgIcuCollator/LgIcuCollator.cs
@@ -94,6 +94,10 @@ namespace SIL.FieldWorks.Language
 		public int Compare(string bstrValue1, string bstrValue2, LgCollatingOptions colopt)
 		{
 			EnsureCollator();
+			if (bstrValue1 == null)
+				bstrValue1 = "";
+			if (bstrValue2 == null)
+				bstrValue2 = "";
 			var key1 = m_collator.GetSortKey(bstrValue1).KeyData;
 			var key2 = m_collator.GetSortKey(bstrValue2).KeyData;
 


### PR DESCRIPTION
I replaced null with "" to avoid the crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/268)
<!-- Reviewable:end -->
