### PR TITLE
LT-21517: Implement DialogInsertItemInVector in Pub/Sub system

### DIFF
--- a/Src/Common/FwUtils/EndOfActionManager.cs
+++ b/Src/Common/FwUtils/EndOfActionManager.cs
@@ -52,7 +52,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 			}
 
 			// Add the dictionary entry if the key is not present. Overwrite the value if the key is present.
-			m_events[publisherParameterObject.Message] = publisherParameterObject.NewValue;
+			m_events[publisherParameterObject.Message] = publisherParameterObject.Data;
 		}
 
 		/// Should be private, but is public to support testing.

--- a/Src/Common/FwUtils/EventConstants.cs
+++ b/Src/Common/FwUtils/EventConstants.cs
@@ -14,6 +14,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 		public const string CreateFirstRecord = "CreateFirstRecord";
 		public const string DataTreeDelete = "DataTreeDelete";
 		public const string DeleteRecord = "DeleteRecord";
+		public const string DialogInsertItemInVector = "DialogInsertItemInVector";
 		public const string DictionaryConfigured = "DictionaryConfigured";
 		public const string FilterListChanged = "FilterListChanged";
 		public const string FollowLink = "FollowLink";

--- a/Src/Common/FwUtils/Publisher.cs
+++ b/Src/Common/FwUtils/Publisher.cs
@@ -70,7 +70,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			Guard.AgainstNull(publisherParameterObject, nameof(publisherParameterObject));
 
-			PublishMessage(publisherParameterObject.Message, publisherParameterObject.NewValue);
+			PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data);
 		}
 
 		/// <inheritdoc />
@@ -89,7 +89,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			foreach (var publisherParameterObject in publisherParameterObjects)
 			{
-				PublishMessage(publisherParameterObject.Message, publisherParameterObject.NewValue);
+				PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data);
 			}
 		}
 		#endregion

--- a/Src/Common/FwUtils/PublisherParameterObject.cs
+++ b/Src/Common/FwUtils/PublisherParameterObject.cs
@@ -8,7 +8,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 {
 	public sealed class PublisherParameterObject
 	{
-		public PublisherParameterObject(string message, object newValue = null)
+		public PublisherParameterObject(string message, object data = null)
 		{
 			if (string.IsNullOrWhiteSpace(message))
 			{
@@ -16,10 +16,25 @@ namespace SIL.FieldWorks.Common.FwUtils
 			}
 
 			Message = message;
-			NewValue = newValue;
+			Data = data;
 		}
 
 		public string Message { get; }
-		public object NewValue { get; }
+		public object Data { get; }
+	}
+
+	/// <summary>
+	/// Convenience class for use when we want to pass a return value back through the PublisherParameterObject.
+	/// </summary>
+	public class ReturnObject
+	{
+		public ReturnObject(object data)
+		{
+			Data = data;
+			ReturnValue = false;
+		}
+
+		public object Data { get; set; }
+		public bool ReturnValue { get; set; }
 	}
 }

--- a/Src/LexText/LexTextControls/EntryDlgListener.cs
+++ b/Src/LexText/LexTextControls/EntryDlgListener.cs
@@ -75,7 +75,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			}
 			// Only handle "LexEntry" class.
 			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
-			if (className == null || className != "LexEntry")
+			if (className != "LexEntry")
 			{
 				return;
 			}

--- a/Src/LexText/LexTextControls/EntryDlgListener.cs
+++ b/Src/LexText/LexTextControls/EntryDlgListener.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Diagnostics;
 using System.Windows.Forms;
+using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Infrastructure;
 using XCore;
@@ -32,28 +34,51 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public InsertEntryDlgListener()
 		{
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
 		}
 
 		#endregion Construction and Initialization
 
+		#region IDisposable
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+			}
+			base.Dispose(disposing);
+		}
+		#endregion IDisposable
+
 		#region XCORE Message Handlers
 
 		/// <summary>
-		/// Handles the xWorks message to insert a new lexical entry.
+		/// Handles the message to insert a new lexical entry.
 		/// Invoked by the RecordClerk
 		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public bool OnDialogInsertItemInVector(object argument)
