### PR TITLE
Fix LT-21461: Problems with Choose Allomorph dialog box

### DIFF
--- a/Src/Common/Controls/XMLViews/MatchingObjectsBrowser.cs
+++ b/Src/Common/Controls/XMLViews/MatchingObjectsBrowser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014-2017 SIL International
+// Copyright (c) 2014-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -138,6 +138,16 @@ namespace SIL.FieldWorks.Common.Controls
 				m_startingObject = value;
 			}
 		}
+
+		/// <summary>
+		/// Delegate for FilterResult.
+		/// </summary>
+		public delegate bool FilterResultDelegate(int hvo);
+
+		/// <summary>
+		/// Should we filter a result?
+		/// </summary>
+		public FilterResultDelegate FilterResult;
 
 		/// <summary>
 		/// Used by a Find dialog's SearchEngine to determine whether to search on a particular field or not
@@ -384,6 +394,8 @@ namespace SIL.FieldWorks.Common.Controls
 				hvos = results.Where(hvo => StartingObject == null || StartingObject.Hvo != hvo).ToArray();
 			}
 
+			if (FilterResult != null)
+				hvos = hvos.Where(hvo => !FilterResult(hvo)).ToArray();
 			int count = hvos.Length;
 			int prevIndex = m_bvMatches.SelectedIndex;
 			int prevHvo = prevIndex == -1 ? 0 : m_bvMatches.AllItems[prevIndex];

--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -877,8 +877,9 @@ namespace SIL.FieldWorks
 					ws.DefaultCollation = new IcuRulesCollationDefinition("standard");
 					nullCollationWs.Append(ws.DisplayLabel + ",");
 				}
-				// Check HasValidRules here rather than in RecordSorter to avoid LT-21461 problem.
-				if (ws != null && ws.DefaultCollation != null && !HasValidRules(ws.DefaultCollation))
+				// Check for invalid collation here rather than in RecordSorter to avoid LT-21461 problem.
+				// This may also repair the previous if statement.
+				if (ws != null && ws.DefaultCollation != null && InvalidCollation(ws.DefaultCollation))
 				{
 					ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
 				}
@@ -896,10 +897,10 @@ namespace SIL.FieldWorks
 		/// An ICURulesCollationDefinition with empty rules was causing access violations in ICU. (LT-20268)
 		/// This method supports the band-aid fallback to SystemCollationDefinition.
 		/// </summary>
-		/// <returns>true if the CollationDefinition is a RulesCollationDefinition with valid non empty rules</returns>
-		private static bool HasValidRules(CollationDefinition cd)
+		/// <returns>true if the CollationDefinition is invalid or is a RulesCollationDefinition with empty rules</returns>
+		private static bool InvalidCollation(CollationDefinition cd)
 		{
-			return cd is RulesCollationDefinition ? !string.IsNullOrEmpty(((RulesCollationDefinition)cd).CollationRules) && cd.IsValid : true;
+			return !cd.IsValid || (cd is RulesCollationDefinition ? string.IsNullOrEmpty(((RulesCollationDefinition)cd).CollationRules) : false);
 		}
 
 

--- a/Src/LexText/LexTextControls/LinkAllomorphDlg.cs
+++ b/Src/LexText/LexTextControls/LinkAllomorphDlg.cs
@@ -136,6 +136,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			base.SetDlgInfo(cache, wp, mediator, propertyTable);
 			// This is needed to make the replacement MatchingEntriesBrowser visible:
 			Controls.SetChildIndex(m_matchingObjectsBrowser, 0);
+			m_matchingObjectsBrowser.FilterResult = FilterLexEntry;
 
 			m_fwcbAllomorphs.WritingSystemFactory = cache.WritingSystemFactory;
 			m_fwcbAllomorphs.WritingSystemCode = cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem.Handle;
@@ -149,6 +150,25 @@ namespace SIL.FieldWorks.LexText.Controls
 		#endregion	Construction and Destruction
 
 		#region	Other methods
+
+		/// <summary>
+		/// Filter hvo if all of its forms are abstract.
+		/// </summary>
+		private bool FilterLexEntry(int hvo)
+		{
+			ILexEntry entry = m_cache.ServiceLocator.GetObject(hvo) as ILexEntry;
+			if (entry == null)
+				return false;
+			var lf = entry.LexemeFormOA;
+			if (lf != null && !lf.IsAbstract)
+				return false;
+			foreach (var allo in entry.AlternateFormsOS)
+			{
+				if (!allo.IsAbstract)
+					return false;
+			}
+			return true;
+		}
 
 		protected override void HandleMatchingSelectionChanged()
 		{


### PR DESCRIPTION
Double-clicking on an abstract morpheme no longer caused a crash, but the Choose Allomorph dialog box wasn't displaying any morphemes after the first search.  This was because the French DefaultCollation was being changed after the first search by RecordSorter, and then the DefaultCollation no longer matched the data in the searcher.  The DefaultCollation was being changed from a standard collation to the system collation to a void a bug when a standard collation doesn't have any rules.  I copied the code to change the DefaultCollation to the initialization code in FieldWorks.EnsureDefaultCollationsPresent to avoid this problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/347)
<!-- Reviewable:end -->
