### PR TITLE
Word Export: LT-22112: Fix RTL gram. info in wrong place

### DIFF
--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2279,13 +2279,10 @@ namespace SIL.FieldWorks.XWorks
 					if (IsBidi)
 					{
 						CharacterElement elem = s_styleCollection.GetCharacterElement(uniqueDisplayName);
-						lock(_collectionLock)
+						if (!elem.WritingSystemIsRtl)
 						{
-							if (!elem.WritingSystemIsRtl)
-							{
-								var defVernWsId = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem.Handle;
-								elem.WritingSystemIsRtl = LcmWordGenerator.IsWritingSystemRightToLeft(Cache, defVernWsId);
-							}
+							var defVernWsId = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem.Handle;
+							elem.WritingSystemIsRtl = LcmWordGenerator.IsWritingSystemRightToLeft(Cache, defVernWsId);
 						}
 					}
 				}

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2273,6 +2273,21 @@ namespace SIL.FieldWorks.XWorks
 					string displayNameBaseCombined = parentElem.DisplayNameBase + WordStylesGenerator.BeforeAfterBetween;
 					uniqueDisplayName = s_styleCollection.AddSpecialCharacterStyle(befAftBetStyleName,
 						displayNameBaseCombined, parentUniqueDisplayName, befAftBetNodePath, wsId);
+
+					// For before/after/between content we want to use the right to left setting for the
+					// default vernacular writing system.
+					if (IsBidi)
+					{
+						CharacterElement elem = s_styleCollection.GetCharacterElement(uniqueDisplayName);
+						lock(_collectionLock)
+						{
+							if (!elem.WritingSystemIsRtl)
+							{
+								var defVernWsId = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem.Handle;
+								elem.WritingSystemIsRtl = LcmWordGenerator.IsWritingSystemRightToLeft(Cache, defVernWsId);
+							}
+						}
+					}
 				}
 			}
 

--- a/Src/xWorks/WordStyleCollection.cs
+++ b/Src/xWorks/WordStyleCollection.cs
@@ -713,7 +713,7 @@ namespace SIL.FieldWorks.XWorks
 			this.BasedOnElement = basedOnElem;
 		}
 		internal int WritingSystemId { get; }
-		internal bool WritingSystemIsRtl { get; }
+		internal bool WritingSystemIsRtl { get; set; }
 		internal CharacterElement Redirect { get; set; }
 		internal CharacterElement BasedOnElement { get; }
 		internal ParagraphElement LinkedParagraphElement { get; set; }


### PR DESCRIPTION
We want to use the specific writing system to get the style properties for before/after/between content, but we don’t typically want to use the specific
ws to determine if the rtl flag should be set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/328)
<!-- Reviewable:end -->
