### PR TITLE
Fix LT-22094: the text entered always appears in a RLT direction

### DIFF
--- a/Src/xWorks/RecordList.cs
+++ b/Src/xWorks/RecordList.cs
@@ -1706,8 +1706,12 @@ namespace SIL.FieldWorks.XWorks
 			}
 			if (Clerk.Id == "interlinearTexts" && cvDel > 0)
 			{
-				// Wait for InterestingTextsList to be updated (cf. LT-22089).
-				m_requestedLoadWhileSuppressed = true;
+				string fieldName = Cache.MetaDataCacheAccessor.GetFieldNameOrNull(tag);
+				if (fieldName != null && fieldName == "InterlinearTexts")
+				{
+					// Wait for InterestingTextsList to be updated (cf. LT-22089).
+					m_requestedLoadWhileSuppressed = true;
+				}
 			}
 
 			// Try to catch things that don't obviously affect us, but will cause problems.


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22094 which was caused by the fix for https://jira.sil.org/browse/LT-22089.  https://jira.sil.org/browse/LT-22089 and https://jira.sil.org/browse/LT-22092 should be checked as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/309)
<!-- Reviewable:end -->
