### PR TITLE
LT-22497: GenerateHCConfigForFLExTrans should use '#', not '.'

### DIFF
--- a/Src/LexText/ParserCore/HCLoader.cs
+++ b/Src/LexText/ParserCore/HCLoader.cs
@@ -70,6 +70,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		private SimpleContext m_any;
 		private CharacterDefinition m_null;
 		private CharacterDefinition m_morphBdry;
+		protected static char m_ReplaceSpaceChar = '.';
 
 		protected HCLoader(LcmCache cache, IHCLoadErrorLogger logger)
 		{
@@ -2571,7 +2572,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 
 		private static string FormatForm(string formStr)
 		{
-			return formStr.Trim().Replace(' ', '.');
+			return formStr.Trim().Replace(' ', m_ReplaceSpaceChar);
 		}
 
 		private IEnumerable<FeatureSymbol> LoadAllPartsOfSpeech(IPartOfSpeech pos)

--- a/Src/Utilities/HCSynthByGloss/GenerateHCConfig4FLExTrans/HCLoaderForFLExTrans.cs
+++ b/Src/Utilities/HCSynthByGloss/GenerateHCConfig4FLExTrans/HCLoaderForFLExTrans.cs
@@ -23,11 +23,13 @@ namespace SIL.GenerateHCConfigForFLExTrans
 		{
 			var loader = new HCLoaderForFLExTrans(cache, logger);
 			loader.LoadLanguage();
+			m_ReplaceSpaceChar = '#';
 			return loader.m_language;
 		}
 
 		protected HCLoaderForFLExTrans(LcmCache cache, IHCLoadErrorLogger logger) : base(cache, logger)
 		{
+			m_ReplaceSpaceChar = '#';
 		}
 
 		protected override void LoadMorphologicalRules(Stratum stratum, ILexEntry entry, IList<IMoForm> allos)


### PR DESCRIPTION
This is a fix for LT-22497.

When using FLExTrans, the GenerateHCConfigForFLExTrans  tool needs to replace spaces in forms with '#' instead of the default '.' from HCLoader.cs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/844)
<!-- Reviewable:end -->
