### PR TITLE
LT-21766: Fix Reversal Sort Order in Webonary

### DIFF
--- a/Src/LexText/Lexicon/ReversalListener.cs
+++ b/Src/LexText/Lexicon/ReversalListener.cs
@@ -417,7 +417,15 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			var layoutFinder = ((Sorter as GenRecordSorter)?.Comparer as StringFinderCompare)?.Finder as LayoutFinder;
 			if (layoutFinder?.Vc != null)
 			{
-				layoutFinder.Vc.OverrideWs = WritingSystemServices.CurrentReversalWsId;
+				var wsComparer = ((Sorter as GenRecordSorter)?.Comparer as StringFinderCompare)?.SubComparer as WritingSystemComparer;
+				if (wsComparer != null)
+				{
+					layoutFinder.Vc.OverrideWs = Cache.WritingSystemFactory.GetWsFromStr(wsComparer.WsId);
+				}
+				else
+				{
+					layoutFinder.Vc.OverrideWs = WritingSystemServices.CurrentReversalWsId;
+				}
 			}
 
 			try


### PR DESCRIPTION
In some situations the CurrentReversalWsId is not correct. Now we first try to get a ws from the SubComparer (if it is a WritingSystemComparer). This looks like the same place that the Sorter gets the ws.

Note: This change also fixes a similar problem with the reversal sort order in Word Export.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/363)
<!-- Reviewable:end -->
