### PR TITLE
LT-22091: Fix Dictionary Configuration yellow highlighting

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -1869,7 +1869,7 @@ namespace SIL.FieldWorks.XWorks
 			var content = GenerateContentForFieldByReflection(item, nodeList, publicationDecorator, settings);
 			if (content.IsNullOrEmpty())
 				return settings.ContentGenerator.CreateFragment();
-			return settings.ContentGenerator.GenerateGramInfoBeforeSensesContent(content, nodeList);
+			return settings.ContentGenerator.GenerateGramInfoBeforeSensesContent(content, nodeList, settings);
 		}
 
 		private static bool IsAllGramInfoTheSame(ConfigurableDictionaryNode config, IEnumerable<ILexSense> collection, bool isSubsense,
@@ -2188,7 +2188,7 @@ namespace SIL.FieldWorks.XWorks
 			var xBldr = settings.ContentGenerator.CreateFragment();
 			using (var xw = settings.ContentGenerator.CreateWriter(xBldr))
 			{
-				settings.ContentGenerator.BeginCrossReference(xw, config, IsBlockProperty(config), GetCollectionItemClassAttribute(config));
+				settings.ContentGenerator.BeginCrossReference(xw, config, settings, IsBlockProperty(config), GetCollectionItemClassAttribute(config));
 				var targetInfo = referenceList.FirstOrDefault();
 				if (targetInfo == null)
 					return settings.ContentGenerator.CreateFragment();

--- a/Src/xWorks/ILcmContentGenerator.cs
+++ b/Src/xWorks/ILcmContentGenerator.cs
@@ -19,7 +19,7 @@ namespace SIL.FieldWorks.XWorks
 		IFragment GenerateAudioLinkContent(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classname, string srcAttribute, string caption, string safeAudioId);
 		IFragment WriteProcessedObject(List<ConfigurableDictionaryNode> nodeList, bool isBlock, IFragment elementContent, string className);
 		IFragment WriteProcessedCollection(List<ConfigurableDictionaryNode> nodeList, bool isBlock, IFragment elementContent, string className);
-		IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList);
+		IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList, ConfiguredLcmGenerator.GeneratorSettings settings);
 		IFragment GenerateGroupingNode(List<ConfigurableDictionaryNode> nodeList, object field, string className,
 			DictionaryPublicationDecorator publicationDecorator, ConfiguredLcmGenerator.GeneratorSettings settings,
 			Func<object, List<ConfigurableDictionaryNode>, DictionaryPublicationDecorator, ConfiguredLcmGenerator.GeneratorSettings, IFragment> childContentGenerator);
@@ -53,14 +53,14 @@ namespace SIL.FieldWorks.XWorks
 		void AddEntryData(IFragmentWriter writer, List<ConfiguredLcmGenerator.ConfigFragment> pieces);
 		void EndEntry(IFragmentWriter writer);
 		void AddCollection(IFragmentWriter writer, List<ConfigurableDictionaryNode> nodeList, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className, IFragment content);
-		void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string getCollectionItemClassAttribute);
+		void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string getCollectionItemClassAttribute);
 		void EndObject(IFragmentWriter writer);
 		void WriteProcessedContents(IFragmentWriter writer, ConfigurableDictionaryNode config, IFragment contents);
 		IFragment AddImage(ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, string classAttribute, string srcAttribute, string pictureGuid);
 		IFragment AddImageCaption(ConfigurableDictionaryNode config, IFragment captionContent);
 		IFragment GenerateSenseNumber(List<ConfigurableDictionaryNode> nodeList, ConfiguredLcmGenerator.GeneratorSettings settings, string formattedSenseNumber, string senseNumberWs);
 		IFragment AddLexReferences(List<ConfigurableDictionaryNode> nodeList, bool generateLexType, IFragment lexTypeContent, string className, IFragment referencesContent, bool typeBefore);
-		void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string className);
+		void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className);
 		void EndCrossReference(IFragmentWriter writer);
 		void BetweenCrossReferenceType(IFragment content, List<ConfigurableDictionaryNode> nodeList, bool firstItem);
 		IFragment WriteProcessedSenses(List<ConfigurableDictionaryNode> nodeList, bool isBlock, IFragment senseContent, string className, IFragment sharedCollectionInfo);

