### PR TITLE
Fix LT-22267: Slow response in interlinear combos

### DIFF
--- a/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
+++ b/Src/LexText/Interlinear/ChooseAnalysisHandler.cs
@@ -3,16 +3,18 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
-using System.Windows.Forms;
 using System.Drawing;
-using SIL.LCModel;
+using System.Linq;
+using System.Windows.Forms;
+using Paratext.BibleInfo;
 using SIL.FieldWorks.Common.ViewsInterfaces;
-using SIL.LCModel.DomainServices;
-using SIL.FieldWorks.FdoUi;
-using SIL.LCModel.Utils;
 using SIL.FieldWorks.Common.Widgets;
-using SIL.LCModel.Core.Text;
+using SIL.FieldWorks.FdoUi;
+using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.DomainServices;
+using SIL.LCModel.Utils;
 
 
 namespace SIL.FieldWorks.IText
@@ -311,9 +313,7 @@ namespace SIL.FieldWorks.IText
 		{
 			AddItem(wa,
 				MakeAnalysisStringRep(wa, m_cache, StyleSheet != null, (m_owner as SandboxBase).RawWordformWs), true);
-			var guess_services = new AnalysisGuessServices(m_cache, IsParsingDevMode());
-			var sorted_glosses = guess_services.GetSortedGlossGuesses(wa, m_occurrence);
-			foreach (var gloss in sorted_glosses)
+			foreach (var gloss in wa.MeaningsOC.ToList())
 			{
 				AddItem(gloss, MakeGlossStringRep(gloss, m_cache, StyleSheet != null), true);
 			}


### PR DESCRIPTION
This fixes a critical performance issue in the combo box.  It was sometimes taking 4-14 seconds to show the menu of possible analyses.  The problem was sorting the glosses.  This was expensive because it happened once per analysis, and it required scanning all of the interlinear texts to get the context needed for the sort.  If a word had 28 analyses, this was very expensive.  I decided that it wasn't necessary to sort the glosses: sorting the analyses was enough.