### PR TITLE
Implement LT-22054: Add UI for setting picture options

### DIFF
--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014-2016 SIL International
+// Copyright (c) 2014-2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -111,7 +111,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 				else if (Options is DictionaryNodePictureOptions)
 				{
-					// todo: loading options here once UX has been worked out
+					optionsView = LoadPictureOptions(model.Pictures);
 				}
 				else
 				{
@@ -194,6 +194,29 @@ namespace SIL.FieldWorks.XWorks
 			View.AfterTextChanged += OnViewOnAfterTextChanged;
 
 			View.ResumeLayout();
+		}
+
+		private UserControl LoadPictureOptions(PictureConfiguration modelPictures)
+		{
+			var pictureOptionsView = new PictureOptionsView
+			{
+				Alignment = modelPictures.Alignment,
+				PictureWidth = modelPictures.Width
+			};
+
+			pictureOptionsView.AlignmentChanged += (sender, e) =>
+			{
+				modelPictures.Alignment = pictureOptionsView.Alignment;
+				RefreshPreview();
+			};
+
+			pictureOptionsView.WidthChanged += (sender, e) =>
+			{
+				modelPictures.Width = pictureOptionsView.PictureWidth;
+				RefreshPreview();
+			};
+
+			return pictureOptionsView;
 		}
 
 		internal static IEnumerable<ConfigurableDictionaryNode> FindNodes(

--- a/Src/xWorks/DictionaryDetailsView/PictureOptionsView.Designer.cs
+++ b/Src/xWorks/DictionaryDetailsView/PictureOptionsView.Designer.cs
@@ -1,0 +1,136 @@
+namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
+{
+	partial class PictureOptionsView
+	{
+		/// <summary> 
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary> 
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			System.Diagnostics.Debug.WriteLineIf(!disposing, "****** Missing Dispose() call for " + GetType().Name + ". ****** ");
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Component Designer generated code
+
+		/// <summary> 
+		/// Required method for Designer support - do not modify 
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+			this.documentPictureSettingsLabel = new System.Windows.Forms.Label();
+			this.alignmentLabel = new System.Windows.Forms.Label();
+			this.alignmentComboBox = new System.Windows.Forms.ComboBox();
+			this.widthLabel = new System.Windows.Forms.Label();
+			this.widthTextBox = new System.Windows.Forms.TextBox();
+			this.tableLayoutPanel.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// tableLayoutPanel
+			// 
+			this.tableLayoutPanel.ColumnCount = 2;
+			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel.Controls.Add(this.documentPictureSettingsLabel, 0, 0);
+			this.tableLayoutPanel.Controls.Add(this.alignmentLabel, 0, 1);
+			this.tableLayoutPanel.Controls.Add(this.alignmentComboBox, 1, 1);
+			this.tableLayoutPanel.Controls.Add(this.widthLabel, 0, 2);
+			this.tableLayoutPanel.Controls.Add(this.widthTextBox, 1, 2);
+			this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel.Name = "tableLayoutPanel";
+			this.tableLayoutPanel.RowCount = 3;
+			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+			this.tableLayoutPanel.Size = new System.Drawing.Size(200, 80);
+			this.tableLayoutPanel.TabIndex = 0;
+			// 
+			// documentImageSettingsLabel
+			// 
+			this.documentPictureSettingsLabel.AutoSize = true;
+			this.tableLayoutPanel.SetColumnSpan(this.documentPictureSettingsLabel, 2);
+			this.documentPictureSettingsLabel.Location = new System.Drawing.Point(3, 0);
+			this.documentPictureSettingsLabel.Name = "documentPictureSettingsLabel";
+			this.documentPictureSettingsLabel.Size = new System.Drawing.Size(123, 13);
+			this.documentPictureSettingsLabel.TabIndex = 0;
+			this.documentPictureSettingsLabel.Text = xWorksStrings.DocumentPictureSettingsLabelText;
+			this.documentPictureSettingsLabel.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+			// 
+			// alignmentLabel
+			// 
+			this.alignmentLabel.AutoSize = true;
+			this.alignmentLabel.Location = new System.Drawing.Point(3, 20);
+			this.alignmentLabel.Name = "alignmentLabel";
+			this.alignmentLabel.Size = new System.Drawing.Size(53, 13);
+			this.alignmentLabel.TabIndex = 1;
+			this.alignmentLabel.Text = xWorksStrings.AlignmentLabelText;
+			this.alignmentLabel.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
+			// 
+			// alignmentComboBox
+			// 
+			this.alignmentComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.alignmentComboBox.FormattingEnabled = true;
+			this.alignmentComboBox.Items.AddRange(new object[] {
+					 SIL.FieldWorks.XWorks.AlignmentType.Left,
+					 SIL.FieldWorks.XWorks.AlignmentType.Center,
+					 SIL.FieldWorks.XWorks.AlignmentType.Right});
+			this.alignmentComboBox.Location = new System.Drawing.Point(62, 23);
+			this.alignmentComboBox.Name = "alignmentComboBox";
+			this.alignmentComboBox.Size = new System.Drawing.Size(121, 21);
+			this.alignmentComboBox.TabIndex = 2;
+			this.alignmentComboBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+			// 
+			// widthLabel
+			// 
+			this.widthLabel.AutoSize = true;
+			this.widthLabel.Location = new System.Drawing.Point(3, 50);
+			this.widthLabel.Name = "widthLabel";
+			this.widthLabel.Size = new System.Drawing.Size(35, 13);
+			this.widthLabel.TabIndex = 3;
+			this.widthLabel.Text = xWorksStrings.WidthLabelText;
+			this.widthLabel.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
+			// 
+			// widthTextBox
+			// 
+			this.widthTextBox.Location = new System.Drawing.Point(62, 53);
+			this.widthTextBox.Name = "widthTextBox";
+			this.widthTextBox.Size = new System.Drawing.Size(121, 20);
+			this.widthTextBox.TabIndex = 4;
+			this.widthTextBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+			// 
+			// PictureOptionsView
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.tableLayoutPanel);
+			this.Name = "PictureOptionsView";
+			this.Size = new System.Drawing.Size(200, 80);
+			this.tableLayoutPanel.ResumeLayout(false);
+			this.tableLayoutPanel.PerformLayout();
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
+		private System.Windows.Forms.Label documentPictureSettingsLabel;
+		private System.Windows.Forms.Label alignmentLabel;
+		private System.Windows.Forms.ComboBox alignmentComboBox;
+		private System.Windows.Forms.Label widthLabel;
+		private System.Windows.Forms.TextBox widthTextBox;
+	}
+}

