### PR TITLE
Fix LT-22077: Crash in interlinear

### DIFF
--- a/Src/LexText/Interlinear/FocusBoxController.ApproveAndMove.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.ApproveAndMove.cs
@@ -403,7 +403,7 @@ namespace SIL.FieldWorks.IText
 			FinishSettingAnalysis(newAnalysisTree, oldAnalysis);
 			if (obsoleteAna != null)
 				obsoleteAna.Delete();
-			if (oldWf != null && oldWf != wf && oldWf.OccurrencesInTexts.Count() == 0)
+			if (oldWf != null && oldWf.Cache != null && oldWf != wf && oldWf.OccurrencesInTexts.Count() == 0)
 				// oldWf is probably the uppercase form of wf.
 				oldWf.Delete();
 		}


### PR DESCRIPTION
oldWf.OccurrencesInTexts() crashes if oldWf.Cache is null.  In this case, oldWf is not really a wordform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/287)
<!-- Reviewable:end -->