--- a/Src/xWorks/LcmJsonGenerator.cs
+++ b/Src/xWorks/LcmJsonGenerator.cs
@@ -105,7 +105,8 @@ namespace SIL.FieldWorks.XWorks
 			return fragment;
 		}
 
-		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList)
+		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList,
+			ConfiguredLcmGenerator.GeneratorSettings settings)
 		{
 			// The grammatical info is generated as a json property on 'senses'
 			return content;
@@ -317,7 +318,8 @@ namespace SIL.FieldWorks.XWorks
 			((JsonFragmentWriter)writer).EndArray();
 		}
 
-		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty,
+		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty,
 			string className)
 		{
 			((JsonFragmentWriter)writer).InsertPropertyName(className);
@@ -406,7 +408,8 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string classAttribute)
+		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string classAttribute)
 		{
 			// In json the context is enough. We don't need the extra 'span' or 'div' with the item name
 			// If the consumer needs to match up (to use our css) they can assume the child is the collection singular

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -1147,7 +1147,8 @@ namespace SIL.FieldWorks.XWorks
 
 			return elementContent;
 		}
-		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList)
+		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList,
+			ConfiguredLcmGenerator.GeneratorSettings settings)
 		{
 			return content;
 		}
@@ -1770,7 +1771,8 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string getCollectionItemClassAttribute)
+		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string getCollectionItemClassAttribute)
 		{
 			return;
 		}
@@ -1916,7 +1918,8 @@ namespace SIL.FieldWorks.XWorks
 			return fragment;
 		}
 
-		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode senseConfigNode, bool isBlockProperty, string className)
+		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode senseConfigNode,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className)
 		{
 			return;
 		}

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -16,7 +16,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Web.UI.WebControls;
 using System.Xml;
@@ -635,7 +634,8 @@ namespace SIL.FieldWorks.XWorks
 			return new StringFragment();
 		}
 
-		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList)
+		public IFragment GenerateGramInfoBeforeSensesContent(IFragment content, List<ConfigurableDictionaryNode> nodeList,
+			ConfiguredLcmGenerator.GeneratorSettings settings)
 		{
 			var bldr = new StringBuilder();
 			var fragment = new StringFragment(bldr);
@@ -643,6 +643,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				xw.WriteStartElement("span");
 				xw.WriteAttributeString("class", "sharedgrammaticalinfo");
+				WriteNodeId(xw, nodeList.Last(), settings);
 				xw.WriteRaw(content.ToString());
 				xw.WriteEndElement();
 				xw.Flush();
@@ -921,12 +922,13 @@ namespace SIL.FieldWorks.XWorks
 			xw.WriteEndElement();
 		}
 
-		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty,
-			string className)
+		public void BeginObjectProperty(IFragmentWriter writer, ConfigurableDictionaryNode config,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string className)
 		{
 			var xw = ((XmlFragmentWriter)writer).Writer;
 			xw.WriteStartElement(isBlockProperty ? "div" : "span");
 			xw.WriteAttributeString("class", className);
+			WriteNodeId(xw, config, settings);
 		}
 
 		public void EndObject(IFragmentWriter writer)
@@ -1012,9 +1014,10 @@ namespace SIL.FieldWorks.XWorks
 			return fragment;
 		}
 
-		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config, bool isBlockProperty, string classAttribute)
+		public void BeginCrossReference(IFragmentWriter writer, ConfigurableDictionaryNode config,
+			ConfiguredLcmGenerator.GeneratorSettings settings, bool isBlockProperty, string classAttribute)
 		{
-			BeginObjectProperty(writer, config, isBlockProperty, classAttribute);
+			BeginObjectProperty(writer, config, settings, isBlockProperty, classAttribute);
 		}
 
 		public void EndCrossReference(IFragmentWriter writer)


### PR DESCRIPTION
Fixed yellow highlighting in the Configure Dictionary dialog for Lexical Relations and Grammatical Info.

Change-Id: Ibbd63d6cf8df2023cd9597bcdb3d8a09a3107a69

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/346)
<!-- Reviewable:end -->
