### PR TITLE
Fix LT-21583: Create an empty gloss line when approving an analysis

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
+++ b/DistFiles/Language Explorer/Configuration/Words/areaConfiguration.xml
@@ -129,6 +129,9 @@
 		<command id="CmdDataTree-Insert-WordGloss" label="Add Word Gloss" message="DataTreeInsert">
 			<parameters field="Meanings" className="WfiGloss"/>
 		</command>
+		<command id="CmdDataTree-Insert-WordGloss-And-Approve" label="Approve" message="InsertWordGlossAndApprove">
+			<parameters field="Meanings" className="WfiGloss"/>
+		</command>
 		<command id="CmdInsertHumanApprovedAnalysis" label="Add Approved Analysis..." message="AddApprovedAnalysis" icon="addNewAnalysis">
 			<parameters field="Analyses" className="WfiAnalysis"/>
 		</command>
@@ -463,7 +466,7 @@
 			<item command="CmdShowHumanApprovedAnalysisConc"/>
 			<item command="CmdAnalysisJumpToConcordance"/>
 			<menu id="mnuDataTree-HumanApprovedStatus" label="User Opinion">
-				<item command="CmdAnalysisApprove"/>
+				<item command="CmdDataTree-Insert-WordGloss-And-Approve"/>
 				<item command="CmdAnalysisUnknown"/>
 				<item command="CmdAnalysisDisapprove"/>
 			</menu>
@@ -478,7 +481,7 @@
 		</menu>
 		<menu id="mnuDataTree-ParserProducedAnalysis">
 			<menu id="mnuDataTree-ParserProducedStatus" label="User Opinion">
-				<item command="CmdAnalysisApprove"/>
+				<item command="CmdDataTree-Insert-WordGloss-And-Approve"/>
 				<item command="CmdAnalysisUnknown"/>
 				<item command="CmdAnalysisDisapprove"/>
 			</menu>
@@ -491,7 +494,7 @@
 		</menu>-->
 		<menu id="mnuDataTree-HumanDisapprovedAnalysis">
 			<menu id="mnuDataTree-HumanDisapprovedStatus" label="User Opinion">
-				<item command="CmdAnalysisApprove"/>
+				<item command="CmdDataTree-Insert-WordGloss-And-Approve"/>
 				<item command="CmdAnalysisUnknown"/>
 				<item command="CmdAnalysisDisapprove"/>
 			</menu>

--- a/Src/LexText/Morphology/MorphologyListener.cs
+++ b/Src/LexText/Morphology/MorphologyListener.cs
@@ -22,6 +22,7 @@ using SIL.FieldWorks.FdoUi;
 using SIL.FieldWorks.IText;
 using SIL.Utils;
 using XCore;
+using SIL.FieldWorks.Common.Framework.DetailControls;
 
 namespace SIL.FieldWorks.XWorks.MorphologyEditor
 {
@@ -806,6 +807,20 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			display.Enabled = display.Visible = InFriendlyArea;
 			display.Checked = Analysis != null && Analysis.IsValidObject && Analysis.ApprovalStatusIcon == 1;
 			return true; //we've handled this
+		}
+
+		/// <summary>
+		/// Insert Word Gloss and Approve Analysis
+		/// </summary>
+		public bool OnInsertWordGlossAndApprove(object cmd)
+		{
+			if (Analysis.MeaningsOC.Count == 0)
+			{
+				// Insert word gloss.
+				OnDataTreeInsert(cmd);
+			}
+			OnAnalysisApprove(cmd);
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21583.  It adds a command to create an empty gloss line when approving an analysis.  It creates the empty gloss line first because approving the analysis may move it.  It doesn't create a gloss line if the analysis already has a gloss.  It uses the existing commands for creating an empty gloss line and for approving an analysis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/835)
<!-- Reviewable:end -->
