### PR TITLE
LT-22481: Fix FLEx Bridge installation

### DIFF
--- a/FLExInstaller/Redistributables.wxi
+++ b/FLExInstaller/Redistributables.wxi
@@ -11,7 +11,7 @@
 			<ExePackage Id="FBInstaller" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				  Name="FLExBridge_Offline.exe"
 				  SourceFile="..\libs\FLExBridge_Offline.exe"
-				  InstallCommand="/Q /norestart"
+				  InstallCommand="/Passive /norestart"
 				  DetectCondition="FLExBridge">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>

--- a/FLExInstaller/wix6/Redistributables.wxi
+++ b/FLExInstaller/wix6/Redistributables.wxi
@@ -11,7 +11,7 @@
 			<ExePackage Id="FBInstaller" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				  Name="FLExBridge_Offline.exe"
 				  SourceFile="..\libs\FLExBridge_Offline.exe"
-				  InstallCommand="/Q /norestart"
+				  InstallCommand="/Passive /norestart"
 				  DetectCondition="FLExBridge">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>

--- a/FLExInstaller/wix6/Shared/Common/Redistributables.wxi
+++ b/FLExInstaller/wix6/Shared/Common/Redistributables.wxi
@@ -11,7 +11,7 @@
 		<ExePackage Id="FBInstaller" Cache="remove" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				   Name="FLExBridge_Offline.exe"
 				   SourceFile="$(var.ProjectDir)libs\FLExBridge_Offline.exe"
-				   InstallArguments="/Q /norestart"
+				   InstallArguments="/Passive /norestart"
 				   DetectCondition="FLExBridge">
 			<ExitCode Value="0" Behavior="success" />
 			<ExitCode Value="1638" Behavior="success" />


### PR DESCRIPTION
Install FLEx Bridge Passively instead of Quietly to prevent the creation of C:\[DATAFOLDER]

genericinstaller requires the UI to be shown (even if not touched) to properly set installation directory paths (LT-20524, https://github.com/sillsdev/genericinstaller/issues/83)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/827)
<!-- Reviewable:end -->