--- a/Src/xWorks/DictionaryDetailsView/PictureOptionsView.cs
+++ b/Src/xWorks/DictionaryDetailsView/PictureOptionsView.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
+{
+    /// <summary>
+    /// This view is responsible for the display of options for a PictureNode in the configuration dialog
+    /// </summary>
+    public partial class PictureOptionsView : UserControl
+    {
+        public PictureOptionsView()
+        {
+            InitializeComponent();
+        }
+
+        public AlignmentType Alignment
+        {
+            get => (AlignmentType)alignmentComboBox.SelectedItem;
+			set => alignmentComboBox.SelectedItem = value;
+		}
+
+        public double PictureWidth
+		{
+			get => double.TryParse(widthTextBox.Text, NumberStyles.Float, null, out var width)
+				? Math.Round(width, 2)
+				: 0.0f;
+			set => widthTextBox.Text = value.ToString("F2");
+		}
+
+        public event EventHandler AlignmentChanged
+        {
+            add => alignmentComboBox.SelectedIndexChanged += value;
+			remove => alignmentComboBox.SelectedIndexChanged -= value;
+		}
+
+        public event EventHandler WidthChanged
+        {
+            add => widthTextBox.TextChanged += value;
+			remove => widthTextBox.TextChanged -= value;
+		}
+    }
+}

--- a/Src/xWorks/DictionaryDetailsView/PictureOptionsView.resx
+++ b/Src/xWorks/DictionaryDetailsView/PictureOptionsView.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Src/xWorks/PictureConfiguration.cs
+++ b/Src/xWorks/PictureConfiguration.cs
@@ -17,12 +17,12 @@ namespace SIL.FieldWorks.XWorks
 		public PictureConfiguration() { }
 
 		[XmlAttribute("alignment")]
