### PR TITLE
LT-22039: xhtml has new nodeId attribute

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -344,7 +344,7 @@ namespace SIL.FieldWorks.XWorks
 				{
 					var clerk = settings.PropertyTable.GetValue<RecordClerk>("ActiveClerk", null);
 					var entryClassName = settings.StylesGenerator.AddStyles(configuration).Trim('.');
-					settings.ContentGenerator.StartEntry(xw, configuration,
+					settings.ContentGenerator.StartEntry(xw, configuration, settings,
 						entryClassName, entry.Guid, index, clerk);
 					settings.ContentGenerator.AddEntryData(xw, pieces);
 					settings.ContentGenerator.EndEntry(xw);
@@ -883,7 +883,7 @@ namespace SIL.FieldWorks.XWorks
 				// An XHTML id attribute must be unique but the ICmfile is used for all references to the same file within the project.
 				// The ICmPicture that owns the file does have unique guid so we use that.
 				var ownerGuid = owner.Guid.ToString();
-				return settings.ContentGenerator.AddImage(config, className, srcAttribute, ownerGuid);
+				return settings.ContentGenerator.AddImage(config, settings, className, srcAttribute, ownerGuid);
 			}
 			return settings.ContentGenerator.CreateFragment();
 		}
@@ -1936,7 +1936,7 @@ namespace SIL.FieldWorks.XWorks
 			if (bldr.Length() == 0)
 				return bldr;
 
-			return settings.ContentGenerator.AddSenseData(config, senseNumberSpan, ((ICmObject)item).Owner.Guid, bldr, first);
+			return settings.ContentGenerator.AddSenseData(config, settings, senseNumberSpan, ((ICmObject)item).Owner.Guid, bldr, first);
 		}
 
 		private static IFragment GeneratePictureContent(ConfigurableDictionaryNode config, DictionaryPublicationDecorator publicationDecorator,
@@ -2021,7 +2021,7 @@ namespace SIL.FieldWorks.XWorks
 			if (bldr.Length() == 0)
 				return bldr;
 			var collectionContent = bldr;
-			return settings.ContentGenerator.AddCollectionItem(config, IsBlockProperty(config), GetCollectionItemClassAttribute(config), collectionContent, first);
+			return settings.ContentGenerator.AddCollectionItem(config, settings, IsBlockProperty(config), GetCollectionItemClassAttribute(config), collectionContent, first);
 		}
 
 		private static void GenerateContentForLexRefCollection(ConfigurableDictionaryNode config,
@@ -2155,7 +2155,7 @@ namespace SIL.FieldWorks.XWorks
 							if (!content.IsNullOrEmpty())
 							{
 								// targets
-								settings.ContentGenerator.AddCollection(xw, child, IsBlockProperty(child),
+								settings.ContentGenerator.AddCollection(xw, child, settings, IsBlockProperty(child),
 									CssGenerator.GetClassAttributeForConfig(child), content);
 								settings.StylesGenerator.AddStyles(child);
 							}
@@ -2222,7 +2222,7 @@ namespace SIL.FieldWorks.XWorks
 			var senseNumberWs = string.IsNullOrEmpty(info.HomographConfig.WritingSystem) ? "en" : info.HomographConfig.WritingSystem;
 			if (string.IsNullOrEmpty(formattedSenseNumber))
 				return settings.ContentGenerator.CreateFragment();
-			return settings.ContentGenerator.GenerateSenseNumber(senseConfigNode, formattedSenseNumber, senseNumberWs);
+			return settings.ContentGenerator.GenerateSenseNumber(senseConfigNode, settings, formattedSenseNumber, senseNumberWs);
 		}
 
 		private static string GetSenseNumber(string numberingStyle, ref SenseInfo info)
@@ -2604,7 +2604,7 @@ namespace SIL.FieldWorks.XWorks
 			var writingSystem = GetLanguageFromFirstOptionOrAnalysis(config.DictionaryNodeOptions as DictionaryNodeWritingSystemOptions,
 				settings.Cache);
 			var cssClassName = settings.StylesGenerator.AddStyles(config).Trim('.');
-			return settings.ContentGenerator.AddProperty(config, settings.PropertyTable, cssClassName, false, simpleString, writingSystem);
+			return settings.ContentGenerator.AddProperty(config, settings, cssClassName, false, simpleString, writingSystem);
 
 		}
 
