### PR TITLE
Fix LT-22084: Crash while performing undo after deleting text

### DIFF
--- a/Src/xWorks/RecordList.cs
+++ b/Src/xWorks/RecordList.cs
@@ -1872,7 +1872,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			CheckDisposed();
 
-			if (SortedObjects.Count == 0)
+			if (SortedObjects.Count <= index)
 				return null;
 			else
 			return SortedObjects[index] as IManyOnePathSortItem;


### PR DESCRIPTION
I improved the guard.  This seemed to fix the problem.  In this case the caller allowed for a null response, but not all callers do.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/296)
<!-- Reviewable:end -->
