### PR TITLE
Include all frameworks in local LCM, Palaso & Chorus

### DIFF
--- a/Build/buildLocalLibraries.sh
+++ b/Build/buildLocalLibraries.sh
@@ -46,7 +46,7 @@ function delete_and_pack_liblcm {
 			(cd "$liblcm_dir/artifacts" && rm *nupkg)
 
 			echo "Running 'dotnet pack' in the liblcm directory: $liblcm_dir"
-			pack_output=$(cd "$liblcm_dir" && dotnet pack -c Debug -p:TargetFrameworks=$liblcm_net_ver)
+			pack_output=$(cd "$liblcm_dir" && dotnet pack -c Debug)
 
 			# Extract version number using regex
 			if [[ $pack_output =~ $version_regex ]]; then
@@ -91,7 +91,7 @@ function delete_and_pack_chorus {
 			(cd "$chorus_dir/output" && rm *nupkg)
 
 			echo "Running 'dotnet pack' in the chorus directory: $chorus_dir"
-			pack_output=$(cd "$chorus_dir" && dotnet pack -c Debug -p:TargetFrameworks=$chorus_net_ver)
+			pack_output=$(cd "$chorus_dir" && dotnet pack -c Debug)
 
 			# Extract version number using regex
 			if [[ $pack_output =~ $version_regex ]]; then
@@ -136,7 +136,7 @@ function delete_and_pack_libpalaso {
 			(cd "$libpalaso_dir/output" && rm *nupkg)
 
 			echo "Running 'dotnet pack' in the libpalaso directory: $libpalaso_dir"
-			pack_output=$(cd "$libpalaso_dir" && dotnet pack -c Debug -p:TargetFrameworks=$libpalaso_net_ver)
+			pack_output=$(cd "$libpalaso_dir" && dotnet pack -c Debug)
 
 			# Extract version number using regex
 			if [[ $pack_output =~ $version_regex ]]; then


### PR DESCRIPTION
One of the LCM target frameworks is netstandard2.0. To build a local LCM that uses a local Palaso, LCM needs the netstandard2.0 framework to be in the palaso nupkg.  By removing the TargetFrameworks parameter from the ‘dotnet pack’ command the nuget packages will contain all the frameworks specified in the .csproj files.

Change-Id: Ia31076ec00105f880b88c975a8eee37dfa63d8b9