### PR TITLE
Fix LT-22089: Creating and undoing a text leads to confusion

### DIFF
--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -950,7 +950,7 @@ namespace SIL.FieldWorks.XWorks
 			// jumps to the first instance of that object (LT-4691).
 			// Through deletion of Reversal Index entry it was possible to arrive here with
 			// no sorted objects. (LT-13391)
-			if (e.Index >= 0 && m_list.SortedObjects.Count > 0)
+			if (0 <= e.Index && e.Index < m_list.SortedObjects.Count)
 			{
 				int ourHvo = m_list.SortItemAt(e.Index).RootObjectHvo;
 				// if for some reason the index doesn't match the hvo, we'll jump to the Hvo.

--- a/Src/xWorks/RecordList.cs
+++ b/Src/xWorks/RecordList.cs
@@ -1704,6 +1704,11 @@ namespace SIL.FieldWorks.XWorks
 				// we want to wait until after everything is finished reloading, however.
 				m_requestedLoadWhileSuppressed = true;
 			}
+			if (Clerk.Id == "interlinearTexts")
+			{
+				// Wait for InterestingTextsList to be updated (cf. LT-22089).
+				m_requestedLoadWhileSuppressed = true;
+			}
 
 			// Try to catch things that don't obviously affect us, but will cause problems.
 			if (cvDel > 0 && CurrentIndex >= 0 && IsPropOwning(tag))


### PR DESCRIPTION
The problem with https://jira.sil.org/browse/LT-22089 is that RecordList gets a PropChanged notification before InterestingTextList does, so RecordList.GetObjectSet returns the old value for InterestingTextList.   At Jason's suggestion, I fixed it by setting m_requestedLoadWhileSuppressed = true so that RecordList would get updated again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/301)
<!-- Reviewable:end -->
