### PR TITLE
Fix LT-21729: Reduce the delay in writing cached data

### DIFF
--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -315,7 +315,17 @@ namespace SIL.FieldWorks.XWorks
 				m_propertyTable.SetProperty("App", app, true);
 				m_propertyTable.SetPropertyPersistence("App", false);
 			}
+			this.Deactivate += FwXWindow_Deactivate;
 		}
+
+		private void FwXWindow_Deactivate(object args, EventArgs e)
+		{
+			// The window has lost the focus.
+			// Save changes so that other applications can access them.
+			Cache.ServiceLocator.GetInstance<IUndoStackManager>().StopSaveTimer();
+			Cache.ServiceLocator.GetInstance<IUndoStackManager>().Save();
+		}
+
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>


### PR DESCRIPTION
I added code to write changes out when FieldWorks loses the focus.  This avoids a problem that Ron Lockwood was running into where the changes that he had just made in FieldWorks weren't visible to FlexTrans because he didn't let FieldWorks idle for a full second before switching back to FlexTrans.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/339)
<!-- Reviewable:end -->
