### PR TITLE
Fix LT-22090: Green box crash in IsLexicalPattern

### DIFF
--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1481,9 +1481,12 @@ namespace SIL.FieldWorks.IText
 			for (var i = 0; i < multiString.StringCount; i++)
 			{
 				int ws;
-				string text = multiString.GetStringFromIndex(i, out ws).Text;
-				if (text.Contains("[") && text.Contains("]"))
-					return true;
+				ITsString tssString = multiString.GetStringFromIndex(i, out ws);
+				if (tssString != null && tssString.Text != null)
+				{
+					if (tssString.Text.Contains("[") && tssString.Text.Contains("]"))
+						return true;
+				}
 			}
 			return false;
 		}


### PR DESCRIPTION
This is for https://jira.sil.org/browse/LT-22090.   It doesn't have an acceptance test, but it is pretty obvious from the stack trace what was causing the null reference pointer exception in IsLexicalPattern.  Mark Bean will have to verify that this fixes his problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/303)
<!-- Reviewable:end -->
