### PR TITLE
Fix LT-22181: Crash when clicking the stem dropdown

### DIFF
--- a/Src/LexText/Morphology/InflAffixTemplateControl.cs
+++ b/Src/LexText/Morphology/InflAffixTemplateControl.cs
@@ -1227,6 +1227,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 		internal bool MoveableMSA(IMoInflAffMsa msa, bool up)
 		{
+			if (m_slot == null)
+				return false;
 			List<ICmObject> vals = m_slot.Affixes.ToList<ICmObject>();
 			int pos = vals.IndexOf(msa);
 			if (up && pos == 0)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22181, which was introduced by the change implementing https://jira.sil.org/browse/LT-826.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/392)
<!-- Reviewable:end -->
