### PR TITLE
LT-21206: Update documentation for Display label

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
+++ b/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
@@ -284,7 +284,7 @@
 		</part>
 		<part ref="DescriptionAllA">
 		</part>
-		<part ref="ShowInGloss" label="Use Abbreviation as label"/>
+		<part ref="ShowInGloss" label="Display label"/>
 		<part ref="InflectionFeaturesValuesSection" expansion="expanded" label="Values" menu="mnuDataTree-ClosedFeature-Values" >
 			<indent>
 				<part ref="Values" expansion="expanded" menu="mnuDataTree-ClosedFeature-Values"/>

--- a/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
+++ b/DistFiles/Language Explorer/Configuration/Parts/Morphology.fwlayout
@@ -360,7 +360,7 @@
 		<part ref="DescriptionAllA">
 		</part>
 		<part ref="Type" label="Type" />
-		<part ref="ShowInGloss" label="Use Abbreviation as label"/>
+		<part ref="ShowInGloss" label="Display label"/>
 		<part ref="RightGlossSepAllA">
 		</part>
 	</layout>

--- a/Src/LexText/LexTextDll/HelpTopicPaths.resx
+++ b/Src/LexText/LexTextDll/HelpTopicPaths.resx
@@ -612,7 +612,7 @@
     <value>User_Interface/Field_Descriptions/Grammar/Features_fields/description_field_feature_features.htm</value>
   </data>
   <data name="khtpField-FsClosedFeature-ShowInGloss" xml:space="preserve">
-    <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/Show_Abbr_as_label_field_Features.htm</value>
+    <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/Display_label_field_(Features).htm</value>
   </data>
   <data name="khtpField-FsComplexFeature-Type" xml:space="preserve">
     <value>User_Interface/Field_Descriptions/Grammar/Features_fields/Type_field_Features.htm</value>
@@ -2103,7 +2103,7 @@
     <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/name_field_feature_features.htm</value>
   </data>
   <data name="khtpField-featuresAdvancedEdit-FsComplexFeature-ShowInGloss" xml:space="preserve">
-    <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/Show_Abbr_as_label_field_Features.htm</value>
+    <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/Display_label_field_(Features).htm</value>
   </data>
   <data name="khtpField-featuresAdvancedEdit-FsComplexFeature-SpecialNote" xml:space="preserve">
     <value>User_Interface/Field_Descriptions/Grammar/Inflection_Features_fields/Special_Note_field_Features.htm</value>


### PR DESCRIPTION
I changed the label for Complex Features to "Display label".
I updated the documentation for Display label to use the new documentation that Marlon wrote.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/337)
<!-- Reviewable:end -->
