### PR TITLE
Fix LT-22146: Darken guess colors in interlinear text display

### DIFF
--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -421,7 +421,7 @@ namespace SIL.FieldWorks.IText
 		/// </summary>
 		public static int ApprovedGuessColor
 		{
-			get { return (int)CmObjectUi.RGB(200, 255, 255); }
+			get { return (int)CmObjectUi.RGB(150, 255, 255); }
 		}
 
 		/// <summary>
@@ -437,7 +437,7 @@ namespace SIL.FieldWorks.IText
 		/// </summary>
 		public static int MachineGuessColor
 		{
-			get { return (int)CmObjectUi.RGB(254, 240, 206); }
+			get { return (int)CmObjectUi.RGB(234, 220, 186); }
 		}
 
 		/// <summary/>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22146.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/366)
<!-- Reviewable:end -->
