### PR TITLE
No Popups from test crashes

### DIFF
--- a/Build/scripts/Invoke-CppTest.ps1
+++ b/Build/scripts/Invoke-CppTest.ps1
@@ -84,6 +84,8 @@ Initialize-VsDevEnvironment
 # Suppress assertion dialog boxes (DebugProcs.dll checks this env var)
 # This prevents tests from blocking on MessageBox popups
 $env:AssertUiEnabled = 'false'
+# Unconditional test-mode override: bypasses registry AssertMessageBox key in DebugProcs.dll
+$env:FW_TEST_MODE = '1'
 
 # Suppress Windows Error Reporting and crash dialogs
 # SEM_FAILCRITICALERRORS = 0x0001

--- a/Build/scripts/Invoke-CppTest.ps1
+++ b/Build/scripts/Invoke-CppTest.ps1
@@ -551,6 +551,13 @@ function Invoke-Run {
 	}
 
 	$process.WaitForExit()
+	$nativeExitCode = $null
+	try {
+		$nativeExitCode = $process.ExitCode
+	}
+	catch {
+		$nativeExitCode = $null
+	}
 
 	$logTail = @()
 	if (Test-Path $LogPath) {
@@ -564,15 +571,34 @@ function Invoke-Run {
 		Write-Host "--- end output ---" -ForegroundColor Yellow
 	}
 
-	# Determine exit code: parse the Unit++ summary line from the log as the authoritative
-	# source. Start-Process -RedirectStandardOutput in PowerShell 5.1 can return a null
-	# ExitCode even after WaitForExit(), so the process exit code is not reliable here.
+	# Determine exit code using both the real process exit code and the Unit++ summary.
+	# The process exit code is authoritative for crashes/teardown failures that occur after
+	# the Unit++ summary has already been written.
 	$exitCode = -1
+	$summaryExitCode = $null
 	if (-not $timedOut) {
 		$summaryLine = $logTail | Where-Object { $_ -match 'Tests \[Ok-Fail-Error\]: \[\d+-\d+-\d+\]' } | Select-Object -Last 1
 		if ($summaryLine) {
 			$m = [regex]::Match($summaryLine, 'Tests \[Ok-Fail-Error\]: \[(\d+)-(\d+)-(\d+)\]')
-			$exitCode = [int]$m.Groups[2].Value + [int]$m.Groups[3].Value
+			$summaryExitCode = [int]$m.Groups[2].Value + [int]$m.Groups[3].Value
+		}
+
+		if ($terminatedAfterCompletion) {
+			if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+				$exitCode = $nativeExitCode
+			}
+			else {
+				$exitCode = 1
+			}
+		}
+		elseif ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+			$exitCode = $nativeExitCode
+		}
+		elseif ($null -ne $summaryExitCode) {
+			$exitCode = $summaryExitCode
+		}
+		elseif ($null -ne $nativeExitCode) {
+			$exitCode = $nativeExitCode
 		}
 	}
 

--- a/Build/scripts/Invoke-CppTest.ps1
+++ b/Build/scripts/Invoke-CppTest.ps1
@@ -22,6 +22,10 @@
 .PARAMETER WorktreePath
 	Path to the worktree root. Defaults to current directory.
 
+.PARAMETER AllowAssertDialogs
+	Allow FieldWorks Abort/Retry/Ignore assertion dialogs during this local test run.
+	Equivalent environment variable: FW_TEST_ALLOW_ASSERT_DIALOGS=1.
+
 .EXAMPLE
 	.\Invoke-CppTest.ps1 -TestProject TestGeneric
 	Build and run TestGeneric using MSBuild.
@@ -33,6 +37,10 @@
 .EXAMPLE
 	.\Invoke-CppTest.ps1 -BuildSystem NMake -TestProject TestGeneric
 	Build TestGeneric using legacy nmake (requires VsDevCmd).
+
+.EXAMPLE
+	.\Invoke-CppTest.ps1 -Action Run -TestProject TestGeneric -AllowAssertDialogs
+	Run TestGeneric with interactive FieldWorks assertion dialogs enabled for debugger attachment.
 #>
 [CmdletBinding()]
 param(
@@ -56,7 +64,9 @@ param(
 
 	[string[]]$TestArguments,
 
-	[string]$LogPath
+	[string]$LogPath,
+
+	[switch]$AllowAssertDialogs
 )
 
 Set-StrictMode -Version Latest
@@ -74,6 +84,80 @@ if (-not (Test-Path $helpersPath)) {
 }
 Import-Module $helpersPath -Force
 
+function Test-EnvironmentSwitchEnabled {
+	param(
+		[string]$Name
+	)
+
+	$value = [Environment]::GetEnvironmentVariable($Name)
+	if ([string]::IsNullOrWhiteSpace($value)) {
+		return $false
+	}
+
+	return @('1', 'true', 'yes', 'on') -contains $value.Trim().ToLowerInvariant()
+}
+
+function Set-AssertDialogEnvironment {
+	param(
+		[bool]$AllowDialogs
+	)
+
+	if ($AllowDialogs) {
+		$env:AssertUiEnabled = 'true'
+		$env:AssertExceptionEnabled = 'false'
+		$env:FW_TEST_MODE = '0'
+		$env:FW_TEST_ALLOW_ASSERT_DIALOGS = '1'
+		Write-Host "[WARN] Interactive assertion dialogs are enabled for this local native test run." -ForegroundColor Yellow
+		return
+	}
+
+	# Suppress assertion dialog boxes (DebugProcs.dll checks these env vars).
+	# This prevents unattended tests from blocking on MessageBox popups.
+	$env:AssertUiEnabled = 'false'
+	$env:AssertExceptionEnabled = 'true'
+	# Unconditional test-mode override: bypasses registry AssertMessageBox key in DebugProcs.dll.
+	$env:FW_TEST_MODE = '1'
+}
+
+function Resolve-NativeTestExitCode {
+	param(
+		[bool]$TimedOut,
+		[bool]$TerminatedAfterCompletion,
+		$NativeExitCode,
+		$SummaryExitCode
+	)
+
+	if ($TimedOut) {
+		return -1
+	}
+
+	if ($null -ne $SummaryExitCode -and $SummaryExitCode -ne 0) {
+		return $SummaryExitCode
+	}
+
+	if ($TerminatedAfterCompletion) {
+		if ($null -ne $NativeExitCode -and $NativeExitCode -ne 0) {
+			return $NativeExitCode
+		}
+
+		return 1
+	}
+
+	if ($null -ne $NativeExitCode -and $NativeExitCode -ne 0) {
+		return $NativeExitCode
+	}
+
+	if ($null -ne $SummaryExitCode) {
+		return $SummaryExitCode
+	}
+
+	if ($null -ne $NativeExitCode) {
+		return $NativeExitCode
+	}
+
+	return -1
+}
+
 # =============================================================================
 # Environment Setup
 # =============================================================================
@@ -81,11 +165,8 @@ Import-Module $helpersPath -Force
 # Initialize VS environment (needed for NMake and MSBuild)
 Initialize-VsDevEnvironment
 
-# Suppress assertion dialog boxes (DebugProcs.dll checks this env var)
-# This prevents tests from blocking on MessageBox popups
-$env:AssertUiEnabled = 'false'
-# Unconditional test-mode override: bypasses registry AssertMessageBox key in DebugProcs.dll
-$env:FW_TEST_MODE = '1'
+$allowAssertDialogsForRun = $AllowAssertDialogs -or (Test-EnvironmentSwitchEnabled -Name 'FW_TEST_ALLOW_ASSERT_DIALOGS')
+Set-AssertDialogEnvironment -AllowDialogs $allowAssertDialogsForRun
 
 # Suppress Windows Error Reporting and crash dialogs
 # SEM_FAILCRITICALERRORS = 0x0001
@@ -571,9 +652,10 @@ function Invoke-Run {
 		Write-Host "--- end output ---" -ForegroundColor Yellow
 	}
 
-	# Determine exit code using both the real process exit code and the Unit++ summary.
-	# The process exit code is authoritative for crashes/teardown failures that occur after
-	# the Unit++ summary has already been written.
+	# Determine exit code using both the Unit++ summary and the real process exit code.
+	# When Unit++ reports failures/errors, prefer that count so the user sees the actionable
+	# test failure total. Fall back to the process exit code for crashes/teardown failures
+	# that happen without a non-zero Unit++ summary.
 	$exitCode = -1
 	$summaryExitCode = $null
 	if (-not $timedOut) {
@@ -582,24 +664,17 @@ function Invoke-Run {
 			$m = [regex]::Match($summaryLine, 'Tests \[Ok-Fail-Error\]: \[(\d+)-(\d+)-(\d+)\]')
 			$summaryExitCode = [int]$m.Groups[2].Value + [int]$m.Groups[3].Value
 		}
+	}
+	$exitCode = Resolve-NativeTestExitCode `
+		-TimedOut $timedOut `
+		-TerminatedAfterCompletion $terminatedAfterCompletion `
+		-NativeExitCode $nativeExitCode `
+		-SummaryExitCode $summaryExitCode
 
-		if ($terminatedAfterCompletion) {
-			if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-				$exitCode = $nativeExitCode
-			}
-			else {
-				$exitCode = 1
-			}
-		}
-		elseif ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-			$exitCode = $nativeExitCode
-		}
-		elseif ($null -ne $summaryExitCode) {
-			$exitCode = $summaryExitCode
-		}
-		elseif ($null -ne $nativeExitCode) {
-			$exitCode = $nativeExitCode
-		}
+	if ($null -ne $summaryExitCode -and $summaryExitCode -ne 0 -and
+		$null -ne $nativeExitCode -and $nativeExitCode -ne 0 -and
+		$nativeExitCode -ne $summaryExitCode) {
+		Write-Host "Native process exit code was $nativeExitCode; reporting Unit++ failure/error count $summaryExitCode." -ForegroundColor Yellow
 	}
 
 	Write-Host ""

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -109,6 +109,32 @@ Build FieldWorks using the PowerShell build script:
 
 For more build options, see [.github/instructions/build.instructions.md](../.github/instructions/build.instructions.md).
 
+### Run tests from the command line
+
+Use `test.ps1` for local test runs:
+
+```powershell
+.\test.ps1
+.\test.ps1 -TestProject "Src/Common/FwUtils/FwUtilsTests"
+.\test.ps1 -SkipManaged -TestProject TestGeneric
+```
+
+By default, test runs suppress FieldWorks assertion dialogs so unattended runs cannot hang on Abort/Retry/Ignore UI. For a local debugger session where you intentionally want the previous interactive assertion dialog behavior, use the command-line switch:
+
+```powershell
+.\test.ps1 -SkipManaged -TestProject TestGeneric -AllowAssertDialogs
+```
+
+The environment-variable equivalent is `FW_TEST_ALLOW_ASSERT_DIALOGS=1`:
+
+```powershell
+$env:FW_TEST_ALLOW_ASSERT_DIALOGS = '1'
+.\test.ps1 -SkipManaged -TestProject TestGeneric
+Remove-Item Env:FW_TEST_ALLOW_ASSERT_DIALOGS
+```
+
+Only use this opt-in for attended local debugging. CI and normal local runs should leave it unset.
+
 ### 5. VS Code and Visual Studio usage
 
 Default recommendation:

