### PR TITLE
Fix LT-22148: tan color reappers in Interlinear Texts

### DIFF
--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -125,23 +125,6 @@ namespace SIL.FieldWorks.LexText.Controls
 			}
 		}
 
-		/// <summary>
-		/// Send the newly selected wordform on to the parser.
-		/// </summary>
-		public void OnPropertyChanged(string propertyName)
-		{
-			CheckDisposed();
-
-			if (m_parserConnection != null && propertyName == "ActiveClerkSelectedObject")
-			{
-				var wordform = m_propertyTable.GetValue<ICmObject>(propertyName) as IWfiWordform;
-				if (wordform != null)
-				{
-					UpdateWordform(wordform, ParserPriority.High);
-				}
-			}
-		}
-
 		#region IVwNotifyChange Members
 
 		public void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22148 by deleting the code that silently parses wordforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/370)
<!-- Reviewable:end -->
