### PR TITLE
LT-22245 use end of line when matching MSA flid

### DIFF
--- a/Src/LexText/ParserCore/XAmplePropertiesXAmpleDataFilesAugmenter.cs
+++ b/Src/LexText/ParserCore/XAmplePropertiesXAmpleDataFilesAugmenter.cs
@@ -211,12 +211,12 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					foreach (ILexSense sense in entry.SensesOS)
 					{
 						var sHvo = sense.MorphoSyntaxAnalysisRA.Hvo.ToString();
-						var hvoMatch = "\\lx " + sHvo;
+						var hvoMatch = "\\lx " + sHvo + "\r";
 						if (!morphemePropertyMapper.ContainsKey(hvoMatch))
 						{
 							var replaceWith =
 								hvoMatch
-								+ "\r\n\\mp "
+								+ "\n\\mp "
 								+ prop.Name.AnalysisDefaultWritingSystem.Text
 								+ "\r\n";
 							morphemePropertyMapper.Add(hvoMatch, replaceWith);


### PR DESCRIPTION
We were matching MSA flids in the XAmple lex file at "\lx _flid_" but did not ensure to include the \r at the end of the flid.  This led to some incorrect matches.