--- a/Lib/src/unit++/main.cc
+++ b/Lib/src/unit++/main.cc
@@ -5,7 +5,10 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if defined(WIN32) || defined(WIN64)
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64) || defined(_M_X64)
+#define UNITPP_WINDOWS 1
+#endif
+#if defined(UNITPP_WINDOWS)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <crtdbg.h>
@@ -13,7 +16,7 @@
 using namespace std;
 using namespace unitpp;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(UNITPP_WINDOWS)
 namespace
 {
 	void TerminateOnSigAbrt(int)
@@ -101,8 +104,9 @@ void unitpp::set_tester(test_runner* tr)
 
 int main(int argc, const char* argv[])
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(UNITPP_WINDOWS)
 	SuppressInteractiveCrashUi();
+	signal(SIGABRT, TerminateOnSigAbrt);
 #endif
     printf("DEBUG: unit++ main start\n"); fflush(stdout);
 	options().add("v", new options_utils::opt_flag(verbose));
@@ -140,7 +144,6 @@ int main(int argc, const char* argv[])
 	}
 
 	retval = runner->run_tests(argc, argv) ? 0 : 1;
-	signal(SIGABRT, TerminateOnSigAbrt);
 
 	try {
 		printf("DEBUG: Calling GlobalTeardown\n"); fflush(stdout);

--- a/Lib/src/unit++/main.cc
+++ b/Lib/src/unit++/main.cc
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #if defined(WIN32) || defined(WIN64)
-#define WINDOWS_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <crtdbg.h>
 #endif

--- a/Lib/src/unit++/main.cc
+++ b/Lib/src/unit++/main.cc
@@ -2,9 +2,85 @@
 // Terms of use are in the file COPYING
 #include "main.h"
 #include <algorithm>
+#include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
+#if defined(WIN32) || defined(WIN64)
+#define WINDOWS_LEAN_AND_MEAN
+#include <Windows.h>
+#include <crtdbg.h>
+#endif
 using namespace std;
 using namespace unitpp;
+
+#if defined(WIN32) || defined(WIN64)
+namespace
+{
+	void TerminateOnSigAbrt(int)
+	{
+		_exit(3);
+	}
+
+	typedef HRESULT (WINAPI * PfnWerGetFlags)(HANDLE, PDWORD);
+	typedef HRESULT (WINAPI * PfnWerSetFlags)(DWORD);
+
+	const DWORD kWerFaultReportingNoUi = 0x00000004;
+	const DWORD kWerFaultReportingAlwaysShowUi = 0x00000010;
+
+	void ConfigureWindowsErrorReportingUi()
+	{
+		DWORD errorMode = GetErrorMode();
+		errorMode |= SEM_FAILCRITICALERRORS;
+		errorMode |= SEM_NOGPFAULTERRORBOX;
+		errorMode |= SEM_NOOPENFILEERRORBOX;
+		SetErrorMode(errorMode);
+
+		HMODULE hWer = LoadLibraryA("wer.dll");
+		if (!hWer)
+			return;
+
+		PfnWerGetFlags pfnWerGetFlags = reinterpret_cast<PfnWerGetFlags>(
+			GetProcAddress(hWer, "WerGetFlags")
+		);
+		PfnWerSetFlags pfnWerSetFlags = reinterpret_cast<PfnWerSetFlags>(
+			GetProcAddress(hWer, "WerSetFlags")
+		);
+
+		if (pfnWerSetFlags)
+		{
+			DWORD flags = 0;
+			if (pfnWerGetFlags)
+				pfnWerGetFlags(GetCurrentProcess(), &flags);
+
+			flags |= kWerFaultReportingNoUi;
+			flags &= ~kWerFaultReportingAlwaysShowUi;
+			pfnWerSetFlags(flags);
+		}
+
+		FreeLibrary(hWer);
+	}
+
+	void ConfigureCrtReportUi()
+	{
+		_set_error_mode(_OUT_TO_STDERR);
+
+		_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+		_CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+		_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+		_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+		_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+		_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+
+		_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+	}
+
+	void SuppressInteractiveCrashUi()
+	{
+		ConfigureWindowsErrorReportingUi();
+		ConfigureCrtReportUi();
+	}
+}
+#endif
 
 bool unitpp::verbose = false;
 int unitpp::verbose_lvl = 0;
@@ -25,6 +101,9 @@ void unitpp::set_tester(test_runner* tr)
 
 int main(int argc, const char* argv[])
 {
+#if defined(WIN32) || defined(WIN64)
+	SuppressInteractiveCrashUi();
+#endif
     printf("DEBUG: unit++ main start\n"); fflush(stdout);
 	options().add("v", new options_utils::opt_flag(verbose));
 	options().alias("verbose", "v");
@@ -42,14 +121,41 @@ int main(int argc, const char* argv[])
 	if (!runner)
 		runner = &plain;
 
-    printf("DEBUG: Calling GlobalSetup\n"); fflush(stdout);
-	GlobalSetup(verbose);
-	printf("DEBUG: Returned from GlobalSetup\n"); fflush(stdout);
+	int retval = 0;
 
-	int retval = runner->run_tests(argc, argv) ? 0 : 1;
+	try {
+		printf("DEBUG: Calling GlobalSetup\n"); fflush(stdout);
+		GlobalSetup(verbose);
+		printf("DEBUG: Returned from GlobalSetup\n"); fflush(stdout);
+	}
+	catch (const std::exception& e) {
+		fprintf(stderr, "GlobalSetup threw std::exception: %s\n", e.what());
+		fflush(stderr);
+		return 1;
+	}
+	catch (...) {
+		fprintf(stderr, "GlobalSetup threw an unknown exception\n");
+		fflush(stderr);
+		return 1;
+	}
 
-    printf("DEBUG: Calling GlobalTeardown\n"); fflush(stdout);
-	GlobalTeardown();
+	retval = runner->run_tests(argc, argv) ? 0 : 1;
+	signal(SIGABRT, TerminateOnSigAbrt);
+
+	try {
+		printf("DEBUG: Calling GlobalTeardown\n"); fflush(stdout);
+		GlobalTeardown();
+	}
+	catch (const std::exception& e) {
+		fprintf(stderr, "GlobalTeardown threw std::exception: %s\n", e.what());
+		fflush(stderr);
+		retval = 1;
+	}
+	catch (...) {
+		fprintf(stderr, "GlobalTeardown threw an unknown exception\n");
+		fflush(stderr);
+		retval = 1;
+	}
 	printf("DEBUG: unit++ main end (retval=%d)\n", retval); fflush(stdout);
 	return retval;
 }

--- a/Src/AppForTests.config
+++ b/Src/AppForTests.config
@@ -4,6 +4,7 @@
 <trace autoflush="false" indentsize="4">
 <listeners>
 <clear/>
+<add name="ConsoleTraceListener" type="System.Diagnostics.ConsoleTraceListener"/>
 <add name="FwTraceListener" type="SIL.LCModel.Utils.EnvVarTraceListener, SIL.LCModel.Utils, Version=11.0.0.0, Culture=neutral"
  initializeData="assertuienabled='false' assertexceptionenabled='true' logfilename='%temp%/asserts.log'"/>
 </listeners>

--- a/Src/AppForTests.config
+++ b/Src/AppForTests.config
@@ -4,7 +4,6 @@
 <trace autoflush="false" indentsize="4">
 <listeners>
 <clear/>
-<add name="ConsoleTraceListener" type="System.Diagnostics.ConsoleTraceListener"/>
 <add name="FwTraceListener" type="SIL.LCModel.Utils.EnvVarTraceListener, SIL.LCModel.Utils, Version=11.0.0.0, Culture=neutral"
  initializeData="assertuienabled='false' assertexceptionenabled='true' logfilename='%temp%/asserts.log'"/>
 </listeners>

--- a/Src/AssemblyInfoForTests.cs
+++ b/Src/AssemblyInfoForTests.cs
@@ -16,6 +16,12 @@ using System.Reflection;
 // Set stub for messagebox so that we don't pop up a message box when running tests.
 [assembly: SetMessageBoxAdapter]
 
+// Log last-chance managed exceptions to console output before process termination.
+[assembly: LogUnhandledExceptions]
+
+// Suppress all assertion dialog boxes (native + managed) regardless of config file coverage
+[assembly: SuppressAssertDialogs]
+
 // Cleanup all singletons after running tests
 [assembly: CleanupSingletons]
 

--- a/Src/AssemblyInfoForUiIndependentTests.cs
+++ b/Src/AssemblyInfoForUiIndependentTests.cs
@@ -10,6 +10,9 @@ using SIL.TestUtilities;
 // This file is for test fixtures for UI independent projects, i.e. projects that don't
 // reference System.Windows.Forms et al.
 
+// Log last-chance managed exceptions to console output before process termination.
+[assembly: LogUnhandledExceptions]
+
 // Cleanup all singletons after running tests
 [assembly: CleanupSingletons]
 

--- a/Src/AssemblyInfoForUiIndependentTests.cs
+++ b/Src/AssemblyInfoForUiIndependentTests.cs
@@ -13,6 +13,9 @@ using SIL.TestUtilities;
 // Log last-chance managed exceptions to console output before process termination.
 [assembly: LogUnhandledExceptions]
 
+// Suppress all assertion dialog boxes (native + managed) regardless of config file coverage
+[assembly: SuppressAssertDialogs]
+
 // Cleanup all singletons after running tests
 [assembly: CleanupSingletons]
 

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/HandleApplicationThreadExceptionAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/HandleApplicationThreadExceptionAttribute.cs
@@ -42,6 +42,10 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 
 		private void OnThreadException(object sender, ThreadExceptionEventArgs e)
 		{
+			Console.Error.WriteLine("Unhandled Windows Forms thread exception during test run:");
+			Console.Error.WriteLine(e.Exception.ToString());
+			Console.Error.Flush();
+
 			throw new ApplicationException(e.Exception.Message, e.Exception);
 		}
 	}

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace SIL.FieldWorks.Common.FwUtils.Attributes
+{
+	/// <summary>
+	/// Assembly-level test bootstrap that logs last-chance managed exceptions to the
+	/// console so unattended test runs always have readable failure details.
+	///
+	/// This is intentionally a logging-only hook. It does not try to recover or keep
+	/// the process alive after an unhandled exception.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	public class LogUnhandledExceptionsAttribute : TestActionAttribute
+	{
+		private UnhandledExceptionEventHandler m_unhandledExceptionHandler;
+		private EventHandler<UnobservedTaskExceptionEventArgs> m_unobservedTaskExceptionHandler;
+
+		/// <summary/>
+		public override ActionTargets Targets => ActionTargets.Suite;
+
+		/// <summary/>
+		public override void BeforeTest(ITest test)
+		{
+			base.BeforeTest(test);
+
+			m_unhandledExceptionHandler = OnUnhandledException;
+			AppDomain.CurrentDomain.UnhandledException += m_unhandledExceptionHandler;
+
+			m_unobservedTaskExceptionHandler = OnUnobservedTaskException;
+			TaskScheduler.UnobservedTaskException += m_unobservedTaskExceptionHandler;
+		}
+
+		/// <summary/>
+		public override void AfterTest(ITest test)
+		{
+			if (m_unhandledExceptionHandler != null)
+			{
+				AppDomain.CurrentDomain.UnhandledException -= m_unhandledExceptionHandler;
+				m_unhandledExceptionHandler = null;
+			}
+
+			if (m_unobservedTaskExceptionHandler != null)
+			{
+				TaskScheduler.UnobservedTaskException -= m_unobservedTaskExceptionHandler;
+				m_unobservedTaskExceptionHandler = null;
+			}
+
+			base.AfterTest(test);
+		}
+
+		private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+		{
+			Console.Error.WriteLine("Unhandled managed exception during test run:");
+			Console.Error.WriteLine($"IsTerminating: {e.IsTerminating}");
+			Console.Error.WriteLine(e.ExceptionObject?.ToString() ?? "<null exception object>");
+			Console.Error.Flush();
+		}
+
+		private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		{
+			Console.Error.WriteLine("Unobserved task exception during test run:");
+			Console.Error.WriteLine(e.Exception.ToString());
+			Console.Error.Flush();
+
+			// Escalate instead of allowing the exception to be quietly ignored at finalization time.
+			throw new UnobservedTaskExceptionLoggedException(e.Exception);
+		}
+	}
+
+	/// <summary>
+	/// Exception used to surface unobserved task failures in test output after the original
+	/// AggregateException has been written to the console.
+	/// </summary>
+	public class UnobservedTaskExceptionLoggedException : Exception
+	{
+		public UnobservedTaskExceptionLoggedException(AggregateException innerException)
+			: base("Unobserved task exception during test run.", innerException)
+		{
+		}
+	}
+}

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
@@ -3,6 +3,8 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System;
+using System.Collections.Concurrent;
+using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -19,6 +21,9 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 	[AttributeUsage(AttributeTargets.Assembly)]
 	public class LogUnhandledExceptionsAttribute : TestActionAttribute
 	{
+		private static readonly ConcurrentQueue<AggregateException> s_unobservedTaskExceptions =
+			new ConcurrentQueue<AggregateException>();
+
 		private UnhandledExceptionEventHandler m_unhandledExceptionHandler;
 		private EventHandler<UnobservedTaskExceptionEventArgs> m_unobservedTaskExceptionHandler;
 
@@ -29,6 +34,7 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 		public override void BeforeTest(ITest test)
 		{
 			base.BeforeTest(test);
+			ResetCapturedUnobservedTaskExceptionsForTesting();
 
 			m_unhandledExceptionHandler = OnUnhandledException;
 			AppDomain.CurrentDomain.UnhandledException += m_unhandledExceptionHandler;
@@ -40,6 +46,8 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 		/// <summary/>
 		public override void AfterTest(ITest test)
 		{
+			var unobservedTaskExceptions = FlushAndDrainCapturedUnobservedTaskExceptions();
+
 			if (m_unhandledExceptionHandler != null)
 			{
 				AppDomain.CurrentDomain.UnhandledException -= m_unhandledExceptionHandler;
@@ -53,6 +61,8 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 			}
 
 			base.AfterTest(test);
+
+			ThrowIfCapturedUnobservedTaskExceptions(unobservedTaskExceptions);
 		}
 
 		private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
@@ -63,26 +73,76 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 			Console.Error.Flush();
 		}
 
-		private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		internal static void OnUnobservedTaskException(
+			object sender,
+			UnobservedTaskExceptionEventArgs e
+		)
 		{
 			Console.Error.WriteLine("Unobserved task exception during test run:");
 			Console.Error.WriteLine(e.Exception.ToString());
 			Console.Error.Flush();
 
-			// Escalate instead of allowing the exception to be quietly ignored at finalization time.
-			throw new UnobservedTaskExceptionLoggedException(e.Exception);
+			s_unobservedTaskExceptions.Enqueue(e.Exception);
+			e.SetObserved();
 		}
-	}
 
