### PR TITLE
Fix issues noted when testing LT-3356

### DIFF
--- a/Src/Common/Controls/DetailControls/Slice.cs
+++ b/Src/Common/Controls/DetailControls/Slice.cs
@@ -2241,17 +2241,28 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			for (int islice = IndexInContainer + 1; islice < cslice; ++islice)
 			{
 				var slice = ContainingDataTree.Slices[islice];
+				// Stop if we get past the children of the current object.
+				if (!EmbeddedSlice(slice))
+					break;
 				if (slice.Object.Hvo == hvo)
 				{
 					if (slice.Expansion == DataTree.TreeItemState.ktisCollapsed)
 						slice.TreeNode.ToggleExpansion(islice);
 					return slice;
 				}
-				// Stop if we get past the children of the current object.
-				if (slice.Indent <= Indent)
-					break;
 			}
 			return null;
+		}
+
+		private bool EmbeddedSlice(Slice slice)
+		{
+			foreach (object obj in Key)
+			{
+				var node = obj as XmlNode;
+				if (IsRefPartNode(node) && !slice.Key.Contains(node))
+					return false;
+			}
+			return true;
 		}
 
 


### PR DESCRIPTION
This fixes the issues noted in a comment by Jaswanth in https://jira.sil.org/browse/LT-3356.  Using Indent was an imperfect proxy for whether one slice was embedded in another.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/440)
<!-- Reviewable:end -->
