### PR TITLE
LT-21960: Fix COM problem with VwPropertyStore

### DIFF
--- a/Src/Common/Controls/Widgets/FontHeightAdjuster.cs
+++ b/Src/Common/Controls/Widgets/FontHeightAdjuster.cs
@@ -165,7 +165,7 @@ namespace SIL.FieldWorks.Common.Widgets
 				}
 			}
 
-			IVwPropertyStore vwps = VwPropertyStoreClass.Create();
+			VwPropertyStoreManaged vwps = new VwPropertyStoreManaged();
 			vwps.Stylesheet = styleSheet;
 			vwps.WritingSystemFactory = writingSystemFactory;
 

--- a/Src/Common/FwUtils/FwUtilsTests/TestFwStylesheetTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/TestFwStylesheetTests.cs
@@ -127,7 +127,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 			stylesheet.OverrideFontsForWritingSystems("FirstStyle", fontOverrides);
 
 			//check results
-			IVwPropertyStore vwps = VwPropertyStoreClass.Create();
+			VwPropertyStoreManaged vwps = new VwPropertyStoreManaged();
 			vwps.Stylesheet = stylesheet;
 			vwps.WritingSystemFactory = wsf;
 
@@ -190,7 +190,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 			stylesheet.OverrideFontsForWritingSystems("FirstStyle", fontOverrides);
 
 			//check results
-			IVwPropertyStore vwps = VwPropertyStoreClass.Create();
+			VwPropertyStoreManaged vwps = new VwPropertyStoreManaged();
 			vwps.Stylesheet = stylesheet;
 			vwps.WritingSystemFactory = wsf;
 

--- a/Src/Common/SimpleRootSite/EditingHelper.cs
+++ b/Src/Common/SimpleRootSite/EditingHelper.cs
@@ -1536,7 +1536,7 @@ namespace SIL.FieldWorks.Common.RootSites
 			ttpBldr.SetIntPropValues((int)FwTextPropType.ktptWs, 0, hvoWs);
 			ITsTextProps ttp = ttpBldr.GetTextProps();
 
-			IVwPropertyStore vwps = VwPropertyStoreClass.Create();
+			VwPropertyStoreManaged vwps = new VwPropertyStoreManaged();
 			vwps.Stylesheet = styleSheet;
 			vwps.WritingSystemFactory = wsf;
 			LgCharRenderProps chrps = vwps.get_ChrpFor(ttp);

--- a/Src/Common/ViewsInterfaces/ViewsInterfaces.csproj
+++ b/Src/Common/ViewsInterfaces/ViewsInterfaces.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -163,6 +163,7 @@
     <Compile Include="AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="VwPropertyStoreManaged.cs" />
     <None Include="BuildInclude.targets">
       <SubType>Designer</SubType>
     </None>