-	/// <summary>
-	/// Exception used to surface unobserved task failures in test output after the original
-	/// AggregateException has been written to the console.
-	/// </summary>
-	public class UnobservedTaskExceptionLoggedException : Exception
-	{
-		public UnobservedTaskExceptionLoggedException(AggregateException innerException)
-			: base("Unobserved task exception during test run.", innerException)
+		internal static void ResetCapturedUnobservedTaskExceptionsForTesting()
 		{
+			AggregateException ignored;
+			while (s_unobservedTaskExceptions.TryDequeue(out ignored)) { }
+		}
+
+		internal static AggregateException[] FlushAndDrainCapturedUnobservedTaskExceptions()
+		{
+			for (int i = 0; i < 3; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			return DrainCapturedUnobservedTaskExceptions();
+		}
+
+		internal static AggregateException[] DrainCapturedUnobservedTaskExceptions()
+		{
+			var exceptions = new ConcurrentQueue<AggregateException>();
+			AggregateException capturedException;
+			while (s_unobservedTaskExceptions.TryDequeue(out capturedException))
+				exceptions.Enqueue(capturedException);
+
+			return exceptions.ToArray();
+		}
+
+		internal static void ThrowIfCapturedUnobservedTaskExceptions(
+			AggregateException[] exceptions
+		)
+		{
+			if (exceptions == null || exceptions.Length == 0)
+				return;
+
+			throw new AssertionException(BuildFailureMessage(exceptions));
+		}
+
+		internal static string BuildFailureMessage(AggregateException[] exceptions)
+		{
+			var builder = new StringBuilder();
+			builder.AppendLine(
+				string.Format(
+					"{0} unobserved task exception(s) were detected during the test run.",
+					exceptions.Length
+				)
+			);
+			builder.AppendLine(
+				"These exceptions were captured from TaskScheduler.UnobservedTaskException and surfaced at suite teardown so the test host fails deterministically without crashing on the finalizer thread."
+			);
+
+			for (int i = 0; i < exceptions.Length; i++)
+			{
+				builder.AppendLine();
+				builder.AppendLine(string.Format("[{0}] {1}", i + 1, exceptions[i]));
+			}
+
+			return builder.ToString();
 		}
 	}
 }

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/LogUnhandledExceptionsAttribute.cs
@@ -94,11 +94,12 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 
 		internal static AggregateException[] FlushAndDrainCapturedUnobservedTaskExceptions()
 		{
-			for (int i = 0; i < 3; i++)
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-			}
+			var alreadyCapturedExceptions = DrainCapturedUnobservedTaskExceptions();
+			if (alreadyCapturedExceptions.Length > 0)
+				return alreadyCapturedExceptions;
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
 			return DrainCapturedUnobservedTaskExceptions();
 		}

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Diagnostics;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace SIL.FieldWorks.Common.FwUtils.Attributes
+{
+	/// <summary>
+	/// NUnit assembly-level attribute that suppresses all assertion dialog boxes during tests.
+	/// Sets environment variables that DebugProcs.dll (native) and EnvVarTraceListener (managed)
+	/// honor, and ensures debug trace/assert output is mirrored to the console.
+	///
+	/// For test projects that link AppForTests.config, EnvVarTraceListener already handles
+	/// assert-to-exception conversion and file logging. For the remaining projects, this
+	/// attribute installs a listener that converts Debug.Fail into test failures.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	public class SuppressAssertDialogsAttribute : TestActionAttribute
+	{
+		private ConsoleErrorTraceListener m_listener;
+
+		/// <summary/>
+		public override ActionTargets Targets => ActionTargets.Suite;
+
+		/// <summary/>
+		public override void BeforeTest(ITest test)
+		{
+			base.BeforeTest(test);
+
+			// Force environment variables that control native (DebugProcs.dll) and
+			// managed (EnvVarTraceListener) assertion behavior.
+			Environment.SetEnvironmentVariable("AssertUiEnabled", "false");
+			Environment.SetEnvironmentVariable("AssertExceptionEnabled", "true");
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", "1");
+
+			// If EnvVarTraceListener is already installed (via AppForTests.config), keep
+			// its assert-to-exception and file logging behavior, but still mirror output
+			// to the console. Otherwise, our listener is responsible for failing tests.
+			bool hasEnvVarListener = false;
+			foreach (TraceListener listener in Trace.Listeners)
+			{
+				// Check by type name to avoid a hard dependency on SIL.LCModel.Utils.
+				if (listener.GetType().Name == "EnvVarTraceListener")
+				{
+					hasEnvVarListener = true;
+					break;
+				}
+			}
+
+			// Suppress the DefaultTraceListener dialog even when another listener is
+			// present so assertions never degrade back to modal UI.
+			foreach (TraceListener listener in Trace.Listeners)
+			{
+				if (listener is DefaultTraceListener dtl)
+				{
+					dtl.AssertUiEnabled = false;
+					break;
+				}
+			}
+
+			m_listener = new ConsoleErrorTraceListener(throwOnFail: !hasEnvVarListener);
+			Trace.Listeners.Insert(0, m_listener);
+		}
+
+		/// <summary/>
+		public override void AfterTest(ITest test)
+		{
+			if (m_listener != null)
+			{
+				Trace.Listeners.Remove(m_listener);
+				m_listener = null;
+			}
+
+			base.AfterTest(test);
+		}
+	}
+
+	/// <summary>
+	/// Mirrors debug trace output to Console.Error and optionally converts
+	/// Debug.Fail/failed Debug.Assert calls into exceptions.
+	/// </summary>
+	internal class ConsoleErrorTraceListener : TraceListener
+	{
+		private readonly bool m_throwOnFail;
+
+		public ConsoleErrorTraceListener(bool throwOnFail)
+		{
+			m_throwOnFail = throwOnFail;
+		}
+
+		public override void Fail(string message)
+		{
+			WriteFailure(message, null);
+		}
+
+		public override void Fail(string message, string detailMessage)
+		{
+			WriteFailure(message, detailMessage);
+		}
+
+		public override void Write(string message)
+		{
+			Console.Error.Write(message);
+			Console.Error.Flush();
+		}
+
+		public override void WriteLine(string message)
+		{
+			Console.Error.WriteLine(message);
+			Console.Error.Flush();
+		}
+
+		private void WriteFailure(string message, string detailMessage)
+		{
+			var full = string.IsNullOrEmpty(detailMessage)
+				? message
+				: $"{message}{Environment.NewLine}{detailMessage}";
+
+			Console.Error.WriteLine("Debug.Fail/Assert fired during test:");
+			Console.Error.WriteLine(full);
+			Console.Error.Flush();
+
+			if (m_throwOnFail)
+				throw new AssertionDialogException(full);
+		}
+	}
+
+	/// <summary>
+	/// Exception thrown when a Debug.Fail or Debug.Assert fires during a test,
+	/// replacing the modal Abort/Retry/Ignore dialog with a clear test failure.
+	/// </summary>
+	public class AssertionDialogException : Exception
+	{
+		public AssertionDialogException(string message)
+			: base($"Debug.Fail/Assert fired during test (would have shown a modal dialog):\n{message}")
+		{
+		}
+	}
+}

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
@@ -22,6 +22,9 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 	public class SuppressAssertDialogsAttribute : TestActionAttribute
 	{
 		private ConsoleErrorTraceListener m_listener;
+		private string m_previousAssertUiEnabled;
+		private string m_previousAssertExceptionEnabled;
+		private string m_previousTestMode;
 
 		/// <summary/>
 		public override ActionTargets Targets => ActionTargets.Suite;
@@ -33,22 +36,29 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 
 			// Force environment variables that control native (DebugProcs.dll) and
 			// managed (EnvVarTraceListener) assertion behavior.
+			m_previousAssertUiEnabled = Environment.GetEnvironmentVariable("AssertUiEnabled");
+			m_previousAssertExceptionEnabled = Environment.GetEnvironmentVariable(
+				"AssertExceptionEnabled"
+			);
+			m_previousTestMode = Environment.GetEnvironmentVariable("FW_TEST_MODE");
+
 			Environment.SetEnvironmentVariable("AssertUiEnabled", "false");
 			Environment.SetEnvironmentVariable("AssertExceptionEnabled", "true");
 			Environment.SetEnvironmentVariable("FW_TEST_MODE", "1");
 
 			// If EnvVarTraceListener is already installed (via AppForTests.config), keep
-			// its assert-to-exception and file logging behavior, but still mirror output
-			// to the console. Otherwise, our listener is responsible for failing tests.
+			// its assert-to-exception and file logging behavior. Otherwise, our listener
+			// is responsible for converting Debug.Fail into a test failure.
 			bool hasEnvVarListener = false;
+			bool hasConsoleErrorListener = false;
 			foreach (TraceListener listener in Trace.Listeners)
 			{
 				// Check by type name to avoid a hard dependency on SIL.LCModel.Utils.
 				if (listener.GetType().Name == "EnvVarTraceListener")
-				{
 					hasEnvVarListener = true;
-					break;
-				}
+
+				if (listener is ConsoleErrorTraceListener)
+					hasConsoleErrorListener = true;
 			}
 
 			// Suppress the DefaultTraceListener dialog even when another listener is
@@ -62,8 +72,11 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 				}
 			}
 
