### PR TITLE
Fix LT-15909: Crash selecting none of the above in inflection features

### DIFF
--- a/Src/FdoUi/InflectionFeatureEditor.cs
+++ b/Src/FdoUi/InflectionFeatureEditor.cs
@@ -255,7 +255,7 @@ namespace SIL.FieldWorks.FdoUi
 			// Arrange to turn all relevant items blue.
 			// Remember which item was selected so we can later 'doit'.
 			var hvoNode = e.Node as HvoTreeNode;
-			m_notSure = (string)hvoNode.Tag == "NotSure";
+			m_notSure = (string)hvoNode?.Tag == "NotSure";
 			if (hvoNode == null || hvoNode.Hvo == 0)
 			{
 				m_selectedHvo = 0;


### PR DESCRIPTION
This seems like a safe fix for the stable release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/358)
<!-- Reviewable:end -->
