### PR TITLE
Fix LT-22057: Duplicate Analysis ws created for English

### DIFF
--- a/Src/FwCoreDlgs/FwNewLangProjectModel.cs
+++ b/Src/FwCoreDlgs/FwNewLangProjectModel.cs
@@ -263,12 +263,15 @@ namespace SIL.FieldWorks.FwCoreDlgs
 			{
 				var defaultAnalysis = WritingSystemContainer.CurrentAnalysisWritingSystems.First();
 				var defaultVernacular = WritingSystemContainer.CurrentVernacularWritingSystems.First();
+				var remainingAnalysisWss = WritingSystemContainer.AnalysisWritingSystems.Skip(1).ToList();
+				// Avoid duplicate "en" because of "en" below (see LT-22057).
+				remainingAnalysisWss.RemoveAll(ws => ws.LanguageTag == "en");
 				return LcmCache.CreateNewLangProj(progressDialog, ProjectName, FwDirectoryFinder.LcmDirectories,
 					threadHelper,
 					defaultAnalysis,
 					defaultVernacular,
 					"en",// TODO: replicate original
-					new HashSet<CoreWritingSystemDefinition>(WritingSystemContainer.AnalysisWritingSystems.Skip(1)),
+					new HashSet<CoreWritingSystemDefinition>(remainingAnalysisWss),
 					new HashSet<CoreWritingSystemDefinition>(WritingSystemContainer.VernacularWritingSystems.Skip(1)),
 					AnthroModel.AnthroFileName);
 			}


### PR DESCRIPTION
There is an "en" writing system created implicitly by the 7th argument of CreateNewLangProj.  To avoid duplicates, we remove any "en" writing systems from the 8th argument to CreateNewLangProj (n remainingAnalysisWss).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/285)
<!-- Reviewable:end -->
