### PR TITLE
Use Nuget to get System.Buffers and update binding redirects

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -266,6 +266,7 @@
 		<PalasoFiles Include="SIL.WritingSystems.Tests.dll"/>
 		<PalasoFiles Include="SIL.Windows.Forms.Archiving.dll"/>
 		<PalasoFiles Include="SIL.Windows.Forms.WritingSystems.dll"/>
+		<PalasoFiles Include="System.Buffers.dll"/>
 		<PalasoFiles Include="System.Drawing.Common.dll"/>
 		<PalasoFiles Include="System.Drawing.Common.pdb"/>
 		<PalasoFiles Include="System.Memory.dll"/>
@@ -451,6 +452,7 @@
 			<SILNugetPackages Include="SIL.Windows.Forms.WritingSystems"><Version>$(PalasoNugetVersion)</Version><Path>lib/net462/*.*</Path><NoSymbols>$(UsingLocalLibraryBuild)</NoSymbols></SILNugetPackages>
 			<SILNugetPackages Include="SIL.WritingSystems"><Version>$(PalasoNugetVersion)</Version><Path>lib/net462/*.*</Path><NoSymbols>$(UsingLocalLibraryBuild)</NoSymbols></SILNugetPackages>
 			<SILNugetPackages Include="SIL.WritingSystems.Tests"><Version>$(PalasoNugetVersion)</Version><Path>lib/net462/*.*</Path><NoSymbols>$(UsingLocalLibraryBuild)</NoSymbols></SILNugetPackages>
+			<SILNugetPackages Include="System.Buffers"><Version>4.6.0</Version><Path>lib/net462/*.*</Path><NoSymbols>true</NoSymbols></SILNugetPackages>
 			<SILNugetPackages Include="System.Drawing.Common"><Version>9.0.0</Version><Path>lib/net462/*.*</Path><NoSymbols>true</NoSymbols></SILNugetPackages>
 			<SILNugetPackages Include="System.Memory"><Version>4.5.4</Version><Path>lib/net461/*.*</Path><NoSymbols>true</NoSymbols></SILNugetPackages>
 			<SILNugetPackages Include="System.Resources.Extensions"><Version>4.6.0</Version><Path>lib/netstandard2.0/*.*</Path><NoSymbols>true</NoSymbols></SILNugetPackages>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -77,6 +77,7 @@
   <package id="SIL.WritingSystems" version="15.0.0-beta0117"  targetFramework="net461" />
   <package id="Spart" version="1.0.0" targetFramework="net461" />
   <package id="structuremap.patched" version="4.7.3" exclude="Build,Analyzers" />
+  <package id="System.Buffers" version="4.6.0" />
   <package id="System.Drawing.Common" version="9.0.0" />
   <package id="System.Memory" version="4.5.4" />
   <package id="System.Net.Http" version="4.3.4" />

--- a/Src/AppForTests.config
+++ b/Src/AppForTests.config
@@ -18,7 +18,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/Src/Common/FieldWorks/App.config
+++ b/Src/Common/FieldWorks/App.config
@@ -8,7 +8,7 @@
 	<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 		<dependentAssembly>
 			<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-			<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			<bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0"/>
 		</dependentAssembly>
 		<dependentAssembly>
 			<assemblyIdentity name="System.Drawing.Common" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>


### PR DESCRIPTION
* This fixes an issue where WeCantSpell.Hunspell can't load the System.Buffers that we end up using