### PR TITLE
Fix LT-21945: Interlinear mode changes requested by Beth

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Main.xml
+++ b/DistFiles/Language Explorer/Configuration/Main.xml
@@ -876,6 +876,7 @@ I (RandyR) brought them into this file, just to keep track of them for the time 
 		<panel id="ProgressBar" width="Contents" minwidth="150" assemblyPath="FwControls.dll" class="SIL.FieldWorks.Common.Controls.StatusBarProgressPanel"/>
 		<panel id="Sort" width="Contents" minwidth="40" assemblyPath="FwControls.dll" class="SIL.FieldWorks.Common.Controls.StatusBarTextBox"/>
 		<panel id="Filter" width="Contents" minwidth="40" assemblyPath="FwControls.dll" class="SIL.FieldWorks.Common.Controls.StatusBarTextBox"/>
+        <panel id="ParsingDev" width="Contents" minwidth="40" assemblyPath="FwControls.dll" class="SIL.FieldWorks.Common.Controls.StatusBarTextBox"/>
 		<panel id="RecordNumber" width="Contents" minwidth="40"/>
 	</statusbar>
 	<!-- ********************************************************** -->

--- a/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
+++ b/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
@@ -28,10 +28,10 @@
 		<command id="CmdChooseHCParser" label="Phonological Rule-based Parser (HermitCrab.NET)" message="ChooseParser">
 			<parameters parser="HC"/>
 		</command>
-        <command id="CmdParsingDevelopmentMode" label="Parsing Development" message="SetParsingMode">
+        <command id="CmdParsingDevelopmentMode" label="Parsing Development" message="SetParsingDevMode">
           <parameters value="true"/>
         </command>
-        <command id="CmdTextAnalysisMode" label="Text Analysis" message="SetParsingMode">
+        <command id="CmdTextGlossingMode" label="Text Glossing" message="SetParsingDevMode">
           <parameters value="false"/>
         </command>
 
@@ -294,7 +294,7 @@
 			</menu>
           <menu id="ChooseModeMenu" label="Interlinear Mode">
             <item command="CmdParsingDevelopmentMode"/>
-            <item command="CmdTextAnalysisMode"/>
+            <item command="CmdTextGlossingMode"/>
           </menu>
           <item command="CmdEditParserParameters"/>
 		</menu>

--- a/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
+++ b/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
@@ -282,7 +282,7 @@ namespace SIL.FieldWorks.IText
 			var wordform = m_owner.GetWordformOfAnalysis();
 
 			// Add the analyses, and recursively the other items.
