### PR TITLE
Fix LT-22079: Yellow Crash occurs while performing Reparse all words

### DIFF
--- a/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
@@ -146,7 +146,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			// SUT
 			// Parsing an uppercase wordform should cause the lowercase wordform to be parsed.
 			// The uppercase wordform doesn't get a parse.
-			var bVal = parserWorker.UpdateWordform(catsUpperTest, ParserPriority.Low);
+			var bVal = parserWorker.ParseAndUpdateWordform(catsUpperTest, ParserPriority.Low);
 			ExecuteIdleQueue();
 			Assert.IsTrue(bVal);
 			CheckAnalysisSize("Cats", 0, false);
@@ -154,7 +154,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 			// SUT
 			// The lowercase wordform has already been parsed.
-			bVal = parserWorker.UpdateWordform(catsLowerTest, ParserPriority.Low);
+			bVal = parserWorker.ParseAndUpdateWordform(catsLowerTest, ParserPriority.Low);
 			ExecuteIdleQueue();
 			Assert.IsTrue(bVal);
 			CheckAnalysisSize("Cats", 0, false);

--- a/Src/LexText/ParserCore/ParserScheduler.cs
+++ b/Src/LexText/ParserCore/ParserScheduler.cs
@@ -106,7 +106,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 			public override void DoWork()
 			{
-				m_scheduler.m_parserWorker.UpdateWordform(m_wordform, m_priority, m_checkParser);
+				m_scheduler.m_parserWorker.ParseAndUpdateWordform(m_wordform, m_priority, m_checkParser);
 				base.DoWork();
 			}
 		}

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -115,7 +115,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			}
 		}
 
-		public bool UpdateWordform(IWfiWordform wordform, ParserPriority priority, bool checkParser = false)
+		public bool ParseAndUpdateWordform(IWfiWordform wordform, ParserPriority priority, bool checkParser = false)
 		{
 			CheckDisposed();
 
@@ -157,7 +157,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 			if (sLower != form.Text)
 			{
-				var text = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
+				var lcText = TsStringUtils.MakeString(sLower, form.get_WritingSystem(0));
 				var lcWord = normalizer.Normalize(sLower.Replace(' ', '.'));
 				ParseResult lcResult = null;
 				stopWatch.Start();
@@ -169,13 +169,9 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				lcResult.ParseTime = stopWatch.ElapsedMilliseconds;
 				if (lcResult.Analyses.Count > 0 && lcResult.ErrorMessage == null)
 				{
-					IWfiWordform lcWordform = null;
-					NonUndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW(
-						m_cache.ActionHandlerAccessor,
-						() => lcWordform = WfiWordformServices.FindOrCreateWordform(m_cache, text));
-					m_parseFiler.ProcessParse(lcWordform, 0, lcResult, checkParser);
-					m_parseFiler.ProcessParse(wordform, priority, result, checkParser);
-					return true;
+					// Don't turn lcText into a wordform here.
+					// This avoids a problem with broadcasting PropChanged (cf. LT-22079).
+					m_parseFiler.ProcessParse(lcText, 0, lcResult, checkParser);
 				}
 			}
 


### PR DESCRIPTION
The crash occurred because ParserWorker.UpdateWordform tried to do a NonUndoableUnitOfWork to create a lower case wordform in its own thread, which crashed if the user happened to independently do something that broadcasted a PropChanged.  The fix was to postpone the NonUndoableUnitOfWork until the work was in the right thread (in ParserFiler).

I also renamed ParserWorker.UpdateWordform to ParserWorker.ParseAndUpdateWordform because it was too easy to confuse with ParserFiler.UpdateWordforms, and I simplified the branch that deals with lowercase wordforms by removing:

    m_parseFiler.ProcessParse(wordform, priority, result, checkParser);
    return true;

The branch now falls through to

    return m_parseFiler.ProcessParse(wordform, priority, result, checkParser);

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/288)
<!-- Reviewable:end -->
