### PR TITLE
Skip native tests in CD

### DIFF
--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -156,7 +156,7 @@ jobs:
         id: build_and_test
         shell: powershell
         run: |
-          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -RunTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -RunTests -SkipNativeTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -225,7 +225,7 @@ jobs:
         shell: powershell
         run: |
           Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NETFramework\AppContext"
-          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -RunTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -RunTests -SkipNativeTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
 
       - name: Scan Build Output
         shell: powershell

--- a/build.ps1
+++ b/build.ps1
@@ -716,7 +716,7 @@ try {
 			$testArgs["TestFilter"] = $TestFilter
 		}
 		if ($SkipNative -or $SkipNativeTests) {
-			$testArgs["NoNative"] = $true
+			$testArgs["SkipNative"] = $true
 		}
 
 		Stop-ConflictingProcesses @cleanupArgs

--- a/build.ps1
+++ b/build.ps1
@@ -63,6 +63,9 @@
 .PARAMETER SkipNative
 	Skips building native C++ components. Use this for faster iterations when making purely managed code changes.
 
+.PARAMETER SkipNativeTests
+	Skips running tests for native C++ components. Does not skip building these tests. Implied by SkipNative.
+
 .PARAMETER ForceBuildBuildTasks
 	Buld FwBuildTasks even if FwBuildTasks.dll already exists. BuildTasks are rarely updated, so the default is not to build them.
 
@@ -161,6 +164,7 @@ param(
 	[int]$TailLines,
 	[switch]$SkipRestore,
 	[switch]$SkipNative,
+	[switch]$SkipNativeTests,
 	[switch]$ForceBuildBuildTasks,
 	[switch]$BuildInstaller,
 	[switch]$BuildPatch,
@@ -710,6 +714,9 @@ try {
 		}
 		if ($TestFilter) {
 			$testArgs["TestFilter"] = $TestFilter
+		}
+		if ($SkipNative -or $SkipNativeTests) {
+			$testArgs["NoNative"] = $true
 		}
 
 		Stop-ConflictingProcesses @cleanupArgs

--- a/test.ps1
+++ b/test.ps1
@@ -26,10 +26,10 @@
 	Test output verbosity: q[uiet], m[inimal], n[ormal], d[etailed].
 	Default is 'normal'.
 
-.PARAMETER NoNative
+.PARAMETER SkipNative
 	Skip running native C++ tests. Run only managed tests.
 
-.PARAMETER NativeOnly
+.PARAMETER SkipManaged
 	Run only native C++ tests, skipping managed tests.
 
 .PARAMETER StartedBy
@@ -68,8 +68,8 @@ param(
 	[switch]$ListTests,
 	[ValidateSet('quiet', 'minimal', 'normal', 'detailed', 'q', 'm', 'n', 'd')]
 	[string]$Verbosity = "normal",
-	[switch]$NoNative,
-	[switch]$NativeOnly,
+	[switch]$SkipNative,
+	[switch]$SkipManaged,
 	[switch]$SkipDependencyCheck,
 	[switch]$SkipWorktreeLock,
 	[ValidateSet('user', 'agent', 'unknown')]
@@ -148,7 +148,7 @@ try {
 		# =============================================================================
 
 		$script:nativeErrorMessages = @()
-		if (-not $NoNative) {
+		if (-not $SkipNative) {
 			$cppScript = Join-Path $PSScriptRoot "Build/scripts/Invoke-CppTest.ps1"
 			if (-not (Test-Path $cppScript)) {
 				Write-Host "[ERROR] Native test script not found at $cppScript" -ForegroundColor Red
@@ -185,9 +185,12 @@ try {
 			}
 			$script:testExitCode = $overallExitCode
 
-			if ($NativeOnly) {
+			if ($SkipManaged) {
 				return
 			}
+		} elseif ($SkipManaged) {
+			Write-Host "[EXCLAMATION] Are you sure you don't want to run any tests?'" -ForegroundColor Red
+			exit 1
 		}
 
 		# =============================================================================
@@ -597,7 +600,7 @@ if ($testExitCode -ne 0 -and (Test-Path $vstestLogPath)) {
 
 	Write-Host "=====================================" -ForegroundColor Red
 	Write-Host "  Full log for managed tests: $vstestLogPath" -ForegroundColor Gray
-	if (-not $NoNative) {
+	if (-not $SkipNative) {
 		$nativeLogPath = Join-Path $PSScriptRoot "Output/$Configuration/<SuiteName>.exe.log"
 		Write-Host "  Logs for each native test suite: $nativeLogPath" -ForegroundColor Gray
 	}


### PR DESCRIPTION
Running Native tests after an installer build results in the following error (the same test passes in CI builds):
```
ERROR: VwTextStore.SetTextEmpty
     : unknown exception
```
This is part of ongoing work on https://jira.sil.org/browse/LT-22425

## Original Description

They had not been running in CD before, and now one is failing, even though all are passing in CI. Perhaps the test filter should be adjusted, but this will get builds running until we figure that out.

CI and CD builds have two differences in how tests are run:
* CI excludes more test categories
* CI runs tests in a separate step from building

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/834)
<!-- Reviewable:end -->
