### PR TITLE
Fix LT-22158: error in Try a Word tracing with Hermit Crab

### DIFF
--- a/Src/LexText/ParserCore/FwXmlTraceManager.cs
+++ b/Src/LexText/ParserCore/FwXmlTraceManager.cs
@@ -388,7 +388,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 		private static XElement CreateInflFeaturesElement(string name, FeatureStruct fs)
 		{
-			return new XElement(name, fs.Head().ToString().Replace(",", ""));
+			string feat = (fs.Head() == null) ? "" : fs.Head().ToString().Replace(",", "");
+			return new XElement(name, feat);
 		}
 
 		private static XElement CreateWordElement(string name, Word word, bool analysis, bool bracketed = false)


### PR DESCRIPTION
It was possible to get a null value for fs.Head().  This fixes it.
Change-Id: If2769369514d415054687db2285b3c4801c23b2f

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/372)
<!-- Reviewable:end -->
