### PR TITLE
Word Export: LT-22051: Fix problem with “Minor Subentries”

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1178,8 +1178,11 @@ namespace SIL.FieldWorks.XWorks
 				// Add the group style.
 				if (!string.IsNullOrEmpty(config.Style))
 				{
+					ParagraphElement paraElem = s_styleCollection.AddParagraphStyle(config);
+					string uniqueDisplayName = paraElem.UniqueDisplayName();
+
 					WP.ParagraphProperties paragraphProps =
-						new WP.ParagraphProperties(new ParagraphStyleId() { Val = config.DisplayLabel });
+						new WP.ParagraphProperties(new ParagraphStyleId() { Val = uniqueDisplayName });
 					groupPara.PrependChild(paragraphProps);
 				}
 				groupData.DocBody.AppendChild(groupPara);

--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -209,7 +209,14 @@ namespace SIL.FieldWorks.XWorks
 				{
 					style = new Style();
 					style.Type = StyleValues.Character;
-					style.Append(parentRunProps.CloneNode(true));
+					if (parentRunProps != null)
+					{
+						style.Append(parentRunProps.CloneNode(true));
+					}
+					else
+					{
+						style.Append(new StyleRunProperties());
+					}
 				}
 
 				// Update the style name.
@@ -313,18 +320,18 @@ namespace SIL.FieldWorks.XWorks
 				// We only need to build the two sets for the children. The node
 				// '.entry .senses .subentries' does NOT need a second set of rules. It's rules
 				// will get created through the normal execution of this method.
-				if (nodes[ii].DisplayLabel == "Subentries" && (ii + 1 < nodes.Count) &&
-					nodes[ii + 1].DisplayLabel == "MainEntrySubentries")
+				if (CssGenerator.GetClassAttributeForConfig(workingNode) == "subentries" && (ii + 1 < nodes.Count) &&
+					CssGenerator.GetClassAttributeForConfig(nodes[ii + 1]) == "mainentrysubentries")
 				{
 					// Build the styles for the '.entry .senses .subentries' path.
 					var mainEntryNode = nodes[ii - 1];
-					var sensesNode = mainEntryNode.Children.First(child => child.DisplayLabel == "Senses");
-					var sensesSubentriesNode = sensesNode.Children.First(child => child.DisplayLabel == "Subentries");
+					var sensesNode = mainEntryNode.Children.First(child => CssGenerator.GetClassAttributeForConfig(child) == "senses");
+					var sensesSubentriesNode = sensesNode.Children.First(child => CssGenerator.GetClassAttributeForConfig(child) == "subentries");
 					parentSensesSubentryUniqueDisplayName = AddStyles(sensesSubentriesNode, wsId);
 					sensesSubentriesNodePath = CssGenerator.GetNodePath(sensesSubentriesNode);
 				}
 
-				if (workingDisplayName == "MainEntrySubentries")
+				if (CssGenerator.GetClassAttributeForConfig(workingNode) == "mainentrysubentries")
 				{
 					buildSenseSubentryRules = true;
 					continue;


### PR DESCRIPTION
We were checking the nodes DisplayLabel for “Subentries” but this can be different for “Minor Subentries”.  Changed the checks to use the class names instead of display labels.

This PR also prevents a possible situation where we could reference an incorrect style name.

Change-Id: I709d1ec18a6cb81eaa5070f184e2b7f8cb5faa58

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/308)
<!-- Reviewable:end -->
