### PR TITLE
Centralize shared Build/Src package versions

### DIFF
--- a/Build/Src/Directory.Packages.props
+++ b/Build/Src/Directory.Packages.props
@@ -5,8 +5,17 @@
 		NuGet auto-imports only the nearest Directory.Packages.props, so parent CPM
 		settings must be imported manually.
 	-->
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)..'))" />
+	<PropertyGroup>
+		<RootDirectoryPackagesProps>$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)..'))</RootDirectoryPackagesProps>
+	</PropertyGroup>
 
+	<Import Project="$(RootDirectoryPackagesProps)" Condition="Exists('$(RootDirectoryPackagesProps)')" />
+
+	<Target Name="EnsureRootDirectoryPackagesPropsExists" BeforeTargets="CollectPackageReferences" Condition="'$(RootDirectoryPackagesProps)' == '' Or !Exists('$(RootDirectoryPackagesProps)')">
+		<Error Text="Unable to locate the repo root Directory.Packages.props for Build/Src. Expected to find a parent Directory.Packages.props above '$(MSBuildThisFileDirectory)'. Ensure the root CPM file exists and has not been renamed or omitted from the current source checkout." />
+	</Target>
+
+	<!-- Use Update for root-pinned packages and Include for build-only packages absent from the root CPM file. -->
 	<ItemGroup Label="Build Tool Package Versions">
 		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
 		<PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />

--- a/Build/Src/Directory.Packages.props
+++ b/Build/Src/Directory.Packages.props
@@ -1,12 +1,17 @@
 <Project>
-	<PropertyGroup>
-		<!--
-			Build infrastructure projects (FwBuildTasks, NativeBuild) manage their own
-			package versions independently. They do not contribute assemblies to the
-			shared Output/ directory, so CPM transitive pinning does not apply here.
-			FwBuildTasks also requires different versions of test infrastructure packages
-			(NUnit3TestAdapter 5.2.0, SIL.TestUtilities 12.0.0-*) than the main codebase.
-		-->
-		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-	</PropertyGroup>
+	<!--
+		Build/Src uses the repo root CPM file as its baseline, then layers only the
+		few build-tool-specific deltas that genuinely differ from application code.
+		NuGet auto-imports only the nearest Directory.Packages.props, so parent CPM
+		settings must be imported manually.
+	-->
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)..'))" />
+
+	<ItemGroup Label="Build Tool Package Versions">
+		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
+		<PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+		<PackageVersion Update="NUnit3TestAdapter" Version="5.2.0" />
+		<PackageVersion Include="SIL.BuildTasks" Version="3.2.0" />
+		<PackageVersion Update="SIL.TestUtilities" Version="12.0.1" />
+	</ItemGroup>
 </Project>

--- a/Build/Src/FwBuildTasks/FwBuildTasks.csproj
+++ b/Build/Src/FwBuildTasks/FwBuildTasks.csproj
@@ -21,14 +21,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" PrivateAssets="All" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.BuildTasks" Version="3.2.0" />
-    <PackageReference Include="SIL.TestUtilities" Version="12.0.1" PrivateAssets="All" />
-    <PackageReference Include="System.Reflection.Metadata" Version="9.0.14" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.14" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
+    <PackageReference Include="NUnit" PrivateAssets="All" />
+    <PackageReference Include="NUnit3TestAdapter" PrivateAssets="All" />
+    <PackageReference Include="SIL.BuildTasks" />
+    <PackageReference Include="SIL.TestUtilities" PrivateAssets="All" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Resources.Extensions" />
     <Reference Include="netstandard" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="System.IO.Compression" />

--- a/Build/Src/NativeBuild/NativeBuild.csproj
+++ b/Build/Src/NativeBuild/NativeBuild.csproj
@@ -17,6 +17,8 @@
   <PropertyGroup>
     <Platform Condition="'$(Platform)'==''">x64</Platform>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <!-- NativeBuild keeps explicit package versions because it is a traditional MSBuild project. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- Set fwrt early so NuGet package restore can find packages -->
     <fwrt>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..'))</fwrt>
     <!--


### PR DESCRIPTION
## Summary
- Convert `Build/Src/Directory.Packages.props` from a CPM opt-out into a CPM overlay that imports the repo root `Directory.Packages.props`.
- Keep only the Build/Src-specific version deltas in that overlay for packages that intentionally differ from application code.
- Remove inline package versions from `Build/Src/FwBuildTasks/FwBuildTasks.csproj` so shared packages resolve from one central declaration.
- Explicitly keep `Build/Src/NativeBuild/NativeBuild.csproj` out of CPM because it is a traditional MSBuild project that still relies on explicit and property-driven package versions.

Why this is needed:
- FwBuildTasks was carrying explicit versions for packages that are also centrally pinned at the repo root.
- Dependabot bumped `System.Resources.Extensions` and `System.Reflection.Metadata` in `FwBuildTasks.csproj` without bringing the matching root pins along, which left duplicate shared-version declarations out of sync.
- Bootstrapping FwBuildTasks early does not require a separate source of truth for shared package versions; it only needs a reliable restore/build path.
- This keeps the intentional Build/Src-only differences while restoring a single declaration point for shared package versions.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
- Targeted validation completed:
  - `msbuild "Build\Src\FwBuildTasks\FwBuildTasks.csproj" /restore /t:Build /p:Configuration=Debug /p:Platform=x64 /p:FwBuildTasksOutputPath="BuildTools\FwBuildTasks\Debug\" /p:SkipFwBuildTasksAssemblyCheck=true /p:SkipFwBuildTasksUsingTask=true /p:SkipGenerateFwTargets=true /p:SkipSetupTargets=true`
  - `msbuild "Build\Src\NativeBuild\NativeBuild.csproj" /t:Restore /p:Configuration=Debug /p:Platform=x64 /p:SkipSetupTargets=true /p:SkipFwBuildTasksAssemblyCheck=true`
- I did not run a full repo build or the full local CI checklist for this narrow build-infrastructure change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/822)
<!-- Reviewable:end -->
