### PR TITLE
LT-22052: Use textboxes instead of textframes for pictures

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -161,7 +161,7 @@ namespace SIL.FieldWorks.XWorks
 			//threads as done here works in all the cases that have been tried.  (Windows/Linux, program/unit test)  Unfortunately,
 			//the speedup on Linux is minimal.
 			var maxThreadCount = Math.Min(16, (int)(Environment.ProcessorCount * 1.5));
-			maxThreadCount = Math.Min(maxThreadCount, actionCount);
+			maxThreadCount = 1;//Math.Min(maxThreadCount, actionCount);
 			Exception exceptionThrown = null;
 			var threadActionArray = new Action[maxThreadCount];
 			using (var countDown = new CountdownEvent(maxThreadCount))

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -161,7 +161,7 @@ namespace SIL.FieldWorks.XWorks
 			//threads as done here works in all the cases that have been tried.  (Windows/Linux, program/unit test)  Unfortunately,
 			//the speedup on Linux is minimal.
 			var maxThreadCount = Math.Min(16, (int)(Environment.ProcessorCount * 1.5));
-			maxThreadCount = 1;//Math.Min(maxThreadCount, actionCount);
+			maxThreadCount = Math.Min(maxThreadCount, actionCount);
 			Exception exceptionThrown = null;
 			var threadActionArray = new Action[maxThreadCount];
 			using (var countDown = new CountdownEvent(maxThreadCount))

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -591,9 +591,9 @@ namespace SIL.FieldWorks.XWorks
 
 				if (lastTextBox == null)
 					return;
-
-				for(int i =0; i < 4; i++)
-					lastTextBox.AppendChild(CloneElement(fragToCopy, para));
+				lastTextBox.AppendChild(CloneElement(fragToCopy, para));
+				//for(int i =0; i < 4; i++)
+				//	lastTextBox.AppendChild(CloneElement(fragToCopy, para));
 			}
 
 			/// <summary>
@@ -753,6 +753,8 @@ namespace SIL.FieldWorks.XWorks
 				Run textBoxRun = new Run();
 				Drawing textBoxDrawing = new Drawing();
 
+				// Need a unique ID and name for the anchor.
+				string anchorId = Guid.NewGuid().ToString();
 				DrawingWP.Anchor anchor = new DrawingWP.Anchor()
 				{
 					DistanceFromTop = (UInt32Value)0U,
@@ -764,7 +766,8 @@ namespace SIL.FieldWorks.XWorks
 					BehindDoc = false,
 					Locked = false,
 					LayoutInCell = true,
-					AllowOverlap = false
+					AllowOverlap = false,
+					AnchorId = anchorId
 				};
 				anchor.Append(new DrawingWP.SimplePosition() { X = 0L, Y = 0L});
 
@@ -2403,7 +2406,9 @@ namespace SIL.FieldWorks.XWorks
 					DistanceFromTop = (UInt32Value)0U,
 					DistanceFromBottom = (UInt32Value)0U,
 					DistanceFromLeft = (UInt32Value)0U,
-					DistanceFromRight = (UInt32Value)0U
+					DistanceFromRight = (UInt32Value)0U,
+					// generate an ID for the drawing anchor
+					AnchorId = Guid.NewGuid().ToString()
 				}
 			);
 

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -759,8 +759,6 @@ namespace SIL.FieldWorks.XWorks
 				Run textBoxRun = new Run();
 				Drawing textBoxDrawing = new Drawing();
 
-				// Need a unique ID and name for the anchor.
-				string anchorId = Guid.NewGuid().ToString();
 				DrawingWP.Anchor anchor = new DrawingWP.Anchor()
 				{
 					DistanceFromTop = (UInt32Value)0U,
@@ -772,8 +770,7 @@ namespace SIL.FieldWorks.XWorks
 					BehindDoc = false,
 					Locked = false,
 					LayoutInCell = true,
-					AllowOverlap = false,
-					AnchorId = anchorId
+					AllowOverlap = false
 				};
 				anchor.Append(new DrawingWP.SimplePosition() { X = 0L, Y = 0L});
 