@@ -2777,12 +2777,12 @@ namespace SIL.FieldWorks.XWorks
 						{
 							writingSystem = writingSystem ?? GetLanguageFromFirstOption(config.DictionaryNodeOptions as DictionaryNodeWritingSystemOptions,
 																settings.Cache);
-							settings.ContentGenerator.StartMultiRunString(writer, config, writingSystem);
+							settings.ContentGenerator.StartMultiRunString(writer, config, settings, writingSystem);
 							var wsRtl = settings.Cache.WritingSystemFactory.get_Engine(writingSystem).RightToLeftScript;
 							if (rightToLeft != wsRtl)
 							{
 								rightToLeft = wsRtl; // the outer WS direction will be used to identify embedded runs of the opposite direction.
-								settings.ContentGenerator.StartBiDiWrapper(writer, config, rightToLeft);
+								settings.ContentGenerator.StartBiDiWrapper(writer, config, settings, rightToLeft);
 							}
 						}
 
@@ -2858,11 +2858,11 @@ namespace SIL.FieldWorks.XWorks
 		private static void GenerateRunWithPossibleLink(GeneratorSettings settings, string writingSystem, IFragmentWriter writer, string style,
 			string text, Guid linkDestination, bool rightToLeft, ConfigurableDictionaryNode config, bool first, string externalLink = null)
 		{
-			settings.ContentGenerator.StartRun(writer, config, settings.PropertyTable, writingSystem, first);
+			settings.ContentGenerator.StartRun(writer, config, settings, writingSystem, first);
 			var wsRtl = settings.Cache.WritingSystemFactory.get_Engine(writingSystem).RightToLeftScript;
 			if (rightToLeft != wsRtl)
 			{
-				settings.ContentGenerator.StartBiDiWrapper(writer, config, wsRtl);
+				settings.ContentGenerator.StartBiDiWrapper(writer, config, settings, wsRtl);
 			}
 			if (!String.IsNullOrEmpty(style))
 			{
@@ -2913,7 +2913,7 @@ namespace SIL.FieldWorks.XWorks
 			if (string.IsNullOrEmpty(audioId) && string.IsNullOrEmpty(srcAttribute) && string.IsNullOrEmpty(audioIcon))
 				return settings.ContentGenerator.CreateFragment();
 			var safeAudioId = GetSafeXHTMLId(audioId);
-			return settings.ContentGenerator.GenerateAudioLinkContent(config, classname, srcAttribute, audioIcon, safeAudioId);
+			return settings.ContentGenerator.GenerateAudioLinkContent(config, settings, classname, srcAttribute, audioIcon, safeAudioId);
 		}
 
 		private static string GetSafeXHTMLId(string audioId)
@@ -3082,7 +3082,7 @@ namespace SIL.FieldWorks.XWorks
 		private static void GenerateError(IFragmentWriter writer, GeneratorSettings settings, ConfigurableDictionaryNode config, string text)
 		{
 			var writingSystem = settings.Cache.WritingSystemFactory.GetStrFromWs(settings.Cache.WritingSystemFactory.UserWs);
-			settings.ContentGenerator.StartRun(writer, null, settings.PropertyTable, writingSystem, true);
+			settings.ContentGenerator.StartRun(writer, null, settings, writingSystem, true);
 			settings.ContentGenerator.SetRunStyle(writer, null, settings.PropertyTable, writingSystem, null, true);
 			if (text.Contains(TxtLineSplit))
 			{
@@ -3258,6 +3258,7 @@ namespace SIL.FieldWorks.XWorks
 			public string ExportPath { get; }
 			public bool RightToLeft { get; }
 			public bool IsWebExport { get; }
+			public bool IsXhtmlExport { get; set; }
 			public bool IsTemplate { get; }
 
 			public GeneratorSettings(LcmCache cache, PropertyTable propertyTable, bool relativePaths,bool copyFiles, string exportPath, bool rightToLeft = false, bool isWebExport = false)
@@ -3285,6 +3286,7 @@ namespace SIL.FieldWorks.XWorks
 				RightToLeft = rightToLeft;
 				IsWebExport = isWebExport;
 				IsTemplate = isTemplate;
+				IsXhtmlExport = false;
 				StylesGenerator.Init(propertyTable);
 			}
 		}

--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -140,7 +140,7 @@ namespace SIL.FieldWorks.XWorks
 			var publicationDecorator = ConfiguredLcmGenerator.GetPublicationDecoratorAndEntries(m_propertyTable, out var entriesToSave, exportType);
 			if (progress != null)
 				progress.Maximum = entriesToSave.Length;
-			LcmXhtmlGenerator.SavePublishedHtmlWithStyles(entriesToSave, publicationDecorator, int.MaxValue, configuration, m_propertyTable, xhtmlPath, progress);
+			LcmXhtmlGenerator.SavePublishedHtmlWithStyles(entriesToSave, publicationDecorator, int.MaxValue, configuration, m_propertyTable, xhtmlPath, progress, true);
 		}
 
 		public List<JArray> ExportConfiguredJson(string folderPath, DictionaryConfigurationModel configuration, out int[] entryIds)

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -16,23 +16,23 @@ namespace SIL.FieldWorks.XWorks
 	public interface ILcmContentGenerator
 	{
 		IFragment GenerateWsPrefixWithString(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool displayAbbreviation, int wsId, IFragment content);
-		IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, string classname, string srcAttribute, string caption, string safeAudioId);
+		IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classname, string srcAttribute, string caption, string safeAudioId);
 		IFragment WriteProcessedObject(ConfigurableDictionaryNode config, bool isBlock, IFragment elementContent, string className);
 		IFragment WriteProcessedCollection(ConfigurableDictionaryNode config, bool isBlock, IFragment elementContent, string className);
 		IFragment GenerateGramInfoBeforeSensesContent(IFragment content, ConfigurableDictionaryNode config);
 		IFragment GenerateGroupingNode(ConfigurableDictionaryNode config, object field, string className,  DictionaryPublicationDecorator publicationDecorator, ConfiguredLcmGenerator.GeneratorSettings settings,
 			Func<object, ConfigurableDictionaryNode, DictionaryPublicationDecorator, ConfiguredLcmGenerator.GeneratorSettings, IFragment> childContentGenerator);
