### PR TITLE
Fix LT-21908: Create a utility to remove user-approved analyses

### DIFF
--- a/DistFiles/Language Explorer/Configuration/UtilityCatalogInclude.xml
+++ b/DistFiles/Language Explorer/Configuration/UtilityCatalogInclude.xml
@@ -3,6 +3,7 @@
 	<utility assemblyPath="LexEdDll.dll" class="SIL.FieldWorks.XWorks.LexEd.HomographResetter"/>
 	<utility assemblyPath="MorphologyEditorDll.dll" class="SIL.FieldWorks.XWorks.MorphologyEditor.ParserAnalysisRemover"/>
 	<utility assemblyPath="MorphologyEditorDll.dll" class="SIL.FieldWorks.XWorks.MorphologyEditor.ParserAnnotationRemover"/>
+	<utility assemblyPath="MorphologyEditorDll.dll" class="SIL.FieldWorks.XWorks.MorphologyEditor.UserAnalysisRemover"/>
 	<utility assemblyPath="FixFwDataDll.dll" class="SIL.FieldWorks.FixData.ErrorFixer"/>
 	<utility assemblyPath="FixFwDataDll.dll" class="SIL.FieldWorks.FixData.WriteAllObjectsUtility"/>
 	<utility assemblyPath="ITextDll.dll" class="SIL.FieldWorks.IText.DuplicateWordformFixer"/>

--- a/DistFiles/Language Explorer/Configuration/strings-en.xml
+++ b/DistFiles/Language Explorer/Configuration/strings-en.xml
@@ -303,6 +303,12 @@
 		<string id="WhatDescription" txt="This utility removes all parser annotations from the system. Parser annotations used to be added by the parser when there was a problem parsing a word. "/>
 		<string id="RedoDescription" txt="You cannot use 'Undo' to cancel the effect of this utility."/>
 	  </group>
+	  <group id="RemoveUserAnalyses">
+		<string id="Label" txt="Remove User-approved analyses"/>
+		<string id="WhenDescription" txt="Run this utility when you want to remove all user-approved analyses.  This is useful if the parser changes how it analyses wordforms."/>
+		<string id="WhatDescription" txt="This utility removes all user approved analyses from the system. It does not remove analyses that are approved/disapproved of by the parser, however. "/>
+		<string id="RedoDescription" txt="You cannot use 'Undo' to cancel the effect of this utility. Therefore, you should back up your project before running this."/>
+	  </group>
 	  <group id="NaturalClassChooser">
 		<string id="kstidChooseNaturalClass" txt="Choose Natural Class"/>
 		<string id="kstidNaturalClassListing" txt="The following natural classes have been specified in the grammar area."/>

--- a/Src/LexText/Morphology/MorphologyEditorDll.csproj
+++ b/Src/LexText/Morphology/MorphologyEditorDll.csproj
@@ -384,6 +384,7 @@
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="RuleFormulaVcBase.cs" />
+    <Compile Include="UserAnalysisRemover.cs" />
     <Compile Include="WordformGoDlg.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Src/LexText/Morphology/UserAnalysisRemover.cs
+++ b/Src/LexText/Morphology/UserAnalysisRemover.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SIL.FieldWorks.Common.FwUtils;
+using SIL.FieldWorks.FwCoreDlgs;
+using SIL.LCModel.Infrastructure;
+using SIL.LCModel;
+
+namespace SIL.FieldWorks.XWorks.MorphologyEditor
+{
+	/// <summary>
+	/// This class serves to remove all analyses that are only approved by the user.
+	/// Analyses that have a parser evaluation (approved or disapproved) remain afterwards.
+	/// </summary>
+	public class UserAnalysisRemover : IUtility
+	{
+		#region Data members
+
+		private UtilityDlg m_dlg;
+		const string kPath = "/group[@id='Linguistics']/group[@id='Morphology']/group[@id='RemoveUserAnalyses']/";
+
+		#endregion Data members
+
+		/// <summary>
+		/// Override method to return the Label property.
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString()
+		{
+			return Label;
+		}
+
+		#region IUtility implementation
+
+		/// <summary>
+		/// Get the main label describing the utility.
+		/// </summary>
+		public string Label
+		{
+			get
+			{
+				Debug.Assert(m_dlg != null);
+				return StringTable.Table.GetStringWithXPath("Label", kPath);
+			}
+		}
+
+		/// <summary>
+		/// Set the UtilityDlg.
+		/// </summary>
+		/// <remarks>
+		/// This must be set, before calling any other property or method.
+		/// </remarks>
+		public UtilityDlg Dialog
+		{
+			set
+			{
+				Debug.Assert(value != null);
+				Debug.Assert(m_dlg == null);
+
+				m_dlg = value;
+			}
+		}
+
+		/// <summary>
+		/// Load 0 or more items in the list box.
+		/// </summary>
+		public void LoadUtilities()
+		{
+			Debug.Assert(m_dlg != null);
+			m_dlg.Utilities.Items.Add(this);
+
+		}
+
+		/// <summary>
+		/// Notify the utility that has been selected in the dlg.
+		/// </summary>
+		public void OnSelection()
+		{
+			Debug.Assert(m_dlg != null);
+			m_dlg.WhenDescription = StringTable.Table.GetStringWithXPath("WhenDescription", kPath);
+			m_dlg.WhatDescription = StringTable.Table.GetStringWithXPath("WhatDescription", kPath);
+			m_dlg.RedoDescription = StringTable.Table.GetStringWithXPath("RedoDescription", kPath);
+		}
+
+		/// <summary>
+		/// Have the utility do what it does.
+		/// </summary>
+		public void Process()
+		{
+			Debug.Assert(m_dlg != null);
+			var cache = m_dlg.PropTable.GetValue<LcmCache>("cache");
+			IWfiAnalysis[] analyses = cache.ServiceLocator.GetInstance<IWfiAnalysisRepository>().AllInstances().ToArray();
+			if (analyses.Length == 0)
+				return;
+
+			// Set up progress bar.
+			m_dlg.ProgressBar.Minimum = 0;
+			m_dlg.ProgressBar.Maximum = analyses.Length;
+			m_dlg.ProgressBar.Step = 1;
+
+			NonUndoableUnitOfWorkHelper.Do(cache.ActionHandlerAccessor, () =>
+			{
+				foreach (IWfiAnalysis analysis in analyses)
+				{
+					ICmAgentEvaluation[] humanEvals = analysis.EvaluationsRC.Where(evaluation => evaluation.Human).ToArray();
+					foreach (ICmAgentEvaluation humanEval in humanEvals)
+						analysis.EvaluationsRC.Remove(humanEval);
+
+					IWfiWordform wordform = analysis.Wordform;
+					if (analysis.EvaluationsRC.Count == 0)
+						wordform.AnalysesOC.Remove(analysis);
+
+					if (humanEvals.Length > 0)
+					{
+						wordform.Checksum = 0;
+						analysis.MoveConcAnnotationsToWordform();
+					}
+
+					m_dlg.ProgressBar.PerformStep();
+				}
+			});
+		}
+
+		#endregion IUtility implementation
+	}
+}


### PR DESCRIPTION
This is patterned after the utility to remove parser-approved analyses.  It should be safe to add to release 9.2 since it doesn't change any existing code.