### PR TITLE
Fix LT-22103: Crash opening list chooser on multiple fields

### DIFF
--- a/Src/Common/Controls/XMLViews/ReallySimpleListChooser.cs
+++ b/Src/Common/Controls/XMLViews/ReallySimpleListChooser.cs
@@ -1843,7 +1843,7 @@ namespace SIL.FieldWorks.Common.Controls
 		/// <returns></returns>
 		protected virtual LabelNode CreateLabelNode(ObjectLabel nol, bool displayUsage)
 		{
-			if (nol.Object.Owner.ToString() == "Publications")
+			if (nol?.Object?.Owner?.ToString() == "Publications")
 				return new PublicationLabelNode(nol, m_stylesheet, displayUsage);
 			return new LabelNode(nol, m_stylesheet, displayUsage);
 		}


### PR DESCRIPTION
This fixes a bug in the code that I wrote to fix LT-21826:

https://github.com/sillsdev/FieldWorks/commit/da7cd68b733a0657a21ae06191aedc68d61c7015

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/315)
<!-- Reviewable:end -->
