### PR TITLE
Fix LT-22155: Merge entry/sense is losing some custom fields

### DIFF
--- a/Src/FdoUi/FdoUiCore.cs
+++ b/Src/FdoUi/FdoUiCore.cs
@@ -1155,7 +1155,11 @@ namespace SIL.FieldWorks.FdoUi
 					mergeCandidates.Sort();
 					dlg.SetDlgInfo(m_cache, m_mediator, m_propertyTable, wp, dObj, mergeCandidates, guiControl, helpTopic);
 					if (DialogResult.OK == dlg.ShowDialog(mainWindow))
+					{
 						ReallyMergeUnderlyingObject(dlg.Hvo, fLoseNoTextData);
+						// Refresh in case "Sense Number" was 0 in the target and non-0 in the source (LT-22155).
+						m_mediator.SendMessage("MasterRefresh", null);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22155.  The main fix is in the new liblcm, but I had to add a MasterRefresh to get Sense Number to be updated.  This causes a flicker, but that is better than having invalid data on the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/458)
<!-- Reviewable:end -->