-		IFragment AddSenseData(ConfigurableDictionaryNode config, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first);
-		IFragment AddCollectionItem(ConfigurableDictionaryNode config, bool isBlock, string collectionItemClass, IFragment content, bool first);
-		IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem);
+		IFragment AddSenseData(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first);
+		IFragment AddCollectionItem(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlock, string collectionItemClass, IFragment content, bool first);
+		IFragment AddProperty(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string className, bool isBlockProperty, string content, string writingSystem);
 		IFragment CreateFragment();
 		IFragment CreateFragment(string str);
 		IFragmentWriter CreateWriter(IFragment fragment);
-		void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem);
+		void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem);
 		void EndMultiRunString(IFragmentWriter writer);
-		void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, bool rightToLeft);
+		void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool rightToLeft);
 		void EndBiDiWrapper(IFragmentWriter writer);
-		void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string writingSystem, bool first);
+		void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem, bool first);
 		void EndRun(IFragmentWriter writer);
 		void SetRunStyle(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propertyTable, string writingSystem, string runStyle, bool error);
 		void StartLink(IFragmentWriter writer, ConfigurableDictionaryNode config, Guid destination);
@@ -48,16 +48,16 @@ namespace SIL.FieldWorks.XWorks
 		void EndTableRow(IFragmentWriter writer);
 		void EndTableBody(IFragmentWriter writer);
 		void EndTable(IFragmentWriter writer, ConfigurableDictionaryNode config);
