### PR TITLE
Fix LT-22377: Inflection feature value changes after refreshing

### DIFF
--- a/Src/LexText/Lexicon/MsaInflectionFeatureListDlgLauncherView.cs
+++ b/Src/LexText/Lexicon/MsaInflectionFeatureListDlgLauncherView.cs
@@ -43,7 +43,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			}
 			else
 			{
-				m_rootb.SetRootObject(m_fs == null ? 0 : m_fs.Hvo, m_vc, (int)VcFrags.kfragName, m_rootb.Stylesheet);
+				m_rootb.SetRootObject(m_fs == null ? 0 : m_fs.Hvo, m_vc, (int)VcFrags.kfragShortName, m_rootb.Stylesheet);
 				m_rootb.Reconstruct();
 			}
 		}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22377.  The inflection feature was displayed incorrectly when it was set.  I changed the code to use the short name, just like the other places where inflection features are displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/829)
<!-- Reviewable:end -->
