### PR TITLE
LT-22185: XHTML: Fix style when there are multiple ws

### DIFF
--- a/Src/xWorks/CssGenerator.cs
+++ b/Src/xWorks/CssGenerator.cs
@@ -689,6 +689,7 @@ namespace SIL.FieldWorks.XWorks
 		private static List<StyleRule> GenerateCssFromWsOptions(ConfigurableDictionaryNode configNode, DictionaryNodeWritingSystemOptions wsOptions,
 													string baseSelection, ReadOnlyPropertyTable propertyTable)
 		{
+			var rules = new List<StyleRule>();
 			var cache = propertyTable.GetValue<LcmCache>("cache");
 			foreach(var ws in wsOptions.Options.Where(opt => opt.IsEnabled))
 			{
@@ -700,10 +701,10 @@ namespace SIL.FieldWorks.XWorks
 				if (!string.IsNullOrEmpty(configNode.Style))
 					wsRule.Declarations.Properties.AddRange(GenerateCssStyleFromLcmStyleSheet(configNode.Style, wsId, propertyTable));
 				if (!IsEmptyRule(wsRule))
-					return new List<StyleRule> {wsRule};
+					rules.Add(wsRule);
 			}
 
-			return new List<StyleRule>();
+			return rules;
 		}
 
 		private static List<StyleRule> GenerateCssForWritingSystemPrefix(ConfigurableDictionaryNode configNode, string baseSelection, ReadOnlyPropertyTable propertyTable)


### PR DESCRIPTION
GenerateCssFromWsOptions() was only generating rules for one writing system. Changed this to generate rules for all enabled writing systems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/454)
<!-- Reviewable:end -->