-			var guess_services = new AnalysisGuessServices(m_cache, IsParsingMode());
+			var guess_services = new AnalysisGuessServices(m_cache, IsParsingDevMode());
 			var sorted_analyses = guess_services.GetSortedAnalysisGuesses(wordform, m_occurrence, false);
 			foreach (var wa in sorted_analyses)
 			{
@@ -311,7 +311,7 @@ namespace SIL.FieldWorks.IText
 		{
 			AddItem(wa,
 				MakeAnalysisStringRep(wa, m_cache, StyleSheet != null, (m_owner as SandboxBase).RawWordformWs), true);
-			var guess_services = new AnalysisGuessServices(m_cache, IsParsingMode());
+			var guess_services = new AnalysisGuessServices(m_cache, IsParsingDevMode());
 			var sorted_glosses = guess_services.GetSortedGlossGuesses(wa, m_occurrence);
 			foreach (var gloss in sorted_glosses)
 			{
@@ -323,11 +323,11 @@ namespace SIL.FieldWorks.IText
 			AddItem(wa, MakeSimpleString(ITextStrings.ksNewWordGloss), false, WfiGlossTags.kClassId);
 		}
 
-		private bool IsParsingMode()
+		private bool IsParsingDevMode()
 		{
 			if (Owner?.InterlinDoc?.GetMaster() == null)
 				return false;
-			return Owner.InterlinDoc.GetMaster().IsParsingMode();
+			return Owner.InterlinDoc.GetMaster().IsParsingDevMode();
 		}
 
 		protected ITsString MakeSimpleString(String str)

--- a/Src/LexText/Interlinear/ITextStrings.Designer.cs
+++ b/Src/LexText/Interlinear/ITextStrings.Designer.cs
@@ -1577,15 +1577,6 @@ namespace SIL.FieldWorks.IText {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parsing.
-        /// </summary>
-        internal static string ksParsingMode {
-            get {
-                return ResourceManager.GetString("ksParsingMode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Ph{0} {1}.
         /// </summary>
         internal static string ksPhaseButton {

--- a/Src/LexText/Interlinear/ITextStrings.resx
+++ b/Src/LexText/Interlinear/ITextStrings.resx
@@ -989,8 +989,4 @@ Click "Cancel" to abort this import.</value>
   <data name="ComplexConcControl_ResultsMayBeIncomplete" xml:space="preserve">
     <value>Results may be incomplete.</value>
   </data>
-  <data name="ksParsingMode" xml:space="preserve">
-    <value>Parsing</value>
-    <comment>alternate name for Analyze tab</comment>
-  </data>
 </root>

--- a/Src/LexText/Interlinear/InterlinMaster.cs
+++ b/Src/LexText/Interlinear/InterlinMaster.cs
@@ -55,8 +55,6 @@ namespace SIL.FieldWorks.IText
 
 		private string m_currentTool = "";
 
-		private string m_analyzeTabName = "";
-
 		public string CurrentTool
 		{
 			get { return m_currentTool; }
@@ -89,8 +87,6 @@ namespace SIL.FieldWorks.IText
 		{
 			// This call is required by the Windows.Forms Form Designer.
 			InitializeComponent();
-			// Save the Analyze tab name.
-			m_analyzeTabName = m_tpInterlinear.Text;
 		}
 
 		internal string BookmarkId
@@ -725,7 +721,7 @@ namespace SIL.FieldWorks.IText
 			m_mediator = mediator;
 			// InitBase will do this, but we need it in place before calling SetInitialTabPage().
 			m_propertyTable = propertyTable;
-			SetParsingMode(IsParsingMode());
+			SetParsingDevMode(IsParsingDevMode());
 
 			// Making the tab control currently requires this first...
 			if (!fHideTitlePane)
@@ -1251,20 +1247,21 @@ namespace SIL.FieldWorks.IText
 			return true; // We handled this
 		}
 
-		public bool OnDisplaySetParsingMode(object commandObject,
+		public bool OnDisplaySetParsingDevMode(object commandObject,
 			ref UIItemDisplayProperties display)
 		{
 			var cmd = (Command)commandObject;
 			bool value = cmd.GetParameter("value") == "true";
-			display.Checked = IsParsingMode() == value;
+			display.Checked = IsParsingDevMode() == value;
 			return true;
 		}
 
-		public bool OnSetParsingMode(object argument)
+		public bool OnSetParsingDevMode(object argument)
 		{
 			var cmd = (Command)argument;
 			string value = cmd.GetParameter("value");
-			SetParsingMode(value == "true");
+			SetParsingDevMode(value == "true");
+			Clerk.UpdateParsingDevStatusBarPanel();
 			// Refresh the display.
 			RootStText = null;
 			m_idcAnalyze.ResetAnalysisCache();
@@ -1272,23 +1269,14 @@ namespace SIL.FieldWorks.IText
 			return true; // we handled this
 		}
 
-		public void SetParsingMode(bool value)
+		public void SetParsingDevMode(bool value)
 		{
-			m_propertyTable.SetProperty("ParsingMode", value, PropertyTable.SettingsGroup.LocalSettings, false);
-			if (value)
-			{
-				m_tpInterlinear.Text = ITextStrings.ksParsingMode;
-			}
-			else
-			{
-				// Restore Analyze tab name.
-				m_tpInterlinear.Text = m_analyzeTabName;
-			}
+			m_propertyTable.SetProperty("ParsingDevMode", value, PropertyTable.SettingsGroup.LocalSettings, false);
 		}
 
-		public bool IsParsingMode()
+		public bool IsParsingDevMode()
 		{
-			return m_propertyTable.GetBoolProperty("ParsingMode", false, PropertyTable.SettingsGroup.LocalSettings);
+			return m_propertyTable.GetBoolProperty("ParsingDevMode", false, PropertyTable.SettingsGroup.LocalSettings);
 		}
 
 		/// <summary>

--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -373,15 +373,15 @@ namespace SIL.FieldWorks.IText
 			if (m_loader != null)
 			{
 				CheckDisposed();
-				m_loader.ResetGuessCache(IsParsingMode());
+				m_loader.ResetGuessCache(IsParsingDevMode());
 			}
 		}
 
-		internal bool IsParsingMode()
+		internal bool IsParsingDevMode()
 		{
 			if (RootSite?.GetMaster() == null)
 				return false;
-			return RootSite.GetMaster().IsParsingMode();
+			return RootSite.GetMaster().IsParsingDevMode();
 		}
 
 		internal AnalysisGuessServices GuessServices
@@ -390,7 +390,7 @@ namespace SIL.FieldWorks.IText
 			{
 				if (m_loader != null && m_loader.GuessServices != null)
 					return m_loader.GuessServices;
-				return new AnalysisGuessServices(m_cache, IsParsingMode());
+				return new AnalysisGuessServices(m_cache, IsParsingDevMode());
 			}
 		}
 
@@ -551,7 +551,7 @@ namespace SIL.FieldWorks.IText
 		private int GetGuessColor(ICmObject obj)
 		{
 			IWfiAnalysis wa;
-			if (IsParsingMode())
+			if (IsParsingDevMode())
 			{
 				// Parser approval takes precedence over User approval.
 				wa = (obj is IWfiGloss) ? ((IWfiGloss)obj).Analysis : obj as IWfiAnalysis;
@@ -2305,7 +2305,7 @@ namespace SIL.FieldWorks.IText
 
 		internal virtual IParaDataLoader CreateParaLoader()
 		{
-			return new InterlinViewCacheLoader(new AnalysisGuessServices(m_cache, IsParsingMode()), GuessCache);
+			return new InterlinViewCacheLoader(new AnalysisGuessServices(m_cache, IsParsingDevMode()), GuessCache);
 		}
 
 		internal void RecordGuessIfNotKnown(AnalysisOccurrence selected)
@@ -2426,7 +2426,7 @@ namespace SIL.FieldWorks.IText
 	{
 		void LoadParaData(IStTxtPara para);
 		void LoadSegmentData(ISegment seg);
-		void ResetGuessCache(bool parsingMode);
+		void ResetGuessCache(bool parsingDevMode);
 		bool UpdatingOccurrence(IAnalysis oldAnalysis, IAnalysis newAnalysis);
 		void RecordGuessIfNotKnown(AnalysisOccurrence occurrence);
 		IAnalysis GetGuessForWordform(IWfiWordform wf, int ws);
@@ -2550,11 +2550,11 @@ namespace SIL.FieldWorks.IText
 		#region IParaDataLoader Members
 
 
-		public void ResetGuessCache(bool parsingMode)
+		public void ResetGuessCache(bool parsingDevMode)
 		{
 			// recreate the guess services, so they will use the latest FDO data.
 			GuessServices.ClearGuessData();
-			GuessServices.PrioritizeParser = parsingMode;
+			GuessServices.PrioritizeParser = parsingDevMode;
 			// clear the cache for the guesses, so it won't have any stale data.
 			m_guessCache.ClearPropFromCache(InterlinViewDataCache.AnalysisMostApprovedFlid);
 		}

--- a/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
+++ b/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
@@ -115,11 +115,11 @@ namespace SIL.FieldWorks.IText
 				m_rootb = sandbox.RootBox;
 			}
 
-			internal bool IsParsingMode()
+			internal bool IsParsingDevMode()
 			{
 				if (m_sandbox.InterlinDoc?.GetMaster() == null)
 					return false;
-				return m_sandbox.InterlinDoc.GetMaster().IsParsingMode();
+				return m_sandbox.InterlinDoc.GetMaster().IsParsingDevMode();
 			}
 
 
@@ -1134,7 +1134,7 @@ namespace SIL.FieldWorks.IText
 					return; // no real wordform, can't have analyses.
 				ITsStrBldr builder = TsStringUtils.MakeStrBldr();
 				ITsString space = TsStringUtils.MakeString(fBaseWordIsPhrase ? "  " : " ", m_wsVern);
-				var guess_services = new AnalysisGuessServices(m_caches.MainCache, IsParsingMode());
+				var guess_services = new AnalysisGuessServices(m_caches.MainCache, IsParsingDevMode());
 				var sorted_analyses = guess_services.GetSortedAnalysisGuesses(wordform, m_wsVern);
 				foreach (IWfiAnalysis wa in sorted_analyses)
 				{
@@ -3210,7 +3210,7 @@ namespace SIL.FieldWorks.IText
 			{
 				IList<int> wsids = m_sandbox.m_choices.EnabledWritingSystemsForFlid(InterlinLineChoices.kflidWordGloss);
 
-				var guess_services = new AnalysisGuessServices(m_caches.MainCache, IsParsingMode());
+				var guess_services = new AnalysisGuessServices(m_caches.MainCache, IsParsingDevMode());
 				var sorted_glosses = guess_services.GetSortedGlossGuesses(wa);
 				foreach (IWfiGloss gloss in sorted_glosses)
 				{

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -609,6 +609,7 @@ namespace SIL.FieldWorks.XWorks
 			bool fRestoredFilter = TryRestoreFilter(m_clerkConfiguration, Cache);
 			UpdateFilterStatusBarPanel();
 			UpdateSortStatusBarPanel();
+			UpdateParsingDevStatusBarPanel();
 			return fRestoredSorter || fRestoredFilter;
 		}
 
@@ -2088,6 +2089,7 @@ namespace SIL.FieldWorks.XWorks
 				return;
 			UpdateFilterStatusBarPanel();
 			UpdateSortStatusBarPanel();
+			UpdateParsingDevStatusBarPanel();
 		}
 
 		/// <summary>
@@ -2849,6 +2851,29 @@ namespace SIL.FieldWorks.XWorks
 		protected virtual string FilterStatusContents(bool listIsFiltered)
 		{
 			return listIsFiltered ? xWorksStrings.Filtered : "";
+		}
+
+		public void UpdateParsingDevStatusBarPanel()
+		{
+			if (!IsControllingTheRecordTreeBar)
+				return; // none of our business!
+			bool fIgnore = m_propertyTable.GetBoolProperty("IgnoreStatusPanel", false);
+			if (fIgnore)
+				return;
+
+			var b = m_propertyTable.GetValue<StatusBarTextBox>("ParsingDev");
+			if (b == null) //Other xworks apps may not have this panel
+				return;
+			if (!m_propertyTable.GetBoolProperty("ParsingDevMode", false, PropertyTable.SettingsGroup.LocalSettings))
+			{
+				b.BackBrush = System.Drawing.Brushes.Transparent;
+				b.TextForReal = "";
+			}
+			else
+			{
+				b.BackBrush = System.Drawing.Brushes.Tan;
+				b.TextForReal = xWorksStrings.ParsingDev;
+			}
 		}
 
 		private void UpdateSortStatusBarPanel()

--- a/Src/xWorks/xWorksStrings.Designer.cs
+++ b/Src/xWorks/xWorksStrings.Designer.cs
@@ -2619,6 +2619,15 @@ namespace SIL.FieldWorks.XWorks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parsing Dev.
+        /// </summary>
+        internal static string ParsingDev {
+            get {
+                return ResourceManager.GetString("ParsingDev", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Max Height (inches):.
         /// </summary>
         internal static string PictureOptionsView_MaxHeightLabel {

--- a/Src/xWorks/xWorksStrings.resx
+++ b/Src/xWorks/xWorksStrings.resx
@@ -1298,4 +1298,7 @@ See USFM documentation for help.</value>
   <data name="PictureOptionsView_MaxWidthLabel" xml:space="preserve">
     <value>Max Width (inches):</value>
   </data>
+  <data name="ParsingDev" xml:space="preserve">
+    <value>Parsing Dev</value>
+  </data>
 </root>


### PR DESCRIPTION
I made changes to https://jira.sil.org/browse/LT-21945 requested by Beth:
- Replaced "Parsing" tab with "Paring Dev" status bar.
- Renamed "Text Analysis" to "Text Glossing"

I also replaced ParsingMode with ParsingDevMode to make names more consistent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/375)
<!-- Reviewable:end -->