--- a/Src/Common/ViewsInterfaces/VwPropertyStoreManaged.cs
+++ b/Src/Common/ViewsInterfaces/VwPropertyStoreManaged.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2002-2025 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using SIL.LCModel.Core.KernelInterfaces;
+
+namespace SIL.FieldWorks.Common.ViewsInterfaces
+{
+	/// <summary/>
+	public sealed class VwPropertyStoreManaged : IDisposable
+	{
+		private const string _viewsDllPath = "views.dll";
+		private IntPtr pVwPropStore;
+
+		// Detect redundant Dispose() calls in a thread-safe manner.
+		// _isDisposed == 0 means Dispose(bool) has not been called yet.
+		// _isDisposed == 1 means Dispose(bool) has already been called.
+		private int _isDisposed;
+
+		/// <summary/>
+		public VwPropertyStoreManaged()
+		{
+			pVwPropStore = VwPropertyStore_Create();
+		}
+
+		/// <summary/>
+		public IVwStylesheet Stylesheet
+		{
+			set
+			{
+				VwPropertyStore_Stylesheet(pVwPropStore, value);
+			}
+		}
+
+		/// <summary/>
+		public ILgWritingSystemFactory WritingSystemFactory
+		{
+			set
+			{
+				VwPropertyStore_WritingSystemFactory(pVwPropStore, value);
+			}
+		}
+
+		/// <summary/>
+		public LgCharRenderProps get_ChrpFor(ITsTextProps ttp)
+		{
+			IntPtr pInt = VwPropertyStore_get_ChrpFor(pVwPropStore, ttp);
+			return (LgCharRenderProps)Marshal.PtrToStructure(pInt, typeof(LgCharRenderProps));
+		}
+
+		#region Disposable stuff
+		/// <summary/>
+		~VwPropertyStoreManaged() => Dispose(false);
+
+		/// <summary/>
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		/// <summary/>
+		private void Dispose(bool disposing)
+		{
+			if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
+			{
+				// Dispose managed resources (if there are any).
+				if (disposing)
+				{
+				}
+
+				// Dispose unmanaged resources.
+				VwPropertyStore_Delete(pVwPropStore);
+			}
+		}
+		#endregion
+
+		#region DLLImport stuff
+		[DllImport(_viewsDllPath, CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr VwPropertyStore_Create();
+
+		[DllImport(_viewsDllPath, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void VwPropertyStore_Delete(IntPtr pVwPropStore);
+
+		[DllImport(_viewsDllPath, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void VwPropertyStore_Stylesheet(IntPtr pVwPropStore,
+			[MarshalAs(UnmanagedType.Interface)] IVwStylesheet pss);
+
+		[DllImport(_viewsDllPath, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void VwPropertyStore_WritingSystemFactory(IntPtr pVwPropStore,
+			[MarshalAs(UnmanagedType.Interface)] ILgWritingSystemFactory pwsf);
+
+		[DllImport(_viewsDllPath, CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr VwPropertyStore_get_ChrpFor(IntPtr pVwPropStore,
+			[MarshalAs(UnmanagedType.Interface)] ITsTextProps _ttp);
+		#endregion
+	}
+}

--- a/Src/views/Views.idh
+++ b/Src/views/Views.idh
@@ -3429,27 +3429,9 @@ Last reviewed:
 		[propget] HRESULT StringProperty(
 			[in] int sp,
 			[out, retval] BSTR * bstrValue);
-		// Get the LgCharRenderProps that this property store would produce for the
-		// specified pttp. The pttp should specify the writing system and ows that the properties
-		// are wanted for.
-		[propget] HRESULT ChrpFor(
-			[in] ITsTextProps * pttp,
-			[out, retval] LgCharRenderProps * pchrp);
-		// Set the style sheet that this property store will use to interpret
-		[propputref] HRESULT Stylesheet(
-			[in] IVwStylesheet * pvps);
-
-		// Set the writing system factory that this property store uses.
-		[propputref] HRESULT WritingSystemFactory(
-			[in] ILgWritingSystemFactory * pwsf);
 
 		// Get the property store that this one was derived from.
 		[propget] HRESULT ParentStore([out, retval]IVwPropertyStore ** ppvps);
-
-		// Gets an ${ITsTextProps} interface pointer on an ITsTextProps object whose properties are
-		// those currently in the store. In particular, if the current VwPropertyStore has just
-		// been created and not changed, the properties will be the system default properties.
-		[propget] HRESULT TextProps([out,retval] ITsTextProps ** ppttp);
 
 		// Get the actual, working value of some string-valued property.
 		[propget] HRESULT DerivedPropertiesForTtp(

--- a/Src/views/VwPropertyStore.cpp
+++ b/Src/views/VwPropertyStore.cpp
@@ -56,6 +56,31 @@ static const int s_ctptWsStyleProps = (isizeof(s_rgtptWsStyleProps) / isizeof(in
 static OleStringLiteral g_pszDefaultFont(L"<default font>");
 
 //:>********************************************************************************************
+//:>	DllExports
+//:>********************************************************************************************
+extern "C" _declspec(dllexport) void* VwPropertyStore_Create() {
+	return (void*)NewObj VwPropertyStore();
+}
+
+extern "C" _declspec(dllexport) void VwPropertyStore_Delete(VwPropertyStore* t) {
+	delete t;
+}
+
+extern "C" _declspec(dllexport) void VwPropertyStore_Stylesheet(VwPropertyStore* t, IVwStylesheet* pss) {
+	t->putref_Stylesheet(pss);
+}
+
+extern "C" _declspec(dllexport) void VwPropertyStore_WritingSystemFactory(VwPropertyStore* t, ILgWritingSystemFactory* pwsf) {
+	t->putref_WritingSystemFactory(pwsf);
+}
+
+extern "C" _declspec(dllexport) LgCharRenderProps* VwPropertyStore_get_ChrpFor(VwPropertyStore* t, ITsTextProps* pttp) {
+	LgCharRenderProps* pchrp = NewObj LgCharRenderProps();
+	t->get_ChrpFor(pttp, pchrp);
+	return pchrp;
+}
+
+//:>********************************************************************************************
 //:>	Constructor/Destructor
 //:>********************************************************************************************
 


### PR DESCRIPTION
Instead of using COM we added a wrapper class that uses DllImport to create and call methods on the VwPropertyStore object.

Change-Id: I8681ad9140a3b5a887b1ba672dae9b58dab55a75