### PR TITLE
Fix LT-22047 without breaking LT-21810

### DIFF
--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -158,26 +158,24 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			if (sLower != form.Text)
 			{
 				var text = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
-				IWfiWordform lcWordform;
-				// We cannot use WfiWordformServices.FindOrCreateWordform because of props change (LT-21810).
-				// Only parse the lowercase version if it exists.
-				if (m_cache.ServiceLocator.GetInstance<IWfiWordformRepository>().TryGetObject(text, out lcWordform))
+				var lcWord = normalizer.Normalize(sLower.Replace(' ', '.'));
+				ParseResult lcResult = null;
+				stopWatch.Start();
+				using (var task = new TaskReport(String.Format(ParserCoreStrings.ksParsingX, word), m_taskUpdateHandler))
 				{
-					var lcWord = normalizer.Normalize(sLower.Replace(' ', '.'));
-					ParseResult lcResult = null;
-					stopWatch.Start();
-					using (var task = new TaskReport(String.Format(ParserCoreStrings.ksParsingX, word), m_taskUpdateHandler))
-					{
-						lcResult = m_parser.ParseWord(lcWord);
-					}
-					stopWatch.Stop();
-					lcResult.ParseTime = stopWatch.ElapsedMilliseconds;
-					if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
-					{
-						m_parseFiler.ProcessParse(lcWordform, 0, lcResult, checkParser);
-						m_parseFiler.ProcessParse(wordform, priority, result, checkParser);
-						return true;
-					}
+					lcResult = m_parser.ParseWord(lcWord);
+				}
+				stopWatch.Stop();
+				lcResult.ParseTime = stopWatch.ElapsedMilliseconds;
+				if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
+				{
+					IWfiWordform lcWordform = null;
+					NonUndoableUnitOfWorkHelper.Do(
+						m_cache.ActionHandlerAccessor,
+						() => lcWordform = WfiWordformServices.FindOrCreateWordform(m_cache, text));
+					m_parseFiler.ProcessParse(lcWordform, 0, lcResult, checkParser);
+					m_parseFiler.ProcessParse(wordform, priority, result, checkParser);
+					return true;
 				}
 			}
 

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -170,7 +170,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
 				{
 					IWfiWordform lcWordform = null;
-					NonUndoableUnitOfWorkHelper.Do(
+					NonUndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW(
 						m_cache.ActionHandlerAccessor,
 						() => lcWordform = WfiWordformServices.FindOrCreateWordform(m_cache, text));
 					m_parseFiler.ProcessParse(lcWordform, 0, lcResult, checkParser);


### PR DESCRIPTION
The original code broke because FindOrCreateWordform was not in the scope of a unit of work helper.  Not knowing better, I fixed in LT-21810 by avoided calling FindOrCreateWordform.  But this causes problems if the corpus has an uppercase version of a lowercase word that doesn't appear in the corpus.  So I added a unit of work helper around FindOrCreateWordform that solves both LT-22047 and LT-21810.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/269)
<!-- Reviewable:end -->
