### PR TITLE
LT-22124: Fix Sense homographs in Lexical Relations

### DIFF
--- a/Src/xWorks/DictionaryPublicationDecorator.cs
+++ b/Src/xWorks/DictionaryPublicationDecorator.cs
@@ -246,7 +246,7 @@ namespace SIL.FieldWorks.XWorks
 
 		public override ITsMultiString get_MultiStringProp(int hvo, int tag)
 		{
-			if (tag == m_mlHeadwordFlid || tag == m_headwordRefFlid)
+			if (tag == m_mlHeadwordFlid || tag == m_headwordRefFlid || tag == m_mlOwnerOutlineFlid)
 			{
 				return new PublicationAwareMultiStringAccessor(hvo, tag, this);
 			}


### PR DESCRIPTION
When getting a property value for a field on a ISenseOrEntry object, call the new method added to LCM that determines the specific object (Sense or Entry), and the specific field on that object, that should be queried to get the value.

In this specific defect we are trying to get the HeadWordRef and the ISenseOrEntry is a LexSense. The specific field remains HeadWordRef, but the specific object we need to get the value from is the associated LexEntry. This is because the LexEntry adjusts the HeadWordRef based on the decorator, the LexSense does not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/437)
<!-- Reviewable:end -->
