### PR TITLE
Fix LT-22475: The tab order is wrong for "Create and Edit" button

### DIFF
--- a/Src/LexText/LexTextControls/InsertEntryDlg.cs
+++ b/Src/LexText/LexTextControls/InsertEntryDlg.cs
@@ -843,6 +843,9 @@ namespace SIL.FieldWorks.LexText.Controls
 				// Display left-to-right: Create | CreateAndEdit | Cancel | Help
 				m_buttonPanel.Controls.Add(m_btnCreateAndEdit);
 				m_buttonPanel.Controls.SetChildIndex(m_btnCreateAndEdit, 2);
+				m_btnCreateAndEdit.TabIndex = m_btnCancel.TabIndex;
+				m_btnCancel.TabIndex++;
+				m_btnHelp.TabIndex++;
 			}
 			var morphComponents = MorphServices.BuildMorphComponents(cache, tssForm, MoMorphTypeTags.kguidMorphStem);
 			var morphType = morphComponents.MorphType;

--- a/Src/LexText/LexTextControls/InsertEntryDlg.cs
+++ b/Src/LexText/LexTextControls/InsertEntryDlg.cs
@@ -843,9 +843,6 @@ namespace SIL.FieldWorks.LexText.Controls
 				// Display left-to-right: Create | CreateAndEdit | Cancel | Help
 				m_buttonPanel.Controls.Add(m_btnCreateAndEdit);
 				m_buttonPanel.Controls.SetChildIndex(m_btnCreateAndEdit, 2);
-				m_btnCreateAndEdit.TabIndex = m_btnCancel.TabIndex;
-				m_btnCancel.TabIndex++;
-				m_btnHelp.TabIndex++;
 			}
 			var morphComponents = MorphServices.BuildMorphComponents(cache, tssForm, MoMorphTypeTags.kguidMorphStem);
 			var morphType = morphComponents.MorphType;

--- a/Src/LexText/LexTextControls/InsertEntryDlg.resx
+++ b/Src/LexText/LexTextControls/InsertEntryDlg.resx
@@ -171,6 +171,9 @@
   <data name="m_btnCreateAndEdit.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 25</value>
   </data>
+  <data name="m_btnCreateAndEdit.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="m_btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
@@ -181,7 +184,7 @@
     <value>80, 25</value>
   </data>
   <data name="m_btnCancel.TabIndex" type="System.Int32, mscorlib">
-	<value>5</value>
+	<value>6</value>
   </data>
   <data name="m_btnCancel.Text" xml:space="preserve">
 	<value>Cancel</value>
@@ -280,7 +283,7 @@
 	<value>80, 25</value>
   </data>
   <data name="m_btnHelp.TabIndex" type="System.Int32, mscorlib">
-	<value>6</value>
+	<value>7</value>
   </data>
   <data name="m_btnHelp.Text" xml:space="preserve">
 	<value>&amp;Help</value>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22475.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/828)
<!-- Reviewable:end -->
