### PR TITLE
Fixes LT-22241: User disapproved analyses in Parsing Dev Mode

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -234,7 +234,7 @@
 		<ChorusNugetVersion>5.2.0-beta0003</ChorusNugetVersion>
 		<PalasoNugetVersion>15.0.0-beta0117</PalasoNugetVersion>
 		<ParatextNugetVersion>9.4.0.1-beta</ParatextNugetVersion>
-		<LcmNugetVersion>11.0.0-beta0129</LcmNugetVersion>
+		<LcmNugetVersion>11.0.0-beta0130</LcmNugetVersion>
 		<IcuNugetVersion>70.1.123</IcuNugetVersion>
 		<HermitCrabNugetVersion>3.6.6</HermitCrabNugetVersion>
 		<IPCFrameworkVersion>1.1.1-beta0001</IPCFrameworkVersion>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -50,15 +50,15 @@
   <package id="SIL.Core" version="8.1.0-beta0035"  targetFramework="net461" />
   <package id="SIL.DesktopAnalytics" version="4.0.0" targetFramework="net461" />
   <package id="SIL.FLExBridge.IPCFramework" version="1.1.1-beta0001"  targetFramework="net461" />
-  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.FixData" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tests" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tools" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils" version="11.0.0-beta0129"  targetFramework="net461" />
-  <package id="SIL.LCModel" version="11.0.0-beta0129"  targetFramework="net461" />
+  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.FixData" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tests" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tools" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils" version="11.0.0-beta0130"  targetFramework="net461" />
+  <package id="SIL.LCModel" version="11.0.0-beta0130"  targetFramework="net461" />
   <package id="SIL.Lexicon" version="15.0.0-beta0117"  targetFramework="net462" />
   <package id="SIL.libpalaso.l10ns" version="6.0.0" targetFramework="net461" />
   <package id="SIL.Lift" version="15.0.0-beta0117"  targetFramework="net462" />

--- a/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
+++ b/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
@@ -288,8 +288,8 @@ namespace SIL.FieldWorks.IText
 			{
 				Opinions o = wa.GetAgentOpinion(
 					m_cache.LangProject.DefaultUserAgent);
-				// skip any analysis the user has disapproved.
-				if (o != Opinions.disapproves)
+				// skip any analysis the user has disapproved unless we are in parsing dev mode.
+				if (IsParsingDevMode() || o != Opinions.disapproves)
 				{
 					AddAnalysisItems(wa);
 					AddSeparatorLine();

--- a/Src/LexText/Interlinear/FocusBoxController.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.cs
@@ -130,7 +130,7 @@ namespace SIL.FieldWorks.IText
 			//if this sandbox is presenting a wordform with multiple possible analyses then set the
 			//bg color indicator
 			if (selected.Analysis.Wordform != null &&
-				SandboxBase.GetHasMultipleRelevantAnalyses(selected.Analysis.Wordform))
+				SandboxBase.GetHasMultipleRelevantAnalyses(selected.Analysis.Wordform, IsParsingDevMode()))
 			{
 				color = InterlinVc.MultipleApprovedGuessColor;
 			}
@@ -152,6 +152,13 @@ namespace SIL.FieldWorks.IText
 			this.ResumeLayout();
 
 			SetSandboxSize();
+		}
+
+		internal bool IsParsingDevMode()
+		{
+			if (InterlinDoc?.GetMaster() == null)
+				return false;
+			return InterlinDoc.GetMaster().IsParsingDevMode();
 		}
 
 		internal virtual IAnalysisControlInternal CreateNewSandbox(AnalysisOccurrence selected)

--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -1832,7 +1832,7 @@ namespace SIL.FieldWorks.IText
 						if (word != null)
 						{
 							//test if there are multiple analyses that a user might choose from
-							if (SandboxBase.GetHasMultipleRelevantAnalyses(word))
+							if (SandboxBase.GetHasMultipleRelevantAnalyses(word, m_this.IsParsingDevMode()))
 							{
 								m_this.SetGuessing(m_vwenv, MultipleApprovedGuessColor); //There are multiple options, set the color
 							}

--- a/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
+++ b/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
@@ -117,12 +117,8 @@ namespace SIL.FieldWorks.IText
 
 			internal bool IsParsingDevMode()
 			{
-				if (m_sandbox.InterlinDoc?.GetMaster() == null)
-					return false;
-				return m_sandbox.InterlinDoc.GetMaster().IsParsingDevMode();
+				return m_sandbox.IsParsingDevMode();
 			}
-
-
 
 			// only for testing
 			internal void SetSandboxForTesting(SandboxBase sandbox)
@@ -1032,8 +1028,8 @@ namespace SIL.FieldWorks.IText
 				{
 					Opinions o = wa.GetAgentOpinion(
 						m_caches.MainCache.LangProject.DefaultUserAgent);
-					if (o == Opinions.disapproves)
-						continue;	// skip any analysis the user has disapproved.
+					if (o == Opinions.disapproves && !IsParsingDevMode())
+						continue;	// skip any analysis the user has disapproved unless we are in parsing dev mode.
 					int cmorphs = wa.MorphBundlesOS.Count;
 					if (cmorphs == 0)
 						continue;

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1211,7 +1211,7 @@ namespace SIL.FieldWorks.IText
 						if ((m_occurrenceSelected == null ||
 							m_occurrenceSelected.Analysis == null ||
 							m_occurrenceSelected.Analysis.Wordform != null) &&
-							GetHasMultipleRelevantAnalyses(CurrentAnalysisTree.Wordform))
+							GetHasMultipleRelevantAnalyses(CurrentAnalysisTree.Wordform, IsParsingDevMode()))
 						{
 							MultipleAnalysisColor = InterlinVc.MultipleApprovedGuessColor;
 						}
@@ -1633,10 +1633,12 @@ namespace SIL.FieldWorks.IText
 			return false;
 		}
 
-		public static bool GetHasMultipleRelevantAnalyses(IWfiWordform analysis)
+		public static bool GetHasMultipleRelevantAnalyses(IWfiWordform wordform, bool isParsingDevMode)
 		{
-			int humanCount = analysis.HumanApprovedAnalyses.Count();
-			int machineCount = analysis.HumanNoOpinionParses.Count();
+			if (isParsingDevMode)
+				return wordform.AnalysesOC.Count > 1;
+			int humanCount = wordform.HumanApprovedAnalyses.Count();
+			int machineCount = wordform.HumanNoOpinionParses.Count();
 			return humanCount + machineCount > 1;
 		}
 
@@ -1647,6 +1649,13 @@ namespace SIL.FieldWorks.IText
 			return (from ae in analysis.EvaluationsRC
 							  where ae.Approves &&  (ae.Owner as ICmAgent).Human
 							  select ae).FirstOrDefault() != null;
+		}
+
+		internal bool IsParsingDevMode()
+		{
+			if (InterlinDoc?.GetMaster() == null)
+				return false;
+			return InterlinDoc.GetMaster().IsParsingDevMode();
 		}
 
 		/// <summary>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22241.  I made inclusion of user-disapproved analyses conditional on IsParsingDevMode.  This required a new liblcm library with a change to the guesser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/433)
<!-- Reviewable:end -->