-			m_listener = new ConsoleErrorTraceListener(throwOnFail: !hasEnvVarListener);
-			Trace.Listeners.Insert(0, m_listener);
+			if (!hasConsoleErrorListener)
+			{
+				m_listener = new ConsoleErrorTraceListener(throwOnFail: !hasEnvVarListener);
+				Trace.Listeners.Insert(0, m_listener);
+			}
 		}
 
 		/// <summary/>
@@ -75,12 +88,23 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 				m_listener = null;
 			}
 
+			Environment.SetEnvironmentVariable("AssertUiEnabled", m_previousAssertUiEnabled);
+			Environment.SetEnvironmentVariable(
+				"AssertExceptionEnabled",
+				m_previousAssertExceptionEnabled
+			);
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", m_previousTestMode);
+
+			m_previousAssertUiEnabled = null;
+			m_previousAssertExceptionEnabled = null;
+			m_previousTestMode = null;
+
 			base.AfterTest(test);
 		}
 	}
 
 	/// <summary>
-	/// Mirrors debug trace output to Console.Error and optionally converts
+	/// Writes debug failure details to Console.Error and optionally converts
 	/// Debug.Fail/failed Debug.Assert calls into exceptions.
 	/// </summary>
 	internal class ConsoleErrorTraceListener : TraceListener
@@ -102,17 +126,9 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 			WriteFailure(message, detailMessage);
 		}
 
-		public override void Write(string message)
-		{
-			Console.Error.Write(message);
-			Console.Error.Flush();
-		}
+		public override void Write(string message) { }
 
-		public override void WriteLine(string message)
-		{
-			Console.Error.WriteLine(message);
-			Console.Error.Flush();
-		}
+		public override void WriteLine(string message) { }
 
 		private void WriteFailure(string message, string detailMessage)
 		{
@@ -136,8 +152,8 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 	public class AssertionDialogException : Exception
 	{
 		public AssertionDialogException(string message)
-			: base($"Debug.Fail/Assert fired during test (would have shown a modal dialog):\n{message}")
-		{
-		}
+			: base(
+				$"Debug.Fail/Assert fired during test (would have shown a modal dialog):\n{message}"
+			) { }
 	}
 }

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
@@ -72,10 +72,7 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 			foreach (TraceListener listener in Trace.Listeners)
 			{
 				if (listener is DefaultTraceListener dtl)
-				{
 					dtl.AssertUiEnabled = false;
-					break;
-				}
 			}
 
 			if (!hasConsoleErrorListener)

--- a/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/Attributes/SuppressAssertDialogsAttribute.cs
@@ -25,6 +25,7 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 		private string m_previousAssertUiEnabled;
 		private string m_previousAssertExceptionEnabled;
 		private string m_previousTestMode;
+		private bool m_suppressionApplied;
 
 		/// <summary/>
 		public override ActionTargets Targets => ActionTargets.Suite;
@@ -33,9 +34,14 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 		public override void BeforeTest(ITest test)
 		{
 			base.BeforeTest(test);
+			m_suppressionApplied = false;
+
+			if (IsAssertDialogOptInEnabled())
+				return;
 
 			// Force environment variables that control native (DebugProcs.dll) and
 			// managed (EnvVarTraceListener) assertion behavior.
+			m_suppressionApplied = true;
 			m_previousAssertUiEnabled = Environment.GetEnvironmentVariable("AssertUiEnabled");
 			m_previousAssertExceptionEnabled = Environment.GetEnvironmentVariable(
 				"AssertExceptionEnabled"
@@ -82,6 +88,12 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 		/// <summary/>
 		public override void AfterTest(ITest test)
 		{
+			if (!m_suppressionApplied)
+			{
+				base.AfterTest(test);
+				return;
+			}
+
 			if (m_listener != null)
 			{
 				Trace.Listeners.Remove(m_listener);
@@ -98,8 +110,27 @@ namespace SIL.FieldWorks.Common.FwUtils.Attributes
 			m_previousAssertUiEnabled = null;
 			m_previousAssertExceptionEnabled = null;
 			m_previousTestMode = null;
+			m_suppressionApplied = false;
 
 			base.AfterTest(test);
+		}
+
+		internal static bool IsAssertDialogOptInEnabled()
+		{
+			var value = Environment.GetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS");
+			if (string.IsNullOrWhiteSpace(value))
+				return false;
+
+			switch (value.Trim().ToLowerInvariant())
+			{
+				case "1":
+				case "true":
+				case "yes":
+				case "on":
+					return true;
+				default:
+					return false;
+			}
 		}
 	}
 

--- a/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
@@ -57,5 +57,16 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Assert.That(exception.Message, Does.Contain("second failure"));
 			Assert.That(exception.Message, Does.Contain("fails deterministically"));
 		}
+
+		[Test]
+		public void OnUnobservedTaskException_MarksExceptionObserved()
+		{
+			var aggregateException = new AggregateException(new InvalidOperationException("boom"));
+			var eventArgs = new UnobservedTaskExceptionEventArgs(aggregateException);
+
+			LogUnhandledExceptionsAttribute.OnUnobservedTaskException(this, eventArgs);
+
+			Assert.That(eventArgs.Observed, Is.True);
+		}
 	}
 }

--- a/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwUtils.Attributes;
+
+namespace SIL.FieldWorks.Common.FwUtils
+{
+	[TestFixture]
+	public class LogUnhandledExceptionsAttributeTests
+	{
+		[SetUp]
+		public void SetUp()
+		{
+			LogUnhandledExceptionsAttribute.ResetCapturedUnobservedTaskExceptionsForTesting();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			LogUnhandledExceptionsAttribute.ResetCapturedUnobservedTaskExceptionsForTesting();
+		}
+
+		[Test]
+		public void OnUnobservedTaskException_RecordsExceptionWithoutThrowing()
+		{
+			var aggregateException = new AggregateException(new InvalidOperationException("boom"));
+			var eventArgs = new UnobservedTaskExceptionEventArgs(aggregateException);
+
+			Assert.DoesNotThrow(() => LogUnhandledExceptionsAttribute.OnUnobservedTaskException(this, eventArgs));
+			CollectionAssert.AreEqual(
+				new[] { aggregateException },
+				LogUnhandledExceptionsAttribute.DrainCapturedUnobservedTaskExceptions());
+		}
+
+		[Test]
+		public void ThrowIfCapturedUnobservedTaskExceptions_DoesNothingWhenNoExceptionsWereCaptured()
+		{
+			Assert.DoesNotThrow(() => LogUnhandledExceptionsAttribute.ThrowIfCapturedUnobservedTaskExceptions(
+				LogUnhandledExceptionsAttribute.DrainCapturedUnobservedTaskExceptions()));
+		}
+
+		[Test]
+		public void ThrowIfCapturedUnobservedTaskExceptions_ThrowsAssertionExceptionWithCapturedDetails()
+		{
+			var first = new AggregateException(new InvalidOperationException("first failure"));
+			var second = new AggregateException(new ApplicationException("second failure"));
+
+			var exception = Assert.Throws<AssertionException>(() =>
+				LogUnhandledExceptionsAttribute.ThrowIfCapturedUnobservedTaskExceptions(new[] { first, second }));
+
+			Assert.That(exception.Message, Does.Contain("2 unobserved task exception(s)"));
+			Assert.That(exception.Message, Does.Contain("first failure"));
+			Assert.That(exception.Message, Does.Contain("second failure"));
+			Assert.That(exception.Message, Does.Contain("fails deterministically"));
+		}
+	}
+}

--- a/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/LogUnhandledExceptionsAttributeTests.cs
@@ -44,6 +44,20 @@ namespace SIL.FieldWorks.Common.FwUtils
 		}
 
 		[Test]
+		public void FlushAndDrainCapturedUnobservedTaskExceptions_ReturnsAlreadyCapturedExceptions()
+		{
+			var aggregateException = new AggregateException(new InvalidOperationException("boom"));
+			var eventArgs = new UnobservedTaskExceptionEventArgs(aggregateException);
+
+			LogUnhandledExceptionsAttribute.OnUnobservedTaskException(this, eventArgs);
+
+			CollectionAssert.AreEqual(
+				new[] { aggregateException },
+				LogUnhandledExceptionsAttribute.FlushAndDrainCapturedUnobservedTaskExceptions());
+			Assert.That(LogUnhandledExceptionsAttribute.DrainCapturedUnobservedTaskExceptions(), Is.Empty);
+		}
+
+		[Test]
 		public void ThrowIfCapturedUnobservedTaskExceptions_ThrowsAssertionExceptionWithCapturedDetails()
 		{
 			var first = new AggregateException(new InvalidOperationException("first failure"));

--- a/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwUtils.Attributes;
+
+namespace SIL.FieldWorks.Common.FwUtils
+{
+	[TestFixture]
+	public class SuppressAssertDialogsAttributeTests
+	{
+		private TraceListener[] m_originalListeners;
+		private TextWriter m_originalError;
+
+		[SetUp]
+		public void SetUp()
+		{
+			m_originalListeners = new TraceListener[Trace.Listeners.Count];
+			Trace.Listeners.CopyTo(m_originalListeners, 0);
+			Trace.Listeners.Clear();
+			m_originalError = Console.Error;
+
+			Environment.SetEnvironmentVariable("AssertUiEnabled", null);
+			Environment.SetEnvironmentVariable("AssertExceptionEnabled", null);
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", null);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Trace.Listeners.Clear();
+			Trace.Listeners.AddRange(m_originalListeners);
+			Console.SetError(m_originalError);
+
+			Environment.SetEnvironmentVariable("AssertUiEnabled", null);
+			Environment.SetEnvironmentVariable("AssertExceptionEnabled", null);
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", null);
+		}
+
+		[Test]
+		public void ConsoleErrorTraceListener_Fail_ThrowsAssertionDialogExceptionAndWritesToStderr()
+		{
+			var stderr = new StringWriter();
+			Console.SetError(stderr);
+
+			var listener = new ConsoleErrorTraceListener(throwOnFail: true);
+
+			var exception = Assert.Throws<AssertionDialogException>(
+				() => listener.Fail("boom", "detail")
+			);
+
+			Assert.That(exception.Message, Does.Contain("boom"));
+			Assert.That(exception.Message, Does.Contain("detail"));
+			Assert.That(stderr.ToString(), Does.Contain("Debug.Fail/Assert fired during test:"));
+		}
+
+		[Test]
+		public void SuppressAssertDialogsAttribute_BeforeAndAfterTest_RestoresEnvironmentVariables()
+		{
+			Environment.SetEnvironmentVariable("AssertUiEnabled", "true");
+			Environment.SetEnvironmentVariable("AssertExceptionEnabled", "false");
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", "0");
+
+			var defaultListener = new DefaultTraceListener();
+			Trace.Listeners.Add(defaultListener);
+
+			var attribute = new SuppressAssertDialogsAttribute();
+
+			attribute.BeforeTest(null);
+
+			Assert.That(Environment.GetEnvironmentVariable("AssertUiEnabled"), Is.EqualTo("false"));
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertExceptionEnabled"),
+				Is.EqualTo("true")
+			);
+			Assert.That(Environment.GetEnvironmentVariable("FW_TEST_MODE"), Is.EqualTo("1"));
+			Assert.That(defaultListener.AssertUiEnabled, Is.False);
+			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(1));
+
+			attribute.AfterTest(null);
+
+			Assert.That(Environment.GetEnvironmentVariable("AssertUiEnabled"), Is.EqualTo("true"));
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertExceptionEnabled"),
+				Is.EqualTo("false")
+			);
+			Assert.That(Environment.GetEnvironmentVariable("FW_TEST_MODE"), Is.EqualTo("0"));
+			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(0));
+		}
+
+		[Test]
+		public void SuppressAssertDialogsAttribute_DoesNotAddDuplicateConsoleListener()
+		{
+			Trace.Listeners.Add(new ConsoleErrorTraceListener(throwOnFail: false));
+			var attribute = new SuppressAssertDialogsAttribute();
+
+			attribute.BeforeTest(null);
+
+			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(1));
+
+			attribute.AfterTest(null);
+		}
+
+		[Test]
+		public void SuppressAssertDialogsAttribute_WithEnvVarTraceListener_LeavesFailAsLoggingOnly()
+		{
+			Trace.Listeners.Add(new EnvVarTraceListener());
+			var stderr = new StringWriter();
+			Console.SetError(stderr);
+
+			var attribute = new SuppressAssertDialogsAttribute();
+			attribute.BeforeTest(null);
+
+			var listener = FindConsoleErrorTraceListener();
+			Assert.That(listener, Is.Not.Null);
+
+			Assert.DoesNotThrow(() => listener.Fail("boom", null));
+			Assert.That(stderr.ToString(), Does.Contain("Debug.Fail/Assert fired during test:"));
+
+			attribute.AfterTest(null);
+		}
+
+		private static int CountListeners<T>()
+			where T : TraceListener
+		{
+			int count = 0;
+			foreach (TraceListener listener in Trace.Listeners)
+			{
+				if (listener is T)
+					count++;
+			}
+
+			return count;
+		}
+
+		private static ConsoleErrorTraceListener FindConsoleErrorTraceListener()
+		{
+			foreach (TraceListener listener in Trace.Listeners)
+			{
+				if (listener is ConsoleErrorTraceListener consoleListener)
+					return consoleListener;
+			}
+
+			return null;
+		}
+
+		private sealed class EnvVarTraceListener : TraceListener
+		{
+			public override void Write(string message) { }
+
+			public override void WriteLine(string message) { }
+		}
+	}
+}

