### PR TITLE
Fix LT-22271: Phonemes/Features column disappears from table

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/MorphologyParts.xml
+++ b/DistFiles/Language Explorer/Configuration/Parts/MorphologyParts.xml
@@ -2669,7 +2669,13 @@
 		<part id="PhNaturalClass-Detail-DescriptionAllA" type="Detail">
 			<slice field="Description" label="Description" editor="multistring" ws="all analysis"/>
 		</part>
-	</bin>
+        <!-- The following is a hack to keep the Phoneme/Features column from disappearing (LT-22171).
+             The Segments field is technically part of PhNCSegments, but the display code is expecting PhNaturalClass.
+        -->
+        <part id="PhNaturalClass-Jt-Segments" type="JtView">
+          <seq field="Segments" layout="shortname" />
+        </part>
+    </bin>
 	<bin class="PhNCSegments">
 		<part id="PhNCSegments-Detail-Segments" type="Detail">
 			<slice field="Segments" label="Phonemes" editor="defaultVectorReference">


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22171.  The Phoneme/Features column was disappearing because it was invalid: there isn't a "Segments" field in PhNaturalClass.  It is in PhNCSegments instead, which is a subclass of PhNaturalClass.   Adding a new part made it valid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/444)
<!-- Reviewable:end -->
