### PR TITLE
LT-22499: use best analysis alternative for morph type

### DIFF
--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/MorphTypesChooser.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/MorphTypesChooser.cs
@@ -56,7 +56,7 @@ namespace SIL.AllomorphGenerator
 				{
 					MorphType morphType = new MorphType();
 					morphType.Guid = mt.Guid.ToString();
-					morphType.Name = mt.Name.AnalysisDefaultWritingSystem.Text;
+					morphType.Name = mt.Name.BestAnalysisAlternative.Text;
 					MorphTypes.Add(morphType);
 				}
 			}


### PR DESCRIPTION
We got a crash when filling a list when the Name property was null.  The fix is to use the best alternative analysis language text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/846)
<!-- Reviewable:end -->
