### PR TITLE
Fix LT-22276: Crashes when clicking blue arrow next to a slot

### DIFF
--- a/Src/LexText/Morphology/InflAffixTemplateControl.cs
+++ b/Src/LexText/Morphology/InflAffixTemplateControl.cs
@@ -1247,7 +1247,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 		internal bool MoveableMSA(IMoInflAffMsa msa, bool up)
 		{
-			if (m_slot == null)
+			if (m_slot == null || !m_slot.IsValidObject)
 				return false;
 			List<ICmObject> vals = m_slot.Affixes.ToList<ICmObject>();
 			int pos = vals.IndexOf(msa);


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22276.