### PR TITLE
Fix LT-22129: Crash when clicking the Insert Affix Template

### DIFF
--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -315,16 +315,7 @@ namespace SIL.FieldWorks.XWorks
 				m_propertyTable.SetProperty("App", app, true);
 				m_propertyTable.SetPropertyPersistence("App", false);
 			}
-			this.Deactivate += FwXWindow_Deactivate;
 		}
-
-		private void FwXWindow_Deactivate(object args, EventArgs e)
-		{
-			// The window has lost the focus.
-			// Save changes so that other applications can access them.
-			Cache.ServiceLocator.GetInstance<IUndoStackManager>().Save();
-		}
-
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>


### PR DESCRIPTION
This undoes https://github.com/sillsdev/FieldWorks/commit/f01203ae64017542b2348b29eb84a598de19e7fd, which didn't fix https://jira.sil.org/browse/LT-21729 according to Sara and which caused https://jira.sil.org/browse/LT-22128 and https://jira.sil.org/browse/LT-22129.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/352)
<!-- Reviewable:end -->
