### PR TITLE
LT-22190: HC can use wrong categories

### DIFF
--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -236,7 +236,7 @@
 		<ParatextNugetVersion>9.4.0.1-beta</ParatextNugetVersion>
 		<LcmNugetVersion>11.0.0-beta0135</LcmNugetVersion>
 		<IcuNugetVersion>70.1.123</IcuNugetVersion>
-		<HermitCrabNugetVersion>3.6.7</HermitCrabNugetVersion>
+		<HermitCrabNugetVersion>3.7.4</HermitCrabNugetVersion>
 		<IPCFrameworkVersion>1.1.1-beta0001</IPCFrameworkVersion>
 		<!-- bt393 is the master branch build of ExCss for Windows development. Update when appropriate. -->
 		<ExCssBuildType Condition="'$(OS)'=='Windows_NT'">bt393</ExCssBuildType>

--- a/Build/nuget-common/packages.config
+++ b/Build/nuget-common/packages.config
@@ -63,8 +63,8 @@
   <package id="SIL.libpalaso.l10ns" version="6.0.0" targetFramework="net461" />
   <package id="SIL.Lift" version="15.0.0-beta0117"  targetFramework="net462" />
   <package id="SIL.Media" version="15.0.0-beta0117"  targetFramework="net462" />
-  <package id="SIL.Machine" version="3.6.7"  targetFramework="netstandard2.0" />
-  <package id="SIL.Machine.Morphology.HermitCrab" version="3.6.7"  targetFramework="netstandard2.0" />
+  <package id="SIL.Machine" version="3.7.4"  targetFramework="netstandard2.0" />
+  <package id="SIL.Machine.Morphology.HermitCrab" version="3.7.4"  targetFramework="netstandard2.0" />
   <package id="SIL.ParatextShared" version="7.4.0.1"  targetFramework="net40" /> <!-- REVIEW (Hasso) 2023.05: do we still integrate with PT 7? -->
   <package id="SIL.Scripture" version="15.0.0-beta0117"  targetFramework="net461" />
   <package id="SIL.TestUtilities" version="15.0.0-beta0117"  targetFramework="net461" />


### PR DESCRIPTION
The fix for this is mainly in SIL.Machine, version 3.7.4.
This pull request is to update the nuget versions used by Flex for SIL.Machine and SIL. Machine.Morphology.HermitCrab,

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/456)
<!-- Reviewable:end -->
