### PR TITLE
Fix LT-12587b: allow MoInflAffMsa to be changed like MoStemMsa

### DIFF
--- a/Src/FdoUi/InflectionFeatureEditor.cs
+++ b/Src/FdoUi/InflectionFeatureEditor.cs
@@ -546,6 +546,16 @@ namespace SIL.FieldWorks.FdoUi
 						fEnable = hvoFeature != m_selectedHvo;
 					}
 				}
+				if (clsid == MoInflAffMsaTags.kClassId)
+				{
+					int pos = sda.get_ObjectProp(hvoMsa, MoInflAffMsaTags.kflidPartOfSpeech);
+					if (m_notSure || (pos != 0 && possiblePOS.Contains(pos)))
+					{
+						// Only show it as a change if it is different
+						int hvoFeature = sda.get_ObjectProp(hvoMsa, MoInflAffMsaTags.kflidInflFeats);
+						fEnable = hvoFeature != m_selectedHvo;
+					}
+				}
 			}
 			return fEnable;
 		}


### PR DESCRIPTION
This fixes the reopened https://jira.sil.org/browse/LT-12587 by allowing Bulk-Edit List Choice to apply to MoInflAffMsa as well as MoStemMsa.  n/a cannot be deleted since it is not an inflection but rather an indication that inflection is not possible.