### PR TITLE
Fix LT-22227: Keep affix ordering when duplicating a slot

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -234,7 +234,7 @@
 		<ChorusNugetVersion>5.2.0-beta0003</ChorusNugetVersion>
 		<PalasoNugetVersion>15.0.0-beta0117</PalasoNugetVersion>
 		<ParatextNugetVersion>9.4.0.1-beta</ParatextNugetVersion>
-		<LcmNugetVersion>11.0.0-beta0132</LcmNugetVersion>
+		<LcmNugetVersion>11.0.0-beta0135</LcmNugetVersion>
 		<IcuNugetVersion>70.1.123</IcuNugetVersion>
 		<HermitCrabNugetVersion>3.6.7</HermitCrabNugetVersion>
 		<IPCFrameworkVersion>1.1.1-beta0001</IPCFrameworkVersion>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -50,15 +50,15 @@
   <package id="SIL.Core" version="8.1.0-beta0035"  targetFramework="net461" />
   <package id="SIL.DesktopAnalytics" version="4.0.0" targetFramework="net461" />
   <package id="SIL.FLExBridge.IPCFramework" version="1.1.1-beta0001"  targetFramework="net461" />
-  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Core" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.FixData" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tests" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Tools" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel.Utils" version="11.0.0-beta0132"  targetFramework="net461" />
-  <package id="SIL.LCModel" version="11.0.0-beta0132"  targetFramework="net461" />
+  <package id="SIL.LCModel.Build.Tasks" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core.Tests" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Core" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.FixData" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tests" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Tools" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils.Tests" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel.Utils" version="11.0.0-beta0135"  targetFramework="net461" />
+  <package id="SIL.LCModel" version="11.0.0-beta0135"  targetFramework="net461" />
   <package id="SIL.Lexicon" version="15.0.0-beta0117"  targetFramework="net462" />
   <package id="SIL.libpalaso.l10ns" version="6.0.0" targetFramework="net461" />
   <package id="SIL.Lift" version="15.0.0-beta0117"  targetFramework="net462" />


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22227 (fixed in liblcm).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/451)
<!-- Reviewable:end -->
