### PR TITLE
LT-18767 yellow box crash in HC for bad XAmple-style reduplication

### DIFF
--- a/Src/GenerateHCConfig/ConsoleLogger.cs
+++ b/Src/GenerateHCConfig/ConsoleLogger.cs
@@ -118,5 +118,10 @@ namespace GenerateHCConfig
 		{
 			Console.WriteLine(reason);
 		}
+
+		void IHCLoadErrorLogger.UnmatchedReduplicationIndexedClass(IMoForm form, string reason, string environment)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/Src/LexText/ParserCore/HCParser.cs
+++ b/Src/LexText/ParserCore/HCParser.cs
@@ -669,6 +669,16 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				m_xmlWriter.WriteElementString("Reason", reason);
 				m_xmlWriter.WriteEndElement();
 			}
+			public void UnmatchedReduplicationIndexedClass(IMoForm form, string reason, string pattern)
+			{
+				m_xmlWriter.WriteStartElement("LoadError");
+				m_xmlWriter.WriteAttributeString("type", "unmatched-redup-indexed-class");
+				m_xmlWriter.WriteElementString("Form", form.Form.VernacularDefaultWritingSystem.Text);
+				m_xmlWriter.WriteElementString("Pattern", pattern);
+				m_xmlWriter.WriteElementString("Reason", reason);
+				m_xmlWriter.WriteElementString("Hvo", form.Hvo.ToString(CultureInfo.InvariantCulture));
+				m_xmlWriter.WriteEndElement();
+			}
 		}
 	}
 }

--- a/Src/LexText/ParserCore/IHCLoadErrorLogger.cs
+++ b/Src/LexText/ParserCore/IHCLoadErrorLogger.cs
@@ -13,5 +13,6 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		void InvalidRewriteRule(IPhRegularRule prule, string reason);
 		void InvalidStrata(string strata, string reason);
 		void OutOfScopeSlot(IMoInflAffixSlot slot, IMoInflAffixTemplate template, string reason);
+		void UnmatchedReduplicationIndexedClass(IMoForm form, string reason, string environment);
 	}
 }

--- a/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/HCLoaderTests.cs
@@ -604,6 +604,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			Assert.That(m_lang.Strata[0].MorphologicalRules.Count, Is.EqualTo(0));
 
 			// now check for missing indexed class which is removed but with an logged error message
+			// LT-18767
 			// case 1: the form has the indexed class, but the environment does not
 			var env = allo.PhoneEnvRC.ElementAt(0);
 			allo.PhoneEnvRC.Remove(env);

--- a/Src/Transforms/Presentation/FormatCommon.xsl
+++ b/Src/Transforms/Presentation/FormatCommon.xsl
@@ -127,6 +127,21 @@
 										<xsl:text> </xsl:text>
 									</li>
 								</xsl:when>
+								<xsl:when test="@type = 'unmatched-redup-indexed-class'">
+									<li>
+										<xsl:text>The reduplication form "</xsl:text>
+										<xsl:value-of select="Form" />
+										<xsl:text>" is invalid. Reason: </xsl:text>
+										<xsl:value-of select="Reason" />
+										<xsl:text> </xsl:text>
+										<span style="cursor:pointer; text-decoration:underline">
+											<xsl:attribute name="id">
+												<xsl:value-of select="Hvo"/>
+											</xsl:attribute>
+											<xsl:text>(Click here to see the entry.)</xsl:text>
+										</span>
+									</li>
+								</xsl:when>
 								<xsl:otherwise>
 									<!-- Do not expect any others to happen, but just in case, we show them in all their HC glory -->
 									<li><xsl:value-of select="."/></li>


### PR DESCRIPTION
One project got a Yellow Crash box with Hermit Crab.  It was due to a mismatch between a partial reduplication pattern and its environment (using the XAmple-style pattern where natural classes are indexed).  In this case, the form was
[C^1][V^1][C^2][C^3]
and the environment was
/[C^1][V^1][C^2]h_
Either the form needed to not have [C^3] or the environment needed to have an instance of [C^3].
The fix is to have HCLoader.cs check for any missing piece and ignore it.  The fix also creates an error message which shows in Try a Word.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/381)
<!-- Reviewable:end -->