@@ -2411,9 +2408,7 @@ namespace SIL.FieldWorks.XWorks
 					DistanceFromTop = (UInt32Value)0U,
 					DistanceFromBottom = (UInt32Value)0U,
 					DistanceFromLeft = (UInt32Value)0U,
-					DistanceFromRight = (UInt32Value)0U,
-					// generate an ID for the drawing anchor
-					AnchorId = Guid.NewGuid().ToString()
+					DistanceFromRight = (UInt32Value)0U
 				}
 			);
 

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2322,9 +2322,6 @@ namespace SIL.FieldWorks.XWorks
 			var ratioActualInches = actHeightInches / actWidthInches;
 			var ratioMaxInches = maxHeightInches / maxWidthInches;
 
-			var totalWidthInches = Math.Min((float)(actWidthPx / horzRezDpi), maxWidthInches);
-			var totalHeightInches = Math.Min((float)(actHeightPx / vertRezDpi), maxHeightInches);
-
 			// height/widthInches will store the final height and width
 			// to use for the image in the Word doc.
 			double heightInches = maxHeightInches;

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -32,7 +32,6 @@ using SIL.LCModel.Core.KernelInterfaces;
 
 namespace SIL.FieldWorks.XWorks
 {
-	using static SIL.Archiving.ArchivingDlgViewModel;
 	// This alias is to be used when creating Wordprocessing Text objects,
 	// since there are multiple different Text types across the packages we are using.
 	using WP = DocumentFormat.OpenXml.Wordprocessing;
@@ -568,7 +567,7 @@ namespace SIL.FieldWorks.XWorks
 				lastPar.AppendChild(CloneElement(fragToCopy, run));
 			}
 
-			public void AppendToTextbox(IFragment fragToCopy, Run run, WP.ParagraphProperties paragraphProps)
+			public void AppendImageToTextbox(IFragment fragToCopy, Run run, WP.ParagraphProperties paragraphProps)
 			{
 				WP.TextBoxContent lastTextBox = GetLastTextBox();
 
@@ -584,7 +583,7 @@ namespace SIL.FieldWorks.XWorks
 				lastTextBox.AppendChild(newImagePar);
 			}
 
-			public void AppendParagraphToTextbox(IFragment fragToCopy, WP.Paragraph para)
+			public void AppendCaptionParagraphToTextbox(IFragment fragToCopy, WP.Paragraph para)
 			{
 				WP.TextBoxContent lastTextBox = GetLastTextBox();
 
@@ -709,8 +708,7 @@ namespace SIL.FieldWorks.XWorks
 
 			public WP.TextBoxContent GetLastTextBox()
 			{
-				//List<WP.TextBoxContent> textBoxContList =
-					//DocBody.OfType<WP.TextBoxContent>().ToList();
+				// Returns the textbox content belonging to the last textbox added to the document
 				List<WP.TextBoxContent> textBoxContList =
 					DocBody.Descendants<WP.TextBoxContent>().ToList();
 				if (textBoxContList.Any())
@@ -1690,15 +1688,9 @@ namespace SIL.FieldWorks.XWorks
 								}
 								else
 								{
-									// TODO: Fix the captions for textboxes
-									//otherwise, we have a caption; we must add the caption to the last textbox, which should contain the image
-									//WP.Paragraph newPar = new WP.Paragraph();
 									WP.ParagraphProperties paragraphProps =
 										new WP.ParagraphProperties(new ParagraphStyleId() { Val = WordStylesGenerator.PictureAndCaptionTextframeStyle });
-									//newPar.Append(paragraphProps);
-									//newPar.Append(run);
-									wordWriter.WordFragment.AppendToTextbox(frag, run, paragraphProps);
-									//wordWriter.WordFragment.AppendToParagraph(frag, run, false);
+									wordWriter.WordFragment.AppendImageToTextbox(frag, run, paragraphProps);
 								}
 							}
 							else