+		/// <param name="obj">Object that contains the xCore Command object and has a ReturnValue. The
+		/// ReturnValue is true if we handled the message.</param>
+		private void DialogInsertItemInVector(object obj)
 		{
 			CheckDisposed();
 
-			Debug.Assert(argument != null && argument is XCore.Command);
-			string className = XmlUtils.GetOptionalAttributeValue(
-				(argument as Command).Parameters[0],
-				"className");
+			if (!(obj is ReturnObject retObj) ||
+				!(retObj.Data is Command command))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			// Only handle "LexEntry" class.
+			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
 			if (className == null || className != "LexEntry")
-				return false;
+			{
+				return;
+			}
 
 			using (InsertEntryDlg dlg = new InsertEntryDlg())
 			{
@@ -72,7 +97,7 @@ namespace SIL.FieldWorks.LexText.Controls
 #pragma warning restore 618
 				}
 			}
-			return true; // We "handled" the message, regardless of what happened.
+			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
 		}
 
 		#endregion XCORE Message Handlers

--- a/Src/LexText/LexTextControls/RecordDlgListener.cs
+++ b/Src/LexText/LexTextControls/RecordDlgListener.cs
@@ -71,7 +71,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			}
 			// Only handle "RnGenericRec" class.
 			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
-			if (className == null || className != "RnGenericRec")
+			if (className != "RnGenericRec")
 			{
 				return;
 			}

--- a/Src/LexText/LexTextControls/RecordDlgListener.cs
+++ b/Src/LexText/LexTextControls/RecordDlgListener.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.Windows.Forms;
+using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.Utils;
 using XCore;
@@ -24,23 +26,55 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		#endregion Properties
 
+		#region Construction and Initialization
+
+		public InsertRecordDlgListener()
+		{
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		#endregion Construction and Initialization
+
+		#region IDisposable
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+			}
+			base.Dispose(disposing);
+		}
+		#endregion IDisposable
 
 		#region XCORE Message Handlers
 
 		/// <summary>
-		/// Handles the xWorks message to insert a new Data Notebook record.
+		/// Handles the message to insert a new Data Notebook record.
 		/// Invoked by the RecordClerk
 		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public bool OnDialogInsertItemInVector(object argument)
+		/// <param name="arg">Object that contains the xCore Command object and has a ReturnValue. The
+		/// ReturnValue is true if we handled the message.</param>
+		private void DialogInsertItemInVector(object arg)
 		{
 			CheckDisposed();
 
-			var command = (Command) argument;
+			if (!(arg is ReturnObject retObj) ||
+				!(retObj.Data is Command command))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			// Only handle "RnGenericRec" class.
 			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
 			if (className == null || className != "RnGenericRec")
-				return false;
+			{
+				return;
+			}
 
 			bool subrecord = XmlUtils.GetOptionalBooleanAttributeValue(command.Parameters[0], "subrecord", false);
 			bool subsubrecord = XmlUtils.GetOptionalBooleanAttributeValue(command.Parameters[0], "subsubrecord", false);
@@ -74,7 +108,7 @@ namespace SIL.FieldWorks.LexText.Controls
 #pragma warning restore 618
 				}
 			}
-			return true; // We "handled" the message, regardless of what happened.
+			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
 		}
 
 		#endregion XCORE Message Handlers

--- a/Src/LexText/Morphology/MasterCatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterCatDlgListener.cs
@@ -92,7 +92,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			}
 			// Only handle "PartOfSpeech" class.
 			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
-			if (className == null || className != "PartOfSpeech")
+			if (className != "PartOfSpeech")
 			{
 				return;
 			}

--- a/Src/LexText/Morphology/MasterCatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterCatDlgListener.cs
@@ -4,9 +4,12 @@
 
 using System.Diagnostics;
 using System.Windows.Forms;
+using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.Utils;
+using XCore;
 
 namespace SIL.FieldWorks.XWorks.MorphologyEditor
 {
@@ -32,6 +35,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterCatDlgListener()
 		{
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
 		}
 
 		#endregion Construction and Initialization
@@ -52,26 +56,46 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			// The base class finalizer is called automatically.
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+			}
+			base.Dispose(disposing);
+		}
 
 		#endregion IDisposable & Co. implementation
 
 		#region XCORE Message Handlers
 
 		/// <summary>
