### PR TITLE
Fix LT-19561: "Use Default Folder" button was truncated

### DIFF
--- a/Src/FwCoreDlgs/FwProjPropertiesDlg.resx
+++ b/Src/FwCoreDlgs/FwProjPropertiesDlg.resx
@@ -1864,10 +1864,10 @@
     <value>True</value>
   </data>
   <data name="linkLbl_useDefaultFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 255</value>
+    <value>155, 255</value>
   </data>
   <data name="linkLbl_useDefaultFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 13</value>
+    <value>195, 13</value>
   </data>
   <data name="linkLbl_useDefaultFolder.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-19561 by moving the button to the left so that it isn't clipped by the window.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/833)
<!-- Reviewable:end -->
