### PR TITLE
Installer: add prerequisites alias for vcredists

### DIFF
--- a/FLExInstaller/Redistributables.wxi
+++ b/FLExInstaller/Redistributables.wxi
@@ -27,6 +27,10 @@
 			<PackageGroupRef Id="redist_vc15to19" />
 			<PackageGroupRef Id="FlexBridgeInstaller" />
 		</PackageGroup>
+		<!-- Backward-compatible alias for older bundle authoring. -->
+		<PackageGroup Id="prerequisites">
+			<PackageGroupRef Id="vcredists" />
+		</PackageGroup>
 	</Fragment>
 </Include>
 <!--

--- a/FLExInstaller/wix6/Redistributables.wxi
+++ b/FLExInstaller/wix6/Redistributables.wxi
@@ -27,6 +27,10 @@
 			<PackageGroupRef Id="redist_vc15to19" />
 			<PackageGroupRef Id="FlexBridgeInstaller" />
 		</PackageGroup>
+		<!-- Backward-compatible alias for older bundle authoring. -->
+		<PackageGroup Id="prerequisites">
+			<PackageGroupRef Id="vcredists" />
+		</PackageGroup>
 	</Fragment>
 </Include>
 <!--

--- a/FLExInstaller/wix6/Shared/Common/Redistributables.wxi
+++ b/FLExInstaller/wix6/Shared/Common/Redistributables.wxi
@@ -27,6 +27,10 @@
 		<PackageGroupRef Id="redist_vc15to19" />
 		<PackageGroupRef Id="FlexBridgeInstaller" />
 	</PackageGroup>
+	<!-- Backward-compatible alias for older bundle authoring. -->
+	<PackageGroup Id="prerequisites">
+		<PackageGroupRef Id="vcredists" />
+	</PackageGroup>
 	</Fragment>
 </Include>
 <!--


### PR DESCRIPTION
## Summary
- add a backward-compatible `prerequisites` package-group alias that forwards to `vcredists`
- apply the alias in the tracked redistributables include files used by legacy WiX 3 and WiX 6 installer authoring
- prevent stale bundle references from breaking installer builds when older authoring still refers to `prerequisites`

## Verification
- `./Build/Agent/check-and-fix-whitespace.ps1`
- `./Build/Agent/commit-messages.ps1`
- `.\build.ps1 -BuildInstaller -Configuration Release`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/820)
<!-- Reviewable:end -->
