### PR TITLE
Fix LT-22192: Put default menu item first in Interlinear Mode menu

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
+++ b/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
@@ -293,8 +293,8 @@
 				<item command="CmdChooseHCParser"/>
 			</menu>
           <menu id="ChooseModeMenu" label="Interlinear Mode">
-            <item command="CmdParsingDevelopmentMode"/>
             <item command="CmdTextGlossingMode"/>
+            <item command="CmdParsingDevelopmentMode"/>
           </menu>
           <item command="CmdEditParserParameters"/>
 		</menu>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22192.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/407)
<!-- Reviewable:end -->