--- a/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
@@ -51,9 +51,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			var listener = new ConsoleErrorTraceListener(throwOnFail: true);
 
-			var exception = Assert.Throws<AssertionDialogException>(
-				() => listener.Fail("boom", "detail")
-			);
+			var exception = Assert.Throws<AssertionDialogException>(() =>
+				listener.Fail("boom", "detail"));
 
 			Assert.That(exception.Message, Does.Contain("boom"));
 			Assert.That(exception.Message, Does.Contain("detail"));
@@ -67,8 +66,10 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Environment.SetEnvironmentVariable("AssertExceptionEnabled", "false");
 			Environment.SetEnvironmentVariable("FW_TEST_MODE", "0");
 
-			var defaultListener = new DefaultTraceListener();
-			Trace.Listeners.Add(defaultListener);
+			var firstDefaultListener = new DefaultTraceListener { AssertUiEnabled = true };
+			var secondDefaultListener = new DefaultTraceListener { AssertUiEnabled = true };
+			Trace.Listeners.Add(firstDefaultListener);
+			Trace.Listeners.Add(secondDefaultListener);
 
 			var attribute = new SuppressAssertDialogsAttribute();
 
@@ -83,7 +84,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 				Is.EqualTo("true")
 			);
 			Assert.That(Environment.GetEnvironmentVariable("FW_TEST_MODE"), Is.EqualTo("1"));
-			Assert.That(defaultListener.AssertUiEnabled, Is.False);
+			Assert.That(firstDefaultListener.AssertUiEnabled, Is.False);
+			Assert.That(secondDefaultListener.AssertUiEnabled, Is.False);
 			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(1));
 
 			attribute.AfterTest(null);

--- a/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/SuppressAssertDialogsAttributeTests.cs
@@ -27,6 +27,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Environment.SetEnvironmentVariable("AssertUiEnabled", null);
 			Environment.SetEnvironmentVariable("AssertExceptionEnabled", null);
 			Environment.SetEnvironmentVariable("FW_TEST_MODE", null);
+			Environment.SetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS", null);
 		}
 
 		[TearDown]
@@ -39,6 +40,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Environment.SetEnvironmentVariable("AssertUiEnabled", null);
 			Environment.SetEnvironmentVariable("AssertExceptionEnabled", null);
 			Environment.SetEnvironmentVariable("FW_TEST_MODE", null);
+			Environment.SetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS", null);
 		}
 
 		[Test]
@@ -72,7 +74,10 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			attribute.BeforeTest(null);
 
-			Assert.That(Environment.GetEnvironmentVariable("AssertUiEnabled"), Is.EqualTo("false"));
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertUiEnabled"),
+				Is.EqualTo("false")
+			);
 			Assert.That(
 				Environment.GetEnvironmentVariable("AssertExceptionEnabled"),
 				Is.EqualTo("true")
@@ -83,7 +88,10 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			attribute.AfterTest(null);
 
-			Assert.That(Environment.GetEnvironmentVariable("AssertUiEnabled"), Is.EqualTo("true"));
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertUiEnabled"),
+				Is.EqualTo("true")
+			);
 			Assert.That(
 				Environment.GetEnvironmentVariable("AssertExceptionEnabled"),
 				Is.EqualTo("false")
@@ -103,6 +111,57 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(1));
 
 			attribute.AfterTest(null);
+		}
+
+		[Test]
+		public void SuppressAssertDialogsAttribute_WithAllowAssertDialogs_DoesNotInstallSuppression()
+		{
+			Environment.SetEnvironmentVariable("AssertUiEnabled", "true");
+			Environment.SetEnvironmentVariable("AssertExceptionEnabled", "false");
+			Environment.SetEnvironmentVariable("FW_TEST_MODE", "0");
+			Environment.SetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS", "1");
+
+			var defaultListener = new DefaultTraceListener { AssertUiEnabled = true };
+			Trace.Listeners.Add(defaultListener);
+
+			var attribute = new SuppressAssertDialogsAttribute();
+			attribute.BeforeTest(null);
+
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertUiEnabled"),
+				Is.EqualTo("true")
+			);
+			Assert.That(
+				Environment.GetEnvironmentVariable("AssertExceptionEnabled"),
+				Is.EqualTo("false")
+			);
+			Assert.That(Environment.GetEnvironmentVariable("FW_TEST_MODE"), Is.EqualTo("0"));
+			Assert.That(defaultListener.AssertUiEnabled, Is.True);
+			Assert.That(CountListeners<ConsoleErrorTraceListener>(), Is.EqualTo(0));
+
+			attribute.AfterTest(null);
+		}
+
+		[TestCase("1")]
+		[TestCase("true")]
+		[TestCase("yes")]
+		[TestCase("on")]
+		public void IsAssertDialogOptInEnabled_WithTruthyValue_ReturnsTrue(string value)
+		{
+			Environment.SetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS", value);
+
+			Assert.That(SuppressAssertDialogsAttribute.IsAssertDialogOptInEnabled(), Is.True);
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase("0")]
+		[TestCase("false")]
+		public void IsAssertDialogOptInEnabled_WithoutTruthyValue_ReturnsFalse(string value)
+		{
+			Environment.SetEnvironmentVariable("FW_TEST_ALLOW_ASSERT_DIALOGS", value);
+
+			Assert.That(SuppressAssertDialogsAttribute.IsAssertDialogOptInEnabled(), Is.False);
 		}
 
 		[Test]

--- a/Src/DebugProcs/DebugProcs.cpp
+++ b/Src/DebugProcs/DebugProcs.cpp
@@ -19,6 +19,12 @@ Last reviewed:
 #include <cstdlib>
 #include <unistd.h>
 #endif
+#include <stdlib.h>
+#if defined(WIN32) || defined(WIN64)
+#include <string.h>
+#else
+#include <strings.h>
+#endif
 #include <stdio.h>
 #include <assert.h>
 #if defined(WIN32) || defined(WIN64)
@@ -37,6 +43,46 @@ typedef Pfn_Assert Pfn_Warn;
 void APIENTRY DefWarnProc(const char * pszExp, const char * pszFile, int nLine, HMODULE hmod);
 void APIENTRY DefAssertProc(const char * pszExp, const char * pszFile, int nLine, HMODULE hmod);
 bool GetShowAssertMessageBox();
+
+static bool TryGetEnvironmentVariableValue(const char * pszName, char ** ppszValue)
+{
+#if defined(WIN32) || defined(WIN64)
+	size_t cchValue = 0;
+	return _dupenv_s(ppszValue, &cchValue, pszName) == 0 && *ppszValue != NULL;
+#else
+	*ppszValue = getenv(pszName);
+	return *ppszValue != NULL;
+#endif
+}
+
+static void FreeEnvironmentVariableValue(char * pszValue)
+{
+#if defined(WIN32) || defined(WIN64)
+	free(pszValue);
+#else
+	(void)pszValue;
+#endif
+}
+
+static bool EqualsIgnoreCase(const char * pszLeft, const char * pszRight)
+{
+#if defined(WIN32) || defined(WIN64)
+	return _stricmp(pszLeft, pszRight) == 0;
+#else
+	return strcasecmp(pszLeft, pszRight) == 0;
+#endif
+}
+
+static bool IsTestModeEnabled()
+{
+	char * pTestMode = NULL;
+	if (!TryGetEnvironmentVariableValue("FW_TEST_MODE", &pTestMode))
+		return false;
+
+	const bool fIsTestMode = strcmp(pTestMode, "1") == 0;
+	FreeEnvironmentVariableValue(pTestMode);
+	return fIsTestMode;
+}
 
 typedef void (__stdcall * _DBG_REPORT_HOOK)(int, char *);
 typedef int (__stdcall * _DBG_DISPLAYMSGBOX_HOOK)(char *);
@@ -291,22 +337,10 @@ extern "C" __declspec(dllexport) int APIENTRY DebugProcsExit(void)
 ----------------------------------------------------------------------------------------------*/
 bool GetShowAssertMessageBox()
 {
-// getenv is deprecated on Windows
-#if defined(WIN32) || defined(WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4996)
-
-// Windows doesn't know strcasecmp, it calls it stricmp instead...
-#ifndef strcasecmp
-#define strcasecmp stricmp
-#endif
-#endif // WIN32
-
 	// FW_TEST_MODE is an unconditional override set by test runners.
 	// It takes priority over both the registry and AssertUiEnabled so that
 	// developer machines with the registry key set never pop dialogs during tests.
-	const char* pTestMode = getenv("FW_TEST_MODE");
-	if (pTestMode && strcasecmp(pTestMode, "1") == 0)
+	if (IsTestModeEnabled())
 		return false;
 
 #if defined(WIN32) || defined(WIN64)
@@ -324,14 +358,16 @@ bool GetShowAssertMessageBox()
 			return fShowAssertMessageBox ? true : false; // otherwise we get a performance warning
 	}
 #endif // WIN32
