### PR TITLE
Fix LT-21206: Features label misleading

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
+++ b/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
@@ -284,7 +284,7 @@
 		</part>
 		<part ref="DescriptionAllA">
 		</part>
-		<part ref="ShowInGloss" label="Use Abbreviation as label"/>
+		<part ref="ShowInGloss" label="Display label"/>
 		<part ref="InflectionFeaturesValuesSection" expansion="expanded" label="Values" menu="mnuDataTree-ClosedFeature-Values" >
 			<indent>
 				<part ref="Values" expansion="expanded" menu="mnuDataTree-ClosedFeature-Values"/>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21206 (along with the latest version of liblcm).

Should the label for FsFeatDefn at line 276 also be changed?
How about the label for FsComplexFeature at line 363?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/332)
<!-- Reviewable:end -->
