### PR TITLE
Fix LT-22125: Clear out DefaultCollations that don't Validate

### DIFF
--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -872,16 +872,20 @@ namespace SIL.FieldWorks
 			StringBuilder nullCollationWs = new StringBuilder();
 			foreach (CoreWritingSystemDefinition ws in cache.ServiceLocator.WritingSystems.AllWritingSystems)
 			{
-				if (ws != null && ws.DefaultCollation == null)
+				if (ws != null && (ws.DefaultCollation == null || !ws.DefaultCollation.Validate(out _)))
 				{
 					ws.DefaultCollation = new IcuRulesCollationDefinition("standard");
 					nullCollationWs.Append(ws.DisplayLabel + ",");
 				}
 				// Check for invalid collation here rather than in RecordSorter to avoid LT-21461 problem.
-				// This may also repair the previous if statement.
 				if (ws != null && ws.DefaultCollation != null && InvalidCollation(ws.DefaultCollation))
 				{
-					ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+					CollationDefinition cd;
+					if (SystemCollator.ValidateLanguageTag(ws.LanguageTag, out _))
+						cd = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+					else
+						cd = new IcuRulesCollationDefinition("standard");
+					ws.DefaultCollation = cd;
 				}
 			}
 			if (nullCollationWs.Length > 0)


### PR DESCRIPTION
  After a thorough investigation of current LCM and palaso code
  I can't find any places where SystemCollationDefinitions were
  not Validated before being set in the DefaultCollation

  There was that possibility here, but I couldn't reliably reproduce
  the bug. This *may* address the root cause and it will prevent any
  repeated crashing due to this type of writing system data error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/359)
<!-- Reviewable:end -->