-	const char* pEnvVar = getenv("AssertUiEnabled");
-	return !pEnvVar ||
-		strcasecmp(pEnvVar, "0") != 0 &&
-		strcasecmp(pEnvVar, "false") != 0 &&
-		strcasecmp(pEnvVar, "no") != 0;
-#if defined(WIN32) || defined(WIN64)
-#pragma warning(pop)
-#endif // WIN32
+	char * pEnvVar = NULL;
+	if (!TryGetEnvironmentVariableValue("AssertUiEnabled", &pEnvVar))
+		return true;
+
+	const bool fShowAssertMessageBox =
+		!EqualsIgnoreCase(pEnvVar, "0") &&
+		!EqualsIgnoreCase(pEnvVar, "false") &&
+		!EqualsIgnoreCase(pEnvVar, "no");
+	FreeEnvironmentVariableValue(pEnvVar);
+	return fShowAssertMessageBox;
 }
 
 /*----------------------------------------------------------------------------------------------
@@ -591,10 +627,13 @@ void __cdecl SilAssert (
 	else
 		OutputDebugString(assertbuf);
 
-	// Always mirror assertion text to the process error stream so test runners,
-	// humans, and automation can see the failure details without a debugger.
-	fprintf(stderr, "%s\n", assertbuf);
-	fflush(stderr);
+	if (IsTestModeEnabled())
+	{
+		// In test mode, mirror assertion text to stderr so unattended runs capture
+		// the failure details without depending on a debugger or modal UI.
+		fprintf(stderr, "%s\n", assertbuf);
+		fflush(stderr);
+	}
 
 	// NOTE: this method is intented to be used by unmanaged apps only;
 	// managed apps should use DebugProcs.AssertProc in DebugProcs.cs

--- a/Src/DebugProcs/DebugProcs.cpp
+++ b/Src/DebugProcs/DebugProcs.cpp
@@ -286,10 +286,29 @@ extern "C" __declspec(dllexport) int APIENTRY DebugProcsExit(void)
 
 /*----------------------------------------------------------------------------------------------
 	Returns the AssertMessageBox value from the registry; if not set return the value of the
-	environment variable AssertUiEnabled; if not set return true
+	environment variable AssertUiEnabled; if not set return true.
+	FW_TEST_MODE=1 takes absolute priority and always returns false (no dialog).
 ----------------------------------------------------------------------------------------------*/
 bool GetShowAssertMessageBox()
 {
+// getenv is deprecated on Windows
+#if defined(WIN32) || defined(WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+
+// Windows doesn't know strcasecmp, it calls it stricmp instead...
+#ifndef strcasecmp
+#define strcasecmp stricmp
+#endif
+#endif // WIN32
+
+	// FW_TEST_MODE is an unconditional override set by test runners.
+	// It takes priority over both the registry and AssertUiEnabled so that
+	// developer machines with the registry key set never pop dialogs during tests.
+	const char* pTestMode = getenv("FW_TEST_MODE");
+	if (pTestMode && strcasecmp(pTestMode, "1") == 0)
+		return false;
+
 #if defined(WIN32) || defined(WIN64)
 	HKEY hk;
 	if (::RegOpenKeyEx(HKEY_LOCAL_MACHINE, "Software\\SIL\\FieldWorks", 0,
@@ -304,15 +323,6 @@ bool GetShowAssertMessageBox()
 		if (ret == ERROR_SUCCESS)
 			return fShowAssertMessageBox ? true : false; // otherwise we get a performance warning
 	}
-// getenv is deprecated on Windows
-#pragma warning(push)
-#pragma warning(disable: 4996)
-
-// Windows doesn't know strcasecmp, it calls it stricmp instead...
-#ifndef strcasecmp
-#define strcasecmp stricmp
-#endif
-
 #endif // WIN32
 	const char* pEnvVar = getenv("AssertUiEnabled");
 	return !pEnvVar ||
@@ -580,6 +590,11 @@ void __cdecl SilAssert (
 		g_ReportHook(_CRT_ASSERT, assertbuf);
 	else
 		OutputDebugString(assertbuf);
+
+	// Always mirror assertion text to the process error stream so test runners,
+	// humans, and automation can see the failure details without a debugger.
+	fprintf(stderr, "%s\n", assertbuf);
+	fflush(stderr);
 
 	// NOTE: this method is intented to be used by unmanaged apps only;
 	// managed apps should use DebugProcs.AssertProc in DebugProcs.cs

--- a/Src/DebugProcs/DebugProcs.cpp
+++ b/Src/DebugProcs/DebugProcs.cpp
@@ -677,11 +677,14 @@ void __cdecl SilAssert (
 	else // !g_fShowMessageBox
 	{
 		// if we don't show a message box we should at least abort (and output the assertion
-		// text if we haven't done that already). Note that we don't call _exit(3) as above
-		// so that we can trap the signal and ignore it in unit tests
+		// text if we haven't done that already). In FW_TEST_MODE we must not continue after
+		// a post-summary assert even if SIGABRT is ignored or intercepted by the native test
+		// runner, so force process termination if raise(SIGABRT) returns.
 		if (g_ReportHook)
 			OutputDebugString(assertbuf);
 		raise(SIGABRT);
+		if (IsTestModeEnabled())
+			_exit(3);
 	}
 
 	/* Ignore: continue execution */

--- a/Src/Generic/Test/TestErrorHandling.h
+++ b/Src/Generic/Test/TestErrorHandling.h
@@ -15,6 +15,8 @@ Last reviewed:
 #pragma once
 
 #include "testGenericLib.h"
+#include <stdexcept>
+#include <string>
 
 namespace TestGenericLib
 {
@@ -151,6 +153,31 @@ namespace TestGenericLib
 				unitpp::assert_true("CheckHr didn't clean error info", !qerrinfo);
 				unitpp::assert_true("No error info in exception", thr.GetErrorInfo());
 			}
+#else
+			// TODO-Linux: port
+#endif
+		}
+
+		void testNativeAssertThrowsExceptionWithoutContinuing()
+		{
+#if defined(WIN32) || defined(_M_X64)
+			bool fReachedAfterAssert = false;
+			try
+			{
+				AssertMsg(false, "Test-induced native assert");
+				fReachedAfterAssert = true;
+				unitpp::assert_fail("Assert did not throw an exception in native test mode");
+			}
+			catch (const std::runtime_error & e)
+			{
+				std::string message(e.what());
+				unitpp::assert_true(
+					"Native assert produced wrong exception text",
+					message.find("Test-induced native assert") != std::string::npos
+				);
+			}
+
+			unitpp::assert_true("Execution continued after native assert", !fReachedAfterAssert);
 #else
 			// TODO-Linux: port
 #endif

--- a/Src/Generic/Test/TestGeneric.vcxproj
+++ b/Src/Generic/Test/TestGeneric.vcxproj
@@ -86,6 +86,7 @@
         $(FwRoot)\Include;
         $(FwRoot)\Src\Generic;
         $(FwRoot)\Src\Generic\Test;
+        $(FwRoot)\Src\DebugProcs;
         $(FwRoot)\Output\$(Configuration);
         $(FwRoot)\Output\$(Configuration)\Common;
         $(IntDir);

--- a/Src/Generic/Test/testGeneric.cpp
+++ b/Src/Generic/Test/testGeneric.cpp
@@ -11,11 +11,13 @@ Last reviewed:
 -------------------------------------------------------------------------------*//*:End Ignore*/
 #include "testGenericLib.h"
 #include "RedirectHKCU.h"
+#include "DebugProcs.h"
 
 namespace unitpp
 {
 	void GlobalSetup(bool verbose)
 	{
+		ShowAssertMessageBox(0); // Disable assertion dialogs
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_ATTACH);
 #endif

--- a/Src/Generic/Test/testGeneric.cpp
+++ b/Src/Generic/Test/testGeneric.cpp
@@ -12,11 +12,62 @@ Last reviewed:
 #include "testGenericLib.h"
 #include "RedirectHKCU.h"
 #include "DebugProcs.h"
+#include <cstdlib>
+#include <cstring>
+#include <csignal>
+#include <stdexcept>
+
+namespace
+{
+	Pfn_Assert g_previousAssertProc = NULL;
+
+	void RestorePreviousAssertProc()
+	{
+		if (g_previousAssertProc != NULL)
+		{
+			SetAssertProc(g_previousAssertProc);
+			g_previousAssertProc = NULL;
+		}
+	}
+
+	void TerminateOnSigAbrt(int)
+	{
+		TerminateProcess(GetCurrentProcess(), 3);
+	}
+
+	bool IsFailureInjectionEnabled(const char * pszName)
+	{
+		size_t cchValue = 0;
+		char * pszValue = NULL;
+		const bool fEnabled =
+			_dupenv_s(&pszValue, &cchValue, pszName) == 0 &&
+			pszValue != NULL &&
+			strcmp(pszValue, "1") == 0;
+		free(pszValue);
+		return fEnabled;
+	}
+
+	void WINAPI ThrowingAssertProc(const char * pszExp, const char * pszFile, int nLine, HMODULE)
+	{
+		char szMessage[1024];
+		sprintf_s(
+			szMessage,
+			"Native assert fired during test: %s (%s:%d)",
+			pszExp,
+			pszFile,
+			nLine
+		);
+		fprintf(stderr, "%s\n", szMessage);
+		fflush(stderr);
+		throw std::runtime_error(szMessage);
+	}
+}
 
 namespace unitpp
 {
 	void GlobalSetup(bool verbose)
 	{
+		g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
 		ShowAssertMessageBox(0); // Disable assertion dialogs
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_ATTACH);
@@ -27,10 +78,29 @@ namespace unitpp
 	}
 	void GlobalTeardown()
 	{
+		signal(SIGABRT, TerminateOnSigAbrt);
+
+		const bool fInjectTeardownAssert = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
+		const bool fInjectTeardownAbort = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
+		if (fInjectTeardownAssert || fInjectTeardownAbort)
+			RestorePreviousAssertProc();
+
+		if (fInjectTeardownAssert)
+			AssertMsg(false, "Injected teardown assert for native test infrastructure validation");
+
+		if (fInjectTeardownAbort)
+		{
+			_set_error_mode(_OUT_TO_STDERR);
+			_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+			abort();
+		}
+
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_DETACH);
 #endif
 		::OleUninitialize();
+
+		RestorePreviousAssertProc();
 	}
 }
 

--- a/Src/Generic/Test/testGeneric.cpp
+++ b/Src/Generic/Test/testGeneric.cpp
@@ -35,7 +35,7 @@ namespace
 		TerminateProcess(GetCurrentProcess(), 3);
 	}
 
-	bool IsFailureInjectionEnabled(const char * pszName)
+	bool IsEnvironmentSwitchEnabled(const char * pszName)
 	{
 		size_t cchValue = 0;
 		char * pszValue = NULL;
@@ -67,8 +67,15 @@ namespace unitpp
 {
 	void GlobalSetup(bool verbose)
 	{
-		g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
-		ShowAssertMessageBox(0); // Disable assertion dialogs
+		if (IsEnvironmentSwitchEnabled("FW_TEST_ALLOW_ASSERT_DIALOGS"))
+		{
+			ShowAssertMessageBox(1);
+		}
+		else
+		{
+			g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
+			ShowAssertMessageBox(0); // Disable assertion dialogs
+		}
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_ATTACH);
 #endif
@@ -80,8 +87,8 @@ namespace unitpp
 	{
 		signal(SIGABRT, TerminateOnSigAbrt);
 
-		const bool fInjectTeardownAssert = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
-		const bool fInjectTeardownAbort = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
+		const bool fInjectTeardownAssert = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
+		const bool fInjectTeardownAbort = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
 		if (fInjectTeardownAssert || fInjectTeardownAbort)
 			RestorePreviousAssertProc();
 

--- a/Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj
+++ b/Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj
@@ -53,5 +53,8 @@
     <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\LogUnhandledExceptionsAttribute.cs">
       <Link>Attributes\LogUnhandledExceptionsAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\SuppressAssertDialogsAttribute.cs">
+      <Link>Attributes\SuppressAssertDialogsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj
+++ b/Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj
@@ -50,5 +50,8 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\LogUnhandledExceptionsAttribute.cs">
+      <Link>Attributes\LogUnhandledExceptionsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Src/InstallValidator/InstallValidatorTests/TestAssemblyInfo.cs
+++ b/Src/InstallValidator/InstallValidatorTests/TestAssemblyInfo.cs
@@ -5,3 +5,4 @@
 using SIL.FieldWorks.Common.FwUtils.Attributes;
 
 [assembly: LogUnhandledExceptions]
+[assembly: SuppressAssertDialogs]

--- a/Src/InstallValidator/InstallValidatorTests/TestAssemblyInfo.cs
+++ b/Src/InstallValidator/InstallValidatorTests/TestAssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using SIL.FieldWorks.Common.FwUtils.Attributes;
+
+[assembly: LogUnhandledExceptions]

--- a/Src/InstallValidator/InstallerArtifactsTests/InstallerArtifactsTests.csproj
+++ b/Src/InstallValidator/InstallerArtifactsTests/InstallerArtifactsTests.csproj
@@ -38,5 +38,8 @@
     <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\LogUnhandledExceptionsAttribute.cs">
       <Link>Attributes\LogUnhandledExceptionsAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\SuppressAssertDialogsAttribute.cs">
+      <Link>Attributes\SuppressAssertDialogsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Src/InstallValidator/InstallerArtifactsTests/InstallerArtifactsTests.csproj
+++ b/Src/InstallValidator/InstallerArtifactsTests/InstallerArtifactsTests.csproj
@@ -29,8 +29,14 @@
     <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="../../AppForTests.config" Link="App.config" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\FwUtils\FwUtilsTests\Attributes\LogUnhandledExceptionsAttribute.cs">
+      <Link>Attributes\LogUnhandledExceptionsAttribute.cs</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/Src/InstallValidator/InstallerArtifactsTests/TestAssemblyInfo.cs
+++ b/Src/InstallValidator/InstallerArtifactsTests/TestAssemblyInfo.cs
@@ -5,3 +5,4 @@
 using SIL.FieldWorks.Common.FwUtils.Attributes;
 
 [assembly: LogUnhandledExceptions]
+[assembly: SuppressAssertDialogs]

--- a/Src/InstallValidator/InstallerArtifactsTests/TestAssemblyInfo.cs
+++ b/Src/InstallValidator/InstallerArtifactsTests/TestAssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using SIL.FieldWorks.Common.FwUtils.Attributes;
+
+[assembly: LogUnhandledExceptions]

--- a/Src/views/Test/testViews.cpp
+++ b/Src/views/Test/testViews.cpp
@@ -15,11 +15,61 @@ Last reviewed:
 #include "testViews.h"
 #include "RedirectHKCU.h"
 #include "DebugProcs.h"
+#include <cstdlib>
+#include <cstring>
+#include <csignal>
+#include <stdexcept>
 #if !defined(WIN32) && !defined(_M_X64)
 // These define GUIDs that we need to define globally somewhere
 #include "TestVwTxtSrc.h"
 #include "TestLayoutPage.h"
 #endif
+
+namespace
+{
+	Pfn_Assert g_previousAssertProc = NULL;
+
+	void RestorePreviousAssertProc()
+	{
+		if (g_previousAssertProc != NULL)
+		{
+			SetAssertProc(g_previousAssertProc);
+			g_previousAssertProc = NULL;
+		}
+	}
+
+	void TerminateOnSigAbrt(int)
+	{
+		TerminateProcess(GetCurrentProcess(), 3);
+	}
+
+	bool IsFailureInjectionEnabled(const char * pszName)
+	{
+		size_t cchValue = 0;
+		char * pszValue = NULL;
+		const bool fEnabled =
+			_dupenv_s(&pszValue, &cchValue, pszName) == 0 &&
+			pszValue != NULL &&
+			strcmp(pszValue, "1") == 0;
+		free(pszValue);
+		return fEnabled;
+	}
+
+	void WINAPI ThrowingAssertProc(const char * pszExp, const char * pszFile, int nLine, HMODULE)
+	{
+		char szMessage[1024];
+		sprintf_s(
+			szMessage,
+			"Native assert fired during test: %s (%s:%d)",
+			pszExp,
+			pszFile,
+			nLine
+		);
+		fprintf(stderr, "%s\n", szMessage);
+		fflush(stderr);
+		throw std::runtime_error(szMessage);
+	}
+}
 
 namespace unitpp
 {
@@ -27,6 +77,7 @@ namespace unitpp
 	{
 		printf("DEBUG: Entering GlobalSetup\n");
 		fflush(stdout);
+		g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
 		ShowAssertMessageBox(0); // Disable assertion dialogs
 		printf("DEBUG: After ShowAssertMessageBox\n");
 		fflush(stdout);
@@ -48,10 +99,29 @@ namespace unitpp
 	}
 	void GlobalTeardown()
 	{
+		signal(SIGABRT, TerminateOnSigAbrt);
+
+		const bool fInjectTeardownAssert = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
+		const bool fInjectTeardownAbort = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
+		if (fInjectTeardownAssert || fInjectTeardownAbort)
+			RestorePreviousAssertProc();
+
+		if (fInjectTeardownAssert)
+			AssertMsg(false, "Injected teardown assert for native test infrastructure validation");
+
+		if (fInjectTeardownAbort)
+		{
+			_set_error_mode(_OUT_TO_STDERR);
+			_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+			abort();
+		}
+
 		::OleUninitialize();
 #if defined(WIN32) || defined(_M_X64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_DETACH);
 #endif
+
+		RestorePreviousAssertProc();
 	}
 }
 

--- a/Src/views/Test/testViews.cpp
+++ b/Src/views/Test/testViews.cpp
@@ -43,7 +43,7 @@ namespace
 		TerminateProcess(GetCurrentProcess(), 3);
 	}
 
-	bool IsFailureInjectionEnabled(const char * pszName)
+	bool IsEnvironmentSwitchEnabled(const char * pszName)
 	{
 		size_t cchValue = 0;
 		char * pszValue = NULL;
@@ -77,8 +77,15 @@ namespace unitpp
 	{
 		printf("DEBUG: Entering GlobalSetup\n");
 		fflush(stdout);
-		g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
-		ShowAssertMessageBox(0); // Disable assertion dialogs
+		if (IsEnvironmentSwitchEnabled("FW_TEST_ALLOW_ASSERT_DIALOGS"))
+		{
+			ShowAssertMessageBox(1);
+		}
+		else
+		{
+			g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
+			ShowAssertMessageBox(0); // Disable assertion dialogs
+		}
 		printf("DEBUG: After ShowAssertMessageBox\n");
 		fflush(stdout);
 #if defined(WIN32) || defined(_M_X64)
@@ -101,8 +108,8 @@ namespace unitpp
 	{
 		signal(SIGABRT, TerminateOnSigAbrt);
 
-		const bool fInjectTeardownAssert = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
-		const bool fInjectTeardownAbort = IsFailureInjectionEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
+		const bool fInjectTeardownAssert = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
+		const bool fInjectTeardownAbort = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
 		if (fInjectTeardownAssert || fInjectTeardownAbort)
 			RestorePreviousAssertProc();
 

--- a/Test.runsettings
+++ b/Test.runsettings
@@ -50,6 +50,9 @@
 
       <!-- Prefer a failing test over a modal dialog or silent continue -->
       <AssertExceptionEnabled>true</AssertExceptionEnabled>
+
+      <!-- Unconditional test-mode override: bypasses registry AssertMessageBox key -->
+      <FW_TEST_MODE>1</FW_TEST_MODE>
     </EnvironmentVariables>
   </RunConfiguration>
 

--- a/test.ps1
+++ b/test.ps1
@@ -32,6 +32,10 @@
 .PARAMETER SkipManaged
 	Run only native C++ tests, skipping managed tests.
 
+.PARAMETER AllowAssertDialogs
+	Allow FieldWorks Abort/Retry/Ignore assertion dialogs during this local test run.
+	Equivalent environment variable: FW_TEST_ALLOW_ASSERT_DIALOGS=1.
+
 .PARAMETER StartedBy
 	Optional actor label written to worktree lock metadata (for example: user or agent).
 	Defaults to FW_BUILD_STARTED_BY if set; otherwise 'unknown'.
@@ -56,6 +60,15 @@
 	.\test.ps1 -NoBuild -Verbosity detailed
 	Runs tests without building first, with detailed output.
 
+.EXAMPLE
+	.\test.ps1 -SkipManaged -TestProject TestGeneric -AllowAssertDialogs
+	Runs TestGeneric with interactive FieldWorks assertion dialogs enabled for debugger attachment.
+
+.EXAMPLE
+	$env:FW_TEST_ALLOW_ASSERT_DIALOGS = '1'
+	.\test.ps1 -SkipManaged -TestProject TestGeneric
+	Uses the environment variable equivalent of -AllowAssertDialogs. Clear the variable after debugging.
+
 .NOTES
 	FieldWorks is x64-only. Tests run in 64-bit mode.
 #>
@@ -70,6 +83,7 @@ param(
 	[string]$Verbosity = "normal",
 	[switch]$SkipNative,
 	[switch]$SkipManaged,
+	[switch]$AllowAssertDialogs,
 	[switch]$SkipDependencyCheck,
 	[switch]$SkipWorktreeLock,
 	[ValidateSet('user', 'agent', 'unknown')]
@@ -95,6 +109,77 @@ if (-not (Test-Path $helpersPath)) {
 	exit 1
 }
 Import-Module $helpersPath -Force
+
+function Test-EnvironmentSwitchEnabled {
+	param(
+		[string]$Name
+	)
+
+	$value = [Environment]::GetEnvironmentVariable($Name)
+	if ([string]::IsNullOrWhiteSpace($value)) {
+		return $false
+	}
+
+	return @('1', 'true', 'yes', 'on') -contains $value.Trim().ToLowerInvariant()
+}
+
+function Set-TestAssertDialogEnvironment {
+	param(
+		[bool]$AllowDialogs
+	)
+
+	if ($AllowDialogs) {
+		$env:AssertUiEnabled = 'true'
+		$env:AssertExceptionEnabled = 'false'
+		$env:FW_TEST_MODE = '0'
+		$env:FW_TEST_ALLOW_ASSERT_DIALOGS = '1'
+		return
+	}
+
+	$env:AssertUiEnabled = 'false'
+	$env:AssertExceptionEnabled = 'true'
+	$env:FW_TEST_MODE = '1'
+}
+
+function New-TestRunSettingsForAssertDialogMode {
+	param(
+		[string]$SourcePath,
+		[string]$Configuration,
+		[bool]$AllowDialogs
+	)
+
+	if (-not $AllowDialogs) {
+		return $SourcePath
+	}
+
+	[xml]$runSettings = Get-Content -LiteralPath $SourcePath -Raw
+	$environmentVariables = $runSettings.RunSettings.RunConfiguration.EnvironmentVariables
+	$environmentVariables.AssertUiEnabled = 'true'
+	$environmentVariables.AssertExceptionEnabled = 'false'
+	$environmentVariables.FW_TEST_MODE = '0'
+
+	$allowNode = $environmentVariables.FW_TEST_ALLOW_ASSERT_DIALOGS
+	if ($allowNode) {
+		$allowNode = $environmentVariables.SelectSingleNode('FW_TEST_ALLOW_ASSERT_DIALOGS')
+		$allowNode.InnerText = '1'
+	}
+	else {
+		$allowNode = $runSettings.CreateElement('FW_TEST_ALLOW_ASSERT_DIALOGS')
+		$allowNode.InnerText = '1'
+		[void]$environmentVariables.AppendChild($allowNode)
+	}
+
+	$runSettingsDir = Join-Path $PSScriptRoot "Output/$Configuration"
+	if (-not (Test-Path $runSettingsDir)) {
+		New-Item -ItemType Directory -Force -Path $runSettingsDir | Out-Null
+	}
+
+	$runSettingsPath = Join-Path $runSettingsDir 'Test.allow-assert-dialogs.runsettings'
+	$runSettings.Save($runSettingsPath)
+	return $runSettingsPath
+}
+
+$allowAssertDialogsForRun = $AllowAssertDialogs -or (Test-EnvironmentSwitchEnabled -Name 'FW_TEST_ALLOW_ASSERT_DIALOGS')
 
 function Add-UniquePath {
 	param(
@@ -234,6 +319,11 @@ try {
 		# Set architecture (x64-only)
 		$env:arch = 'x64'
 
+		Set-TestAssertDialogEnvironment -AllowDialogs $allowAssertDialogsForRun
+		if ($allowAssertDialogsForRun) {
+			Write-Host "[WARN] Interactive assertion dialogs are enabled for this local test run." -ForegroundColor Yellow
+		}
+
 		# Stop conflicting processes
 		Stop-ConflictingProcesses @cleanupArgs
 
@@ -274,7 +364,15 @@ try {
 			$overallExitCode = 0
 			foreach ($proj in $projectsToRun) {
 				Write-Host "Dispatching $proj to Invoke-CppTest.ps1..." -ForegroundColor Cyan
-				& $cppScript -Action $action -TestProject $proj -Configuration $Configuration
+				$cppTestArgs = @{
+					Action = $action
+					TestProject = $proj
+					Configuration = $Configuration
+				}
+				if ($allowAssertDialogsForRun) {
+					$cppTestArgs.AllowAssertDialogs = $true
+				}
+				& $cppScript @cppTestArgs
 				if ($LASTEXITCODE -ne 0) {
 					$overallExitCode = $LASTEXITCODE
 					$message = "$proj failed with exit code $LASTEXITCODE"
@@ -379,10 +477,8 @@ try {
 
 		# FieldWorks native + managed assertion infrastructure may show modal UI unless
 		# explicitly disabled. Ensure the test host inherits these settings even when
-		# invoked outside the .runsettings flow.
-		$env:AssertUiEnabled = 'false'
-		$env:AssertExceptionEnabled = 'true'
-		$env:FW_TEST_MODE = '1'
+		# invoked outside the .runsettings flow, unless a local debugging run opted back in.
+		Set-TestAssertDialogEnvironment -AllowDialogs $allowAssertDialogsForRun
 
 		$outputDir = Join-Path $PSScriptRoot "Output/$Configuration"
 
@@ -540,7 +636,11 @@ try {
 			}
 		}
 
-		$runSettingsPath = Join-Path $PSScriptRoot "Test.runsettings"
+		$runSettingsSourcePath = Join-Path $PSScriptRoot "Test.runsettings"
+		$runSettingsPath = New-TestRunSettingsForAssertDialogMode `
+			-SourcePath $runSettingsSourcePath `
+			-Configuration $Configuration `
+			-AllowDialogs $allowAssertDialogsForRun
 
 		$vstestArgs = @()
 		$vstestArgs += $testDlls

--- a/test.ps1
+++ b/test.ps1
@@ -297,7 +297,7 @@ try {
 		# =============================================================================
 
 		if (-not $NoBuild) {
-			$normalizedTestProjectForBuild = $TestProject.Replace('\\', '/').TrimEnd('/')
+			$normalizedTestProjectForBuild = $TestProject.Replace('\', '/').TrimEnd('/')
 
 			if ($TestProject -and ($normalizedTestProjectForBuild -match '^Build/Src/FwBuildTasks($|/)' -or $normalizedTestProjectForBuild -match '/FwBuildTasksTests$' -or $normalizedTestProjectForBuild -match '^FwBuildTasksTests$')) {
 				Write-Host "Building FwBuildTasks before running tests..." -ForegroundColor Cyan
@@ -337,6 +337,23 @@ try {
 					-Description 'FwBuildTasks (Tests)'
 				Write-Host ""
 			}
+			elseif ($TestProject -and ($normalizedTestProjectForBuild -match '(^|/)Src/InstallValidator/InstallValidatorTests($|/InstallValidatorTests\.csproj$)')) {
+				Write-Host "Building InstallValidatorTests before running tests..." -ForegroundColor Cyan
+
+				Invoke-MSBuild `
+					-Arguments @(
+						'Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj',
+						'/t:Restore;Build',
+						"/p:Configuration=$Configuration",
+						'/p:Platform=x64',
+						'/nr:false',
+						'/v:minimal',
+						'/nologo'
+					) `
+					-Description 'InstallValidatorTests'
+
+				Write-Host ""
+			}
 			else {
 				Write-Host "Building before running tests..." -ForegroundColor Cyan
 				# This nested call runs while test.ps1 already owns the same-worktree lock.
@@ -370,7 +387,7 @@ try {
 		$outputDir = Join-Path $PSScriptRoot "Output/$Configuration"
 
 		if ($TestProject) {
-			$normalizedTestProject = $TestProject.Replace('\\', '/').TrimEnd('/')
+			$normalizedTestProject = $TestProject.Replace('\', '/').TrimEnd('/')
 
 			# Specific project/DLL requested
 			if ($normalizedTestProject -match '^Build/Src/FwBuildTasks($|/)' -or $normalizedTestProject -match '/FwBuildTasksTests$' -or $normalizedTestProject -match '^FwBuildTasksTests$') {
@@ -384,6 +401,9 @@ try {
 			else {
 				# Assume it's a project path, find the DLL
 				$projectName = Split-Path $TestProject -Leaf
+				if ($projectName -match '\.csproj$') {
+					$projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectName)
+				}
 				if ($projectName -notmatch 'Tests?$') {
 					$projectName = "${projectName}Tests"
 				}

--- a/test.ps1
+++ b/test.ps1
@@ -335,7 +335,6 @@ try {
 						'/nologo'
 					) `
 					-Description 'FwBuildTasks (Tests)'
-
 				Write-Host ""
 			}
 			else {
@@ -366,6 +365,7 @@ try {
 		# invoked outside the .runsettings flow.
 		$env:AssertUiEnabled = 'false'
 		$env:AssertExceptionEnabled = 'true'
+		$env:FW_TEST_MODE = '1'
 
 		$outputDir = Join-Path $PSScriptRoot "Output/$Configuration"
 


### PR DESCRIPTION
## Summary
FieldWorks tests were still inheriting interactive desktop assertion behavior from both native and managed code paths, so some failures could block the run with modal popups instead of surfacing as ordinary test failures. Those popups exist for a legitimate reason in normal developer debugging: they force attention, allow debugger attachment, and prevent silent continuation after a serious assertion. This change keeps that interactive behavior for normal app runs, but makes test runs explicitly non-interactive, fail-fast, and diagnosable across the managed runner, native runner, shared test bootstrap, and projects that opt out of the shared bootstrap.

## What Was Happening
This PR addresses a class of test failures where the process did not simply fail the test and continue. Instead, some failures flowed through existing desktop-era assertion and exception infrastructure that was designed for an interactive developer sitting at the machine.

In practice there were two main problem paths:
- native C++ assertions could route through `DebugProcs.dll` and show a Windows `Abort/Retry/Ignore` message box
- managed assertions and last-chance exceptions could surface through trace listeners or WinForms exception hooks rather than as a clean, visible test failure

That behavior is acceptable for interactive local debugging, but it is the wrong default for unattended test runs and CI because a popup can block the entire run indefinitely.

## Why Popups Exist At All
The popup behavior is not accidental. FieldWorks is a long-lived Windows desktop application with native and managed components, and modal assertion UI is useful during manual debugging because it:
- immediately stops the developer on a serious failure
- offers a debugger-friendly path instead of silently swallowing the problem
- avoids continuing execution after state may already be invalid

So the goal here is not to remove that behavior from the product globally. The goal is to prevent test runs from inheriting it.

## Why This Fix Uses Several Layers
A single switch was not enough because tests in this repository cross several boundaries:
- PowerShell test runners
- `.runsettings`
- assembly-level NUnit bootstrap
- some test projects that do not use the shared bootstrap/config path
- managed code
- native code

If only one layer is changed, another entry point can still pop UI or lose useful failure information. This fix therefore applies the same policy at each boundary: test runs must never block on modal UI, and failures must still be visible in logs.

## What This Change Does
### 1. Mark test runs explicitly as test mode
The runners now set `AssertUiEnabled=false`, `AssertExceptionEnabled=true`, and `FW_TEST_MODE=1` so tests always opt into non-interactive behavior, even when invoked outside the normal `.runsettings` path.

### 2. Give native test mode absolute priority
`DebugProcs.dll` now treats `FW_TEST_MODE=1` as an unconditional override, ahead of the registry-based `AssertMessageBox` setting. This matters because some developer machines may have local registry settings that are reasonable for manual debugging but unacceptable for automated tests.

### 3. Preserve diagnostics instead of only suppressing UI
Suppressing the popup alone would be a partial fix because it can trade a visible hang for an opaque failure. In test mode, native assertion text is mirrored to `stderr`, managed `Debug.Fail` paths are surfaced to `Console.Error`, and last-chance managed exceptions are logged so the reason for failure is still visible in unattended runs.

### 4. Fail deterministically instead of crashing unpredictably
For unobserved task exceptions, the implementation does not throw directly from `TaskScheduler.UnobservedTaskException`. Instead it logs the failure, marks it observed, captures it, and fails once during suite teardown so the test host fails deterministically rather than crashing from the finalizer thread.

### 5. Cover projects outside the shared bootstrap path
Some installer-related projects and other test assemblies do not fully rely on the shared test bootstrap/config arrangement. This PR explicitly applies the same assert-dialog suppression and last-chance exception logging behavior there as well, so the fix does not depend on one particular project layout.

## Why This Is The Best Path
This is the best path because it fixes the root cause without degrading normal developer workflows.

Other approaches were weaker:
- only removing the popup in one native call site would miss managed paths and other entry points
- only changing `.runsettings` would miss tests launched outside that flow
- globally removing assertion UI from the product would make manual debugging worse for developers
- simply swallowing failures would avoid hangs but lose the information needed to diagnose them

The chosen approach keeps the useful desktop-debugging behavior for ordinary app runs while making tests explicitly non-interactive, fail-fast, and readable.

## Design Tradeoffs
There are a few intentional tradeoffs here:
- More plumbing, less surprise: the fix touches runner, config, assembly bootstrap, and native assertion code because that is what complete coverage requires in a mixed native/managed desktop codebase.
- Test-only behavior, not global behavior: `FW_TEST_MODE` scopes the behavior to automated runs instead of changing the product’s debugging experience for everyone.
- Visible failure over silent continuation: when an assertion or last-chance exception occurs during tests, the design prefers clear console output and deterministic failure rather than quiet continuation.
- Deterministic teardown failure over finalizer-thread throw: this is slightly more code, but it is much safer and easier to understand in CI logs.

## Validation
- `./build.ps1`
- `./test.ps1`
- `./test.ps1 -Native`

## Additional Validation
- `./test.ps1 -TestProject "Src/InstallValidator/InstallValidatorTests/InstallValidatorTests.csproj"`
- `./test.ps1 -Native -TestProject TestGeneric`
- `./test.ps1 -Native -TestProject TestViews`

## Notes
- managed test suite passed across 43 test assemblies
- native test executables passed: `testGenericLib.exe` and `TestViews.exe`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/745)
<!-- Reviewable:end -->