-		void StartEntry(IFragmentWriter writer, ConfigurableDictionaryNode config, string className, Guid entryGuid, int index, RecordClerk clerk);
+		void StartEntry(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string className, Guid entryGuid, int index, RecordClerk clerk);
 		void AddEntryData(IFragmentWriter writer, List<ConfiguredLcmGenerator.ConfigFragment> pieces);
 		void EndEntry(IFragmentWriter writer);
-		void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className, IFragment content);
+		void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className, IFragment content);
 		void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string getCollectionItemClassAttribute);
 		void EndObject(IFragmentWriter writer);
 		void WriteProcessedContents(IFragmentWriter writer, ConfigurableDictionaryNode config, IFragment contents);
-		IFragment AddImage(ConfigurableDictionaryNode config, string classAttribute, string srcAttribute, string pictureGuid);
+		IFragment AddImage(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classAttribute, string srcAttribute, string pictureGuid);
 		IFragment AddImageCaption(ConfigurableDictionaryNode config, IFragment captionContent);
-		IFragment GenerateSenseNumber(ConfigurableDictionaryNode config, string formattedSenseNumber, string senseNumberWs);
+		IFragment GenerateSenseNumber(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string formattedSenseNumber, string senseNumberWs);
 		IFragment AddLexReferences(ConfigurableDictionaryNode config, bool generateLexType, IFragment lexTypeContent, string className, IFragment referencesContent, bool typeBefore);
 		void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className);
 		void EndCrossReference(IFragmentWriter writer);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -44,7 +44,7 @@ namespace SIL.FieldWorks.XWorks
 			return content;
 		}
 
