### PR TITLE
Fix LT-22149: Exported Interlinear text is duplicated

### DIFF
--- a/Src/LexText/Interlinear/FilterAllTextsDialog.cs
+++ b/Src/LexText/Interlinear/FilterAllTextsDialog.cs
@@ -139,7 +139,7 @@ namespace SIL.FieldWorks.IText
 		/// </summary>
 		public IStText[] GetListOfIncludedTexts()
 		{
-			return m_treeTexts.GetCheckedTagData().OfType<IStText>().ToArray();
+			return m_treeTexts.GetCheckedTagData().OfType<IStText>().Distinct().ToArray();
 		}
 
 		#region Windows Form Designer generated code


### PR DESCRIPTION
Added .Distinct() to eliminate duplicates.