### PR TITLE
LT-22064: Issue with uppercase words in "Word Analyses" view

### DIFF
--- a/Src/LexText/Interlinear/FocusBoxController.ApproveAndMove.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.ApproveAndMove.cs
@@ -403,6 +403,9 @@ namespace SIL.FieldWorks.IText
 			FinishSettingAnalysis(newAnalysisTree, oldAnalysis);
 			if (obsoleteAna != null)
 				obsoleteAna.Delete();
+			if (oldWf != null && oldWf != wf && oldWf.OccurrencesInTexts.Count() == 0)
+				// oldWf is probably the uppercase form of wf.
+				oldWf.Delete();
 		}
 
 		// Caller must create UOW


### PR DESCRIPTION
In https://jira.sil.org/browse/LT-22047, Ron Lockwood complained that uppercase wordforms that were assigned a lowercase analysis still appeared in the Word Analyses window.  I thought that I had a fix for this issue, but https://jira.sil.org/browse/LT-22064 showed that the uppercase wordform still appeared in the Word Analyses window if you closed and reopened the project before it was assigned a lowercase analysis.  I fixed LT-22064 by explicitly deleting the uppercase wordform if it didn't appear in the corpus when it was assigned a lowercase analysis.

This should be included in release/9.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/279)
<!-- Reviewable:end -->
