### PR TITLE
Fix LT-22104b: Incorrrect title for reversal index

### DIFF
--- a/Src/xWorks/DictionaryConfigurationUtils.cs
+++ b/Src/xWorks/DictionaryConfigurationUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 SIL International
+// Copyright (c) 2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -59,7 +59,9 @@ namespace SIL.FieldWorks.XWorks
 					var configName = reader["name"];
 					if (configName == null)
 						throw new InvalidDataException(String.Format("{0} is an invalid configuration file", configFile));
-					configurations[configName] = configFile;
+					if (!configurations.Keys.Contains(configName))
+						// Use the first one if there is more than one to avoid picking en2 over en.
+						configurations[configName] = configFile;
 				}
 			}
 		}

--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -1075,7 +1075,16 @@ namespace SIL.FieldWorks.XWorks
 		private void SetActiveSelectedEntryOnView(GeckoWebBrowser browser)
 		{
 			if (Clerk.CurrentObject == null)
+			{
+				if (Clerk.Id == "AllReversalEntries" && m_updateContentLater)
+				{
+					// There are no entries, but we still need to clear the pane and update the title.
+					var currentConfig = m_propertyTable.GetStringProperty("ReversalIndexPublicationLayout", string.Empty);
+					UpdateContent(currentConfig);
+					m_updateContentLater = false;
+				}
 				return;
+			}
 
 			if (Clerk.Id == "AllReversalEntries")
 			{


### PR DESCRIPTION
This fixes "When clicking 'Show in Reversal Index' (Ctrl+Click) in the English Reversal Entries, it displays the correct entries, but they are listed under 'All Reversal Indexes' instead of 'English Reversals'." in a comment in https://jira.sil.org/browse/LT-22104.  The problem was caused by the existence of two English writing systems in Sena 3: one labeled "en" and one labeled "en2".  I changed the code to prefer the first one.

I also fixed the problem that if you tried to change to a reversal index that didn't have any entries using the drop down menu, then it said "No Reversal Entries" but the title didn't update. 