@@ -1720,8 +1712,8 @@ namespace SIL.FieldWorks.XWorks
 							// If we have a paragraph associated with a Pictures node, we are dealing with an image caption.
 							if (config.Label == "Pictures" || config.Parent?.Label == "Pictures")
 							{
-								// TODO: Handle cloning the caption paragraph inside the textbox...
-								wordWriter.WordFragment.AppendParagraphToTextbox(frag, para);
+								// In this case, the paragraph is an image caption and belongs in the last textbox
+								wordWriter.WordFragment.AppendCaptionParagraphToTextbox(frag, para);
 							}
 							else
 								wordWriter.WordFragment.AppendParagraph(frag, para);

--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -25,6 +25,7 @@ namespace SIL.FieldWorks.XWorks
 		//
 		private Dictionary<string,List<StyleElement>> styleDictionary = new Dictionary<string, List<StyleElement>>();
 		private int bulletAndNumberingUniqueIdCounter = 1;
+		private int pictureUniqueIdCounter = 1;
 
 		/// <summary>
 		/// Returns a single list containing all of the Styles.
@@ -62,6 +63,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				styleDictionary.Clear();
 				bulletAndNumberingUniqueIdCounter = 1;
+				pictureUniqueIdCounter = 1;
 			}
 		}
 