-		public IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, string classname, string srcAttribute, string caption,
+		public IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classname, string srcAttribute, string caption,
 			string safeAudioId)
 		{
 			/*"audio": {
@@ -117,14 +117,14 @@ namespace SIL.FieldWorks.XWorks
 			return new StringFragment();
 		}
 
-		public IFragment AddCollectionItem(ConfigurableDictionaryNode config, bool isBlock, string className, IFragment content, bool first)
+		public IFragment AddCollectionItem(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlock, string className, IFragment content, bool first)
 		{
 			var fragment = new StringFragment();
 			fragment.StrBuilder.Append(content.IsNullOrEmpty() ? string.Empty : $"{{{content}}},");
 			return fragment;
 		}
 
-		public IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem)
+		public IFragment AddProperty(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string className, bool isBlockProperty, string content, string writingSystem)
 		{
 			var fragment = new StringFragment($"\"{className}\": \"{content}\",");
 			return fragment;
@@ -145,7 +145,7 @@ namespace SIL.FieldWorks.XWorks
 			return new JsonFragmentWriter(((StringFragment)bldr).StrBuilder);
 		}
 
-		public void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem)
+		public void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem)
 		{
 		}
 
@@ -153,7 +153,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 		}
 
-		public void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, bool rightToLeft)
+		public void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool rightToLeft)
 		{
 		}
 
@@ -161,7 +161,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 		}
 
-		public void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string writingSystem, bool first)
+		public void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem, bool first)
 		{
 			var jsonWriter = (JsonFragmentWriter)writer;
 			jsonWriter.StartObject();
@@ -253,7 +253,7 @@ namespace SIL.FieldWorks.XWorks
 			// TODO: decide on a useful json representation for tables
 		}
 
-		public void StartEntry(IFragmentWriter xw, ConfigurableDictionaryNode config, string className, Guid entryGuid, int index, RecordClerk clerk)
+		public void StartEntry(IFragmentWriter xw, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string className, Guid entryGuid, int index, RecordClerk clerk)
 		{
 			var jsonWriter = (JsonFragmentWriter)xw;
 			jsonWriter.StartObject();
@@ -292,7 +292,7 @@ namespace SIL.FieldWorks.XWorks
 			((JsonFragmentWriter)xw).EndObject();
 		}
 
-		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className, IFragment content)
+		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className, IFragment content)
 		{
 			((JsonFragmentWriter)writer).InsertPropertyName(className);
 			BeginArray(writer);
@@ -335,7 +335,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		public IFragment AddImage(ConfigurableDictionaryNode config, string classAttribute, string srcAttribute, string pictureGuid)
+		public IFragment AddImage(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classAttribute, string srcAttribute, string pictureGuid)
 		{
 			var bldr = new StringBuilder();
 			var fragment = new StringFragment();
@@ -358,7 +358,7 @@ namespace SIL.FieldWorks.XWorks
 			return new StringFragment(captionContent.ToString());
 		}
 
-		public IFragment GenerateSenseNumber(ConfigurableDictionaryNode config, string formattedSenseNumber, string wsId)
+		public IFragment GenerateSenseNumber(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string formattedSenseNumber, string wsId)
 		{
 			return new StringFragment(formattedSenseNumber);
 		}
@@ -435,7 +435,7 @@ namespace SIL.FieldWorks.XWorks
 			return new StringFragment($"\\u+0FFF\\u+0FFF\\u+0FFF{badStrBuilder}");
 		}
 
-		public IFragment AddSenseData(ConfigurableDictionaryNode config, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first)
+		public IFragment AddSenseData(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first)
 		{
 			var bldr = new StringBuilder();
 			var fragment = new StringFragment(bldr);

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -900,7 +900,7 @@ namespace SIL.FieldWorks.XWorks
 			return content;
 		}
 
-		public IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, string classname, string srcAttribute, string caption, string safeAudioId)
+		public IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classname, string srcAttribute, string caption, string safeAudioId)
 		{
 			// We are not planning to support audio and video content for Word Export.
 			return new DocFragment();
@@ -1019,7 +1019,7 @@ namespace SIL.FieldWorks.XWorks
 			return groupData;
 		}
 
-		public IFragment AddSenseData(ConfigurableDictionaryNode config, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first)
+		public IFragment AddSenseData(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, IFragment senseNumberSpan, Guid ownerGuid, IFragment senseContent, bool first)
 		{
 			var senseData = new DocFragment();
 			WP.Paragraph newPara = null;
@@ -1078,7 +1078,7 @@ namespace SIL.FieldWorks.XWorks
 			return senseData;
 		}
 
-		public IFragment AddCollectionItem(ConfigurableDictionaryNode config, bool isBlock, string collectionItemClass, IFragment content, bool first)
+		public IFragment AddCollectionItem(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlock, string collectionItemClass, IFragment content, bool first)
 		{
 			// Add the style to all the runs in the content fragment.
 			if (!string.IsNullOrEmpty(config.Style) &&
@@ -1121,7 +1121,7 @@ namespace SIL.FieldWorks.XWorks
 
 			return collData;
 		}
-		public IFragment AddProperty(ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string className, bool isBlockProperty, string content, string writingSystem)
+		public IFragment AddProperty(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string className, bool isBlockProperty, string content, string writingSystem)
 		{
 			var propFrag = new DocFragment();
 			Run contentRun = null;
@@ -1135,7 +1135,7 @@ namespace SIL.FieldWorks.XWorks
 
 			// Create a run with the correct style.
 			var writer = CreateWriter(propFrag);
-			((WordFragmentWriter)writer).AddRun(Cache, config, propTable, writingSystem, true);
+			((WordFragmentWriter)writer).AddRun(Cache, config, settings.PropertyTable, writingSystem, true);
 
 			// Add the content to the run.
 			AddToRunContent(writer, content);
@@ -1177,7 +1177,7 @@ namespace SIL.FieldWorks.XWorks
 			return new WordFragmentWriter((DocFragment)frag);
 		}
 
-		public void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, string writingSystem)
+		public void StartMultiRunString(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem)
 		{
 			return;
 		}
@@ -1185,7 +1185,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			return;
 		}
-		public void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, bool rightToLeft)
+		public void StartBiDiWrapper(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool rightToLeft)
 		{
 			return;
 		}
@@ -1198,9 +1198,9 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		/// <param name="writer"></param>
 		/// <param name="writingSystem"></param>
-		public void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ReadOnlyPropertyTable propTable, string writingSystem, bool first)
+		public void StartRun(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string writingSystem, bool first)
 		{
-			((WordFragmentWriter)writer).AddRun(Cache, config, propTable, writingSystem, first);
+			((WordFragmentWriter)writer).AddRun(Cache, config, settings.PropertyTable, writingSystem, first);
 		}
 		public void EndRun(IFragmentWriter writer)
 		{
@@ -1413,7 +1413,7 @@ namespace SIL.FieldWorks.XWorks
 			wordWriter.CurrentTable = null;
 		}
 
-		public void StartEntry(IFragmentWriter writer, ConfigurableDictionaryNode node, string className, Guid entryGuid, int index, RecordClerk clerk)
+		public void StartEntry(IFragmentWriter writer, ConfigurableDictionaryNode node, ConfiguredLcmGenerator.GeneratorSettings settings, string className, Guid entryGuid, int index, RecordClerk clerk)
 		{
 			// Each entry starts a new paragraph. The paragraph will end whenever a child needs its own paragraph or
 			// when a data type exists that cannot be in a paragraph (Tables or nested paragraphs).
@@ -1546,7 +1546,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			return;
 		}
-		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className, IFragment content)
+		public void AddCollection(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className, IFragment content)
 		{
 			string styleDisplayName = GetUniqueDisplayName(config, content);
 			// Add Before text.
@@ -1583,7 +1583,7 @@ namespace SIL.FieldWorks.XWorks
 				((WordFragmentWriter)writer).Insert(contents);
 			}
 		}
-		public IFragment AddImage(ConfigurableDictionaryNode config, string classAttribute, string srcAttribute, string pictureGuid)
+		public IFragment AddImage(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classAttribute, string srcAttribute, string pictureGuid)
 		{
 			DocFragment imageFrag = new DocFragment();
 			WordprocessingDocument wordDoc = imageFrag.DocFrag;
@@ -1624,7 +1624,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			return docFrag;
 		}
-		public IFragment GenerateSenseNumber(ConfigurableDictionaryNode senseConfigNode, string formattedSenseNumber, string senseNumberWs)
+		public IFragment GenerateSenseNumber(ConfigurableDictionaryNode senseConfigNode, ConfiguredLcmGenerator.GeneratorSettings settings, string formattedSenseNumber, string senseNumberWs)
 		{
 			var senseOptions = (DictionaryNodeSenseOptions)senseConfigNode?.DictionaryNodeOptions;
 			string afterNumber = null;


### PR DESCRIPTION
A nodeId attribute was recently added to the XHTML representation to aid the right-click Dictionary Configuration option in finding the correct data after recent changes that reduced the number of styles in a project.  The nodeId attribute is also included when exporting a project to XHTML, which is undesirable according to Ken Zook.  I fixed this by added an IsXhtmlExport property to GeneratorSettings and passing GeneratorSettings to all of the methods in LcmXhtmlGenerator that wrote a nodeId attribute.  I also added a WriteNodeId method which contains the logic for deciding whether a nodeId attribute should be written out.

I believe that the IsXhtmlExport property is only set when exporting XHTML, but I don't know how to test whether the Dictionary Configuration option is still working correctly.  I also don't know how to verify that exporting to Word and Webonary is still working correctly.

This should be considered for release/9.2 since it is a regression caused by changes in FW 9.2.5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/283)
<!-- Reviewable:end -->