-		/// Handles the xWorks message to insert a new PartOfSpeech.
+		/// Handles the message to insert a new PartOfSpeech.
 		/// Invoked by the RecordClerk via a main menu.
 		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public override bool OnDialogInsertItemInVector(object argument)
+		/// <param name="obj">Object that contains the xCore Command object and has a ReturnValue. The
+		/// ReturnValue is true if we handled the message.</param>
+		private void DialogInsertItemInVector(object obj)
 		{
 			CheckDisposed();
 
-			Debug.Assert(argument != null && argument is XCore.Command);
-			string className = XmlUtils.GetOptionalAttributeValue(
-				(argument as XCore.Command).Parameters[0], "className");
+			if (!(obj is ReturnObject retObj) ||
+				!(retObj.Data is Command command))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			// Only handle "PartOfSpeech" class.
+			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
 			if (className == null || className != "PartOfSpeech")
-				return false;
+			{
+				return;
+			}
 
 			using (var dlg = new MasterCategoryListDlg())
 			{
@@ -91,7 +115,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 						break;
 				}
 			}
-			return true; // We "handled" the message, regardless of what happened.
+			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
 		}
 
 		#endregion XCORE Message Handlers

--- a/Src/LexText/Morphology/MasterDlgListener.cs
+++ b/Src/LexText/Morphology/MasterDlgListener.cs
@@ -193,20 +193,5 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		}
 
 		#endregion IxCoreColleague implementation
-
-		#region XCORE Message Handlers
-
-		/// <summary>
-		/// Handles the xWorks message to insert a new class.
-		/// Invoked by the RecordClerk via a main menu.
-		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public virtual bool OnDialogInsertItemInVector(object argument)
-		{
-			return false; // Needs to be handled by the override method
-		}
-
-		#endregion XCORE Message Handlers
 	}
 }

--- a/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
@@ -4,9 +4,12 @@
 
 using System.Diagnostics;
 using System.Windows.Forms;
+using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.Utils;
+using XCore;
 
 namespace SIL.FieldWorks.XWorks.MorphologyEditor
 {
@@ -33,6 +36,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterInflFeatDlgListener()
 		{
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
 		}
 
 		#endregion Construction and Initialization
@@ -53,28 +57,51 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			// The base class finalizer is called automatically.
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+			}
+			base.Dispose(disposing);
+		}
 
 		#endregion IDisposable & Co. implementation
 
 		#region XCORE Message Handlers
 
 		/// <summary>
-		/// Handles the xWorks message to insert a new FsFeatDefn.
+		/// Handles the message to insert a new FsFeatDefn.
 		/// Invoked by the RecordClerk via a main menu.
 		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public override bool OnDialogInsertItemInVector(object argument)
+		/// <param name="obj">Object that contains the xCore Command object and has a ReturnValue. The
+		/// ReturnValue is true if we handled the message.</param>
+		private void DialogInsertItemInVector(object obj)
 		{
 			CheckDisposed();
 
-			Debug.Assert(argument != null && argument is XCore.Command);
-			string className = XmlUtils.GetOptionalAttributeValue(
-				(argument as XCore.Command).Parameters[0], "className");
+			if (!(obj is ReturnObject retObj) ||
+				!(retObj.Data is Command command))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			// Only handle "FsClosedFeature" and "FsComplexFeature" classes.
+			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
 			if (className == null || ((className != "FsClosedFeature") && (className != "FsComplexFeature")))
-				return false;
-			if (className == "FsClosedFeature" && (argument as XCore.Command).Id != "CmdInsertClosedFeature")
-				return false;
+			{
+				return;
+			}
+			// Only handle "FsClosedFeature" for "CmdInsertClosedFeature".
+			if (className == "FsClosedFeature" && command.Id != "CmdInsertClosedFeature")
+			{
+				return;
+			}
 
 			using (MasterInflectionFeatureListDlg dlg = new MasterInflectionFeatureListDlg(className))
 			{
@@ -101,7 +128,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 						break;
 				}
 			}
-			return true; // We "handled" the message, regardless of what happened.
+			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
 		}
 
 		#endregion XCORE Message Handlers

--- a/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
@@ -93,7 +93,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			}
 			// Only handle "FsClosedFeature" and "FsComplexFeature" classes.
 			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
