### PR TITLE
LT-22063: Crash while navigating to Word Analyses view

### DIFF
--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -1075,7 +1075,11 @@ namespace SIL.FieldWorks.XWorks
 					// target before complaining to the user about a filter being on.
 					var mdc = (IFwMetaDataCacheManaged)m_list.VirtualListPublisher.MetaDataCache;
 					int clidList = mdc.FieldExists(m_list.Flid) ? mdc.GetDstClsId(m_list.Flid) : -1;
-					int clidObj = m_list.Cache.ServiceLocator.GetInstance<ICmObjectRepository>().GetObject(hvoTarget).ClassID;
+					ICmObjectRepository objRepository = m_list.Cache.ServiceLocator.GetInstance<ICmObjectRepository>();
+					if (!objRepository.TryGetObject(hvoTarget, out ICmObject targetObject))
+						// The object was deleted (LT-22063).
+						return true;
+					int clidObj = targetObject.ClassID;
 
 					// If (int) clidList is -1, that means it was for a decorator property and the IsSameOrSubclassOf
 					// test won't be valid.


### PR DESCRIPTION
I fixed this by returning if the object no longer exists.  This is a good candidate for release/9.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/276)
<!-- Reviewable:end -->
