### PR TITLE
LT-22127: Fix crash when changing language code

### DIFF
--- a/Src/FwCoreDlgs/FwWritingSystemSetupModel.cs
+++ b/Src/FwCoreDlgs/FwWritingSystemSetupModel.cs
@@ -554,7 +554,7 @@ namespace SIL.FieldWorks.FwCoreDlgs
 
 				var languagesToChange = new List<WSListItemModel>(WorkingList.Where(ws => ws.WorkingWs.LanguageName == _languageName));
 				languageSubtag = new LanguageSubtag(languageSubtag, info.DesiredName);
-				var oldDefaultScriptSubtag = IetfLanguageTag.GetScriptSubtag(languagesToChange[0].WorkingWs.Language.Code);
+				IetfLanguageTag.TryGetSubtags(languagesToChange[0].WorkingWs.Language.Code, out _, out var oldDefaultScriptSubtag, out _, out _);
 
 				foreach (var ws in languagesToChange)
 				{


### PR DESCRIPTION
Allow the operation to continue if there is a problem getting the script subtag for the old Language code.

Change-Id: I5813da3624ce78012d1b57fb98b18a64f9e3d7e4