### PR TITLE
Fix LT-22295: Don't crash if MakeDefaultSelection is called early

### DIFF
--- a/Src/LexText/Interlinear/FocusBoxController.cs
+++ b/Src/LexText/Interlinear/FocusBoxController.cs
@@ -316,7 +316,19 @@ namespace SIL.FieldWorks.IText
 		{
 			if (IsDisposed)
 				return false; // result is not currently used, not sure what it should be.
-			InterlinWordControl.MakeDefaultSelection();
+			if (InterlinWordControl != null)
+			{
+				InterlinWordControl.MakeDefaultSelection();
+			}
+			else
+			{
+				// It wasn't ready yet. Try once more later.
+				m_mediator.IdleQueue.Add(IdleQueuePriority.Medium, _ =>
+				{
+					InterlinWordControl?.MakeDefaultSelection();
+					return true;
+				});
+			}
 			return true;
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/484)
<!-- Reviewable:end -->
