### PR TITLE
Fix LT-22240: Refresh template after moving affix slot

### DIFF
--- a/Src/xWorks/DTMenuHandler.cs
+++ b/Src/xWorks/DTMenuHandler.cs
@@ -575,6 +575,7 @@ namespace SIL.FieldWorks.XWorks
 				if (m_moveObj is IMoInflAffixSlot slot)
 				{
 					MoveSlot(slot, selectedPOS);
+					m_mediator.SendMessage("MasterRefresh", null);
 				}
 				if (m_moveObj is IMoInflAffixTemplate template)
 				{


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22240.  I tried broadcasting "SlotMoved", but InflAffixTemplateControl isn't able to receive messages unless it is being edited.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/452)
<!-- Reviewable:end -->
