### PR TITLE
Fix LT-22065: Turn off vernacular spell-checking by default

### DIFF
--- a/Src/LexText/Lexicon/FLExBridgeListener.cs
+++ b/Src/LexText/Lexicon/FLExBridgeListener.cs
@@ -1394,7 +1394,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 		// currently duplicated in MorphologyListener, to avoid an assembly dependency.
 		private static bool IsVernacularSpellingEnabled(PropertyTable propertyTable)
 		{
-			return propertyTable.GetBoolProperty("UseVernSpellingDictionary", true);
+			return propertyTable.GetBoolProperty("UseVernSpellingDictionary", false);
 		}
 
 		private static bool CheckForExistingFileName(string projectFolder, string revisedFileName)

--- a/Src/LexText/Morphology/MorphologyListener.cs
+++ b/Src/LexText/Morphology/MorphologyListener.cs
@@ -271,7 +271,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		// currently duplicated in FLExBridgeListener, to avoid an assembly dependency.
 		private bool IsVernacularSpellingEnabled()
 		{
-			return m_propertyTable.GetBoolProperty("UseVernSpellingDictionary", true);
+			return m_propertyTable.GetBoolProperty("UseVernSpellingDictionary", false);
 		}
 
 		private void RestartSpellChecking()


### PR DESCRIPTION
This issue was originally titled "Turn off vernacular spell-checking by default", but the title was changed when Beth found a mismatch between the state of vernacular spell-checking and what was happening.  I was not able to reproduce what Beth found, so she suggested that we turn off vernacular spell-checking by default and if she sees the problem again she would report it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/324)
<!-- Reviewable:end -->
