### PR TITLE
Fix LT-22153: Analyses marked as "guess" in .flextext file

### DIFF
--- a/Src/LexText/Interlinear/BIRDInterlinearImporter.cs
+++ b/Src/LexText/Interlinear/BIRDInterlinearImporter.cs
@@ -710,6 +710,11 @@ namespace SIL.FieldWorks.IText
 			//use the items under the word to determine what kind of thing to add to the segment
 			var cache = newSegment.Cache;
 			IAnalysis analysis = CreateWordAnalysisStack(cache, word);
+			if (analysis != null && word.morphemes?.analysisStatus == analysisStatusTypes.guess)
+			{
+				// Ignore morphological analysis if it was only a guess.
+				analysis = analysis.Wordform;
+			}
 
 			// Add to segment
 			if (analysis != null)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22153.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/382)
<!-- Reviewable:end -->
