### PR TITLE
Fix LT-22083: Crash occurs while importing interlinear into empty pane

### DIFF
--- a/Src/LexText/Interlinear/InterlinDocRootSiteBase.cs
+++ b/Src/LexText/Interlinear/InterlinDocRootSiteBase.cs
@@ -1030,7 +1030,7 @@ namespace SIL.FieldWorks.IText
 		{
 			//If the RootStText is null we are either in a place that doesn't care about parser related updates
 			// or we are not yet completely displaying the text, so we should be fine, I hope? (LT-12493)
-			if (SuspendResettingAnalysisCache || RootStText == null)
+			if (SuspendResettingAnalysisCache || RootStText == null || RootStText.Cache == null)
 				return;
 
 			switch (tag)


### PR DESCRIPTION
This crashed because RootStText.Cache was null.  I assume that this is some sort of dummy RootStText.  I fixed this by avoiding processing it.  I'm not sure how RootStText.Cache became null.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/294)
<!-- Reviewable:end -->
