### PR TITLE
Fix LT-22086: Reversal Indexes crashes without any reversals

### DIFF
--- a/Src/xWorks/RecordList.cs
+++ b/Src/xWorks/RecordList.cs
@@ -1872,10 +1872,10 @@ namespace SIL.FieldWorks.XWorks
 		{
 			CheckDisposed();
 
-			if (SortedObjects.Count <= index)
-				return null;
+			if (0 <= index && index < SortedObjects.Count)
+				return SortedObjects[index] as IManyOnePathSortItem;
 			else
-			return SortedObjects[index] as IManyOnePathSortItem;
+				return null;
 		}
 
 		/// <summary>


### PR DESCRIPTION
I improved the guard on SortObjects[index] to prevent a crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/298)
<!-- Reviewable:end -->