-		public AlignmentType Alignment { get; set; } = AlignmentType.Center;
+		public AlignmentType Alignment { get; set; } = AlignmentType.Right;
 
 		/// <summary>
 		/// Width of the picture in inches.
 		/// </summary>
 		[XmlAttribute("width")]
-		public float Width { get; set; } = 1.0f;
+		public double Width { get; set; } = 1.0f;
 	}
 }

--- a/Src/xWorks/xWorks.csproj
+++ b/Src/xWorks/xWorks.csproj
@@ -349,6 +349,12 @@
     <Compile Include="ConfigurableDictionaryNode.cs" />
     <Compile Include="ConfiguredLcmGenerator.cs" />
     <Compile Include="DictConfigModelExt.cs" />
+    <Compile Include="DictionaryDetailsView\PictureOptionsView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="DictionaryDetailsView\PictureOptionsView.Designer.cs">
+      <DependentUpon>PictureOptionsView.cs</DependentUpon>
+    </Compile>
     <Compile Include="HeadWordNumbersController.cs" />
     <Compile Include="HeadWordNumbersDlg.cs">
       <SubType>Form</SubType>
@@ -609,6 +615,9 @@
     <EmbeddedResource Include="AddCustomFieldDlg.resx">
       <DependentUpon>AddCustomFieldDlg.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DictionaryDetailsView\PictureOptionsView.resx">
+      <DependentUpon>PictureOptionsView.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="HeadWordNumbersDlg.resx">
       <DependentUpon>HeadWordNumbersDlg.cs</DependentUpon>

--- a/Src/xWorks/xWorksStrings.Designer.cs
+++ b/Src/xWorks/xWorksStrings.Designer.cs
@@ -70,6 +70,15 @@ namespace SIL.FieldWorks.XWorks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Alignment:.
+        /// </summary>
+        internal static string AlignmentLabelText {
+            get {
+                return ResourceManager.GetString("AlignmentLabelText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All Analysis then all Vernacular Writing Systems.
         /// </summary>
         internal static string AllAnalysisVernacularWs {
@@ -371,6 +380,15 @@ namespace SIL.FieldWorks.XWorks {
         internal static string DidNotSelectValidWsForDb {
             get {
                 return ResourceManager.GetString("DidNotSelectValidWsForDb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Document Picture Settings:.
+        /// </summary>
+        internal static string DocumentPictureSettingsLabelText {
+            get {
+                return ResourceManager.GetString("DocumentPictureSettingsLabelText", resourceCulture);
             }
         }
         
@@ -3085,6 +3103,15 @@ namespace SIL.FieldWorks.XWorks {
         internal static string WebonaryLogViewer_Save_a_copy {
             get {
                 return ResourceManager.GetString("WebonaryLogViewer_Save_a_copy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Width (inches):.
+        /// </summary>
+        internal static string WidthLabelText {
+            get {
+                return ResourceManager.GetString("WidthLabelText", resourceCulture);
             }
         }
         

--- a/Src/xWorks/xWorksStrings.resx
+++ b/Src/xWorks/xWorksStrings.resx
@@ -158,6 +158,15 @@ Are you SURE you want to delete the field {0}?</value>
   <data name="AlreadyFieldWithThisLabel" xml:space="preserve">
     <value>There are duplicate {0} fields named "{1}". Please choose a different name.</value>
   </data>
+  <data name="AlignmentLabelText" xml:space="preserve">
+    <value>Alignment:</value>
+  </data>
+  <data name="WidthLabelText" xml:space="preserve">
+    <value>Width (inches):</value>
+  </data>
+  <data name="DocumentPictureSettingsLabelText" xml:space="preserve">
+    <value>Document Picture Settings:</value>
+  </data>
   <data name="LabelAlreadyExists" xml:space="preserve">
     <value>Duplicate Custom Field Names</value>
   </data>


### PR DESCRIPTION
* Add a new DictionaryDetailsView for pictures that modifies the Pictures part of the DictionaryConfigurationModel

- I chose to use the existing picture node to add the interaction as that is most discoverable. I decided that with a lable that indicated that the setting was for *all* pictures in the document a separate dialog was not required. This could prove to be unfounded optimism

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/281)
<!-- Reviewable:end -->