@@ -256,6 +258,20 @@ namespace SIL.FieldWorks.XWorks
 				lock(styleDictionary)
 				{
 					return bulletAndNumberingUniqueIdCounter++;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Returns a unique id that is used for picture IDs.
+		/// </summary>
+		public int GetAndIncrementPictureUniqueIdCount
+		{
+			get
+			{
+				lock (styleDictionary)
+				{
+					return pictureUniqueIdCounter++;
 				}
 			}
 		}

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -392,8 +392,28 @@ namespace SIL.FieldWorks.XWorks
 		private static Style GenerateParagraphStyleFromPictureOptions(ConfigurableDictionaryNode configNode, DictionaryNodePictureOptions pictureOptions,
 			LcmCache cache, ReadOnlyPropertyTable propertyTable)
 		{
-			//TODO: rework style for textframes
+			//TODO: check if anything else about the style needs to be added for textframes
 			var frameStyle = new Style();
+
+			// TODO: Use the picture configuration to set the justification value and width for the textframe.
+			// initialize width to one inch and justification to right
+			double widthInches = 1.0;
+			JustificationValues alignment = JustificationValues.Right;
+
+			// if we have picture options, update width and alignment
+			if (configNode.DictionaryNodeOptions is DictionaryNodePictureOptions)
+			{
+				DictionaryNodePictureOptions picOpts = (DictionaryNodePictureOptions)configNode.DictionaryNodeOptions;
+
+				if(picOpts.MaximumWidth > 0)
+					widthInches = picOpts.MaximumWidth;
+
+				if (picOpts.PictureLocation.ToString() == "Center")
+					alignment = JustificationValues.Center;
+				else if (picOpts.PictureLocation.ToString() == "Left")
+					alignment = JustificationValues.Left;
+
+			}
 
 			// A textframe for holding an image/caption has to be a paragraph
 			frameStyle.Type = StyleValues.Paragraph;
@@ -401,7 +421,7 @@ namespace SIL.FieldWorks.XWorks
 			// We use FLEX's max image width as the width for the textframe.
 			// Note: 1 inch is equivalent to 72 points, and width is specified in twentieths of a point.
 			// Thus, we calculate textframe width by multiplying max image width in inches by 72*30 = 1440
-			var textFrameWidth = LcmWordGenerator.maxImageWidthInches * 1440;
+			var textFrameWidth = widthInches * 1440;
 
 			// We will leave a 4-pt border around the textframe--80 twentieths of a point.
 			var textFrameBorder = "80";
@@ -419,8 +439,8 @@ namespace SIL.FieldWorks.XWorks
 			var parProps = new ParagraphProperties();
 			frameStyle.StyleId = PictureAndCaptionTextframeStyle;
 			frameStyle.StyleName = new StyleName(){Val = PictureAndCaptionTextframeStyle};
-			// TODO: Use the justification specified in FLEx for pictures to set the value here.
-			parProps.Justification = new Justification() { Val = JustificationValues.Left };
+
+			parProps.Justification = new Justification() { Val = alignment };
 			//parProps.Append(textFrameProps);
 			frameStyle.Append(parProps);
 			return frameStyle;

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -419,6 +419,8 @@ namespace SIL.FieldWorks.XWorks
 			var parProps = new ParagraphProperties();
 			frameStyle.StyleId = PictureAndCaptionTextframeStyle;
 			frameStyle.StyleName = new StyleName(){Val = PictureAndCaptionTextframeStyle};
+			// TODO: Use the justification specified in FLEx for pictures to set the value here.
+			parProps.Justification = new Justification() { Val = JustificationValues.Left };
 			//parProps.Append(textFrameProps);
 			frameStyle.Append(parProps);
 			return frameStyle;

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -392,58 +392,18 @@ namespace SIL.FieldWorks.XWorks
 		private static Style GenerateParagraphStyleFromPictureOptions(ConfigurableDictionaryNode configNode, DictionaryNodePictureOptions pictureOptions,
 			LcmCache cache, ReadOnlyPropertyTable propertyTable)
 		{
-			//TODO: check if anything else about the style needs to be added for textframes
-			var frameStyle = new Style();
+			// Creating a style for the paragraph that will contain the image and caption
+			var textBoxStyle = new Style() {
+				Type = StyleValues.Paragraph,
+				StyleId = PictureAndCaptionTextframeStyle,
+				StyleName = new StyleName() { Val = PictureAndCaptionTextframeStyle }
+			};
 
-			// TODO: Use the picture configuration to set the justification value and width for the textframe.
-			// initialize width to one inch and justification to right
-			double widthInches = 1.0;
-			JustificationValues alignment = JustificationValues.Right;
-
-			// if we have picture options, update width and alignment
-			if (configNode.DictionaryNodeOptions is DictionaryNodePictureOptions)
-			{
-				DictionaryNodePictureOptions picOpts = (DictionaryNodePictureOptions)configNode.DictionaryNodeOptions;
-
-				if(picOpts.MaximumWidth > 0)
-					widthInches = picOpts.MaximumWidth;
-
-				if (picOpts.PictureLocation.ToString() == "Center")
-					alignment = JustificationValues.Center;
-				else if (picOpts.PictureLocation.ToString() == "Left")
-					alignment = JustificationValues.Left;
-
-			}
-
-			// A textframe for holding an image/caption has to be a paragraph
-			frameStyle.Type = StyleValues.Paragraph;
-
-			// We use FLEX's max image width as the width for the textframe.
-			// Note: 1 inch is equivalent to 72 points, and width is specified in twentieths of a point.
-			// Thus, we calculate textframe width by multiplying max image width in inches by 72*30 = 1440
-			var textFrameWidth = widthInches * 1440;
-
-			// We will leave a 4-pt border around the textframe--80 twentieths of a point.
-			var textFrameBorder = "80";
-
-			// A paragraph is turned into a textframe simply by adding a frameproperties object inside the paragraph properties.
-			// Note that the argument "Y = textFrameBorder" is necessary for the following reason:
-			// In Word 2019, in order for the image textframe to display below the entry it portrays,
-			// a positive y-value offset must be specified that matches or exceeds the border of the textframe.
-			// We also lock the image's anchor because this allows greater flexibility in positioning the image from within Word.
-			// Without a locked anchor, if a user drags a textframe, Word will arbitrarily change the anchor and snap the textframe into a new location,
-			// rather than allowing the user to drag the textframe to their desired location.
-			//var textFrameProps = new FrameProperties() { Width = textFrameWidth.ToString(), HeightType = HeightRuleValues.Auto, HorizontalSpace = textFrameBorder, VerticalSpace = textFrameBorder,
-			//	Wrap = TextWrappingValues.NotBeside, VerticalPosition = VerticalAnchorValues.Text, HorizontalPosition = HorizontalAnchorValues.Text, XAlign = HorizontalAlignmentValues.Right,
-			//	Y=textFrameBorder, AnchorLock = new DocumentFormat.OpenXml.OnOffValue(true) };
 			var parProps = new ParagraphProperties();
-			frameStyle.StyleId = PictureAndCaptionTextframeStyle;
-			frameStyle.StyleName = new StyleName(){Val = PictureAndCaptionTextframeStyle};
-
-			parProps.Justification = new Justification() { Val = alignment };
-			//parProps.Append(textFrameProps);
-			frameStyle.Append(parProps);
-			return frameStyle;
+			// The image and caption should always be centered within the textbox.
+			parProps.Justification = new Justification() { Val = JustificationValues.Center }; ;
+			textBoxStyle.Append(parProps);
+			return textBoxStyle;
 		}
 
 		private static Styles GenerateWordStylesFromListAndParaOptions(ConfigurableDictionaryNode configNode,

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -392,6 +392,7 @@ namespace SIL.FieldWorks.XWorks
 		private static Style GenerateParagraphStyleFromPictureOptions(ConfigurableDictionaryNode configNode, DictionaryNodePictureOptions pictureOptions,
 			LcmCache cache, ReadOnlyPropertyTable propertyTable)
 		{
+			//TODO: rework style for textframes
 			var frameStyle = new Style();
 
 			// A textframe for holding an image/caption has to be a paragraph
@@ -412,13 +413,13 @@ namespace SIL.FieldWorks.XWorks
 			// We also lock the image's anchor because this allows greater flexibility in positioning the image from within Word.
 			// Without a locked anchor, if a user drags a textframe, Word will arbitrarily change the anchor and snap the textframe into a new location,
 			// rather than allowing the user to drag the textframe to their desired location.
-			var textFrameProps = new FrameProperties() { Width = textFrameWidth.ToString(), HeightType = HeightRuleValues.Auto, HorizontalSpace = textFrameBorder, VerticalSpace = textFrameBorder,
-				Wrap = TextWrappingValues.NotBeside, VerticalPosition = VerticalAnchorValues.Text, HorizontalPosition = HorizontalAnchorValues.Text, XAlign = HorizontalAlignmentValues.Right,
-				Y=textFrameBorder, AnchorLock = new DocumentFormat.OpenXml.OnOffValue(true) };
+			//var textFrameProps = new FrameProperties() { Width = textFrameWidth.ToString(), HeightType = HeightRuleValues.Auto, HorizontalSpace = textFrameBorder, VerticalSpace = textFrameBorder,
+			//	Wrap = TextWrappingValues.NotBeside, VerticalPosition = VerticalAnchorValues.Text, HorizontalPosition = HorizontalAnchorValues.Text, XAlign = HorizontalAlignmentValues.Right,
+			//	Y=textFrameBorder, AnchorLock = new DocumentFormat.OpenXml.OnOffValue(true) };
 			var parProps = new ParagraphProperties();
 			frameStyle.StyleId = PictureAndCaptionTextframeStyle;
 			frameStyle.StyleName = new StyleName(){Val = PictureAndCaptionTextframeStyle};
-			parProps.Append(textFrameProps);
+			//parProps.Append(textFrameProps);
 			frameStyle.Append(parProps);
 			return frameStyle;
 		}


### PR DESCRIPTION
Use textboxes for pictures, and use the picture options to set width and alignment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/284)
<!-- Reviewable:end -->
