### PR TITLE
Fix LT-21826: Usage figures for Publications show inverted values

### DIFF
--- a/Src/Common/Controls/XMLViews/LabelNode.cs
+++ b/Src/Common/Controls/XMLViews/LabelNode.cs
@@ -105,6 +105,14 @@ namespace SIL.FieldWorks.Common.Controls
 			// I think only label.Object is likely to be null, but let's prevent crashes thoroughly.
 			if (label != null && label.Object != null && label.Object.ReferringObjects != null)
 			{
+				if (label.Object.Owner.ToString() == "Publications")
+				{
+					// IPublication is the value of DoNotPublishIn,
+					// so we need to invert the count.
+					ILexEntryRepository repository = label.Object.Cache.ServiceLocator.GetInstance<ILexEntryRepository>();
+					count = repository.Count - label.Object.ReferringObjects.Count;
+					return count;
+				}
 				count = label.Object.ReferringObjects.Count;
 				foreach (ICmObject x in label.Object.ReferringObjects)
 				{


### PR DESCRIPTION
Publications are included unless that are stored in DoNotPublishIn.  So, the ReferringObjects are the excluded lexical entries, not the included lexical entries.  I inverted the count in LabelNode.CountUsages.  But there has to be a better way to determine that we are dealing with publications than what I did.

This could be in release/9.2, since it is in the backlog.