-			if (className == null || ((className != "FsClosedFeature") && (className != "FsComplexFeature")))
+			if ((className != "FsClosedFeature") && (className != "FsComplexFeature"))
 			{
 				return;
 			}

--- a/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
@@ -9,8 +9,10 @@ using System.Windows.Forms;
 using SIL.LCModel;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel.Infrastructure;
 using SIL.Utils;
+using XCore;
 
 namespace SIL.FieldWorks.XWorks.MorphologyEditor
 {
@@ -37,6 +39,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterPhonFeatDlgListener()
 		{
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
 		}
 
 		#endregion Construction and Initialization
@@ -57,27 +60,51 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			// The base class finalizer is called automatically.
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+			}
+			base.Dispose(disposing);
+		}
+
 		#endregion IDisposable & Co. implementation
 
 		#region XCORE Message Handlers
 
 		/// <summary>
-		/// Handles the xWorks message to insert a new FsFeatDefn.
+		/// Handles the message to insert a new FsFeatDefn.
 		/// Invoked by the RecordClerk via a main menu.
 		/// </summary>
-		/// <param name="argument">The xCore Command object.</param>
-		/// <returns>true, if we handled the message, otherwise false, if there was an unsupported 'classname' parameter</returns>
-		public override bool OnDialogInsertItemInVector(object argument)
+		/// <param name="obj">Object that contains the xCore Command object and has a ReturnValue. The
+		/// ReturnValue is true if we handled the message.</param>
+		private void DialogInsertItemInVector(object obj)
 		{
 			CheckDisposed();
 
-			Debug.Assert(argument != null && argument is XCore.Command);
-			string className = XmlUtils.GetOptionalAttributeValue(
-				(argument as XCore.Command).Parameters[0], "className");
+			if (!(obj is ReturnObject retObj) ||
+				!(retObj.Data is Command command))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			// Only handle "FsClosedFeature" class.
+			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
 			if ((className == null) || (className != "FsClosedFeature"))
-				return false;
-			if (className == "FsClosedFeature" && (argument as XCore.Command).Id != "CmdInsertPhonologicalClosedFeature")
-				return false;
+			{
+				return;
+			}
+			// Only handle "FsClosedFeature" for "CmdInsertPhonologicalClosedFeature".
+			if (className == "FsClosedFeature" && command.Id != "CmdInsertPhonologicalClosedFeature")
+			{
+				return;
+			}
 
 			using (MasterPhonologicalFeatureListDlg dlg = new MasterPhonologicalFeatureListDlg(className))
 			{
@@ -118,7 +145,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 						break;
 				}
 			}
-			return true; // We "handled" the message, regardless of what happened.
+			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
 		}
 
 		#endregion XCORE Message Handlers

--- a/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
@@ -94,14 +94,9 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			{
 				return;
 			}
-			// Only handle "FsClosedFeature" class.
-			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
-			if ((className == null) || (className != "FsClosedFeature"))
-			{
-				return;
-			}
 			// Only handle "FsClosedFeature" for "CmdInsertPhonologicalClosedFeature".
-			if (className == "FsClosedFeature" && command.Id != "CmdInsertPhonologicalClosedFeature")
+			string className = XmlUtils.GetOptionalAttributeValue(command.Parameters[0], "className");
+			if (className != "FsClosedFeature" || command.Id != "CmdInsertPhonologicalClosedFeature")
 			{
 				return;
 			}

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -2551,10 +2551,10 @@ namespace SIL.FieldWorks.XWorks
 			m_suppressSaveOnChangeRecord = true;
 			try
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				if (m_mediator.SendMessage("DialogInsertItemInVector", argument))
+				var retObj = new ReturnObject(argument);
+				Publisher.Publish(new PublisherParameterObject(EventConstants.DialogInsertItemInVector, retObj));
+				if (retObj.ReturnValue)
 					return true;
-#pragma warning restore 618
 			}
 			finally
 			{


### PR DESCRIPTION
Add a ReturnObject class to return a ‘handled’ value, which the Publisher needs to know. All of the Subscribers only handle a specific className or className and Id combination so it did not matter that two of the classes are derived from DlgListenerBase, which has ColleaguePriority.High.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/836)
<!-- Reviewable:end -->
