### PR TITLE
Fix LT-22290: Crash on deleting disapproved wordform analysis

### DIFF
--- a/Src/LexText/Morphology/MorphologyListener.cs
+++ b/Src/LexText/Morphology/MorphologyListener.cs
@@ -790,7 +790,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			ref UIItemDisplayProperties display)
 		{
 			display.Enabled = display.Visible = InFriendlyArea;
-			display.Checked = Analysis != null && Analysis.ApprovalStatusIcon == 1;
+			display.Checked = Analysis != null && Analysis.IsValidObject && Analysis.ApprovalStatusIcon == 1;
 			return true; //we've handled this
 		}
 


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22290.