### PR TITLE
Fix LT-22162: Sandbox focus shifts when switching interlinear mode

### DIFF
--- a/Src/LexText/Interlinear/InterlinMaster.cs
+++ b/Src/LexText/Interlinear/InterlinMaster.cs
@@ -1263,6 +1263,7 @@ namespace SIL.FieldWorks.IText
 			SetParsingDevMode(value == "true");
 			Clerk.UpdateParsingDevStatusBarPanel();
 			// Refresh the display.
+			SaveBookMark();
 			RootStText = null;
 			m_idcAnalyze.ResetAnalysisCache();
 			Clerk.JumpToIndex(Clerk.CurrentIndex);


### PR DESCRIPTION
Added a call to SaveBookmark so that Clerk.JumpToIndex would focus the right object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/378)
<!-- Reviewable:end -->
