### PR TITLE
LT-22425: Fix testSetTextEmpty for Release builds

### DIFF
--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired'
+          .\test.ps1 -Configuration Release -NoBuild -SkipManaged
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -156,7 +156,12 @@ jobs:
         id: build_and_test
         shell: powershell
         run: |
-          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -RunTests -SkipNativeTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -BuildTests -TestFilter 'TestCategory!=ByHand&TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+
+      - name: Run tests
+        shell: powershell
+        run: |
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired'
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -156,12 +156,12 @@ jobs:
         id: build
         shell: powershell
         run: |
-          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") *>&1 | Tee-Object -FilePath build.log
 
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' | Tee-Object -FilePath test.log
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' *>&1 | Tee-Object -FilePath test.log
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -152,16 +152,16 @@ jobs:
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         if: github.event_name != 'pull_request'
 
-      - name: Build and test
-        id: build_and_test
+      - name: Build
+        id: build
         shell: powershell
         run: |
-          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -BuildTests -TestFilter 'TestCategory!=ByHand&TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildInstaller -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
 
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -SkipManaged
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' | Tee-Object -FilePath test.log
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -SkipManaged
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' | Tee-Object -FilePath test.log
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -220,12 +220,17 @@ jobs:
               New-ItemProperty -Path $path -Name $valueName -Value $expectedValue -Type String -Force
           }
 
-      - name: Build and test
-        id: build_and_test
+      - name: Build
+        id: build
         shell: powershell
         run: |
           Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NETFramework\AppContext"
-          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -RunTests -SkipNativeTests -TestFilter 'TestCategory!=DesktopRequired' -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+
+      - name: Run tests
+        shell: powershell
+        run: |
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired'
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -225,12 +225,12 @@ jobs:
         shell: powershell
         run: |
           Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NETFramework\AppContext"
-          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") | Tee-Object -FilePath build.log
+          .\build.ps1 -BuildPatch -Configuration Release -Verbosity detailed -BuildTests -MsBuildArgs @("/bl") *>&1 | Tee-Object -FilePath build.log
 
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' | Tee-Object -FilePath test.log
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' *>&1 | Tee-Object -FilePath test.log
 
       - name: Scan Build Output
         shell: powershell

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired'
+          .\test.ps1 -Configuration Release -NoBuild -SkipManaged
 
       - name: Scan Build Output
         shell: powershell

--- a/Src/views/Test/TestVwTextStore.h
+++ b/Src/views/Test/TestVwTextStore.h
@@ -23,6 +23,9 @@ Last reviewed:
 
 #pragma once
 
+#include <chrono>
+#include <thread>
+
 #include "testViews.h"
 
 #if defined(_WIN32) || defined(_M_X64)
@@ -123,12 +126,11 @@ namespace TestViews
 	public:
 		MockTextStoreACPSink(ITextStoreACP * ptsa, IUnknown * punkOldSink)
 		{
-			//cout << "MockTextStoreACPSink constructor; ";
+			this_thread::sleep_for(1ms); // testSetTextEmpty fails without this on Release builds but not Debug builds (discovered by LT-22425)
 			m_qtsa = ptsa;
 			if (punkOldSink)
 				CheckHr(ptsa->UnadviseSink(punkOldSink));
 			CheckHr(ptsa->AdviseSink(IID_ITextStoreACPSink, this, TS_AS_ALL_SINKS));
-			//cout << "MockTextStoreACPSink constructor mostly done: " << (void*)this << endl;
 			m_fLockGranted = false;
 			m_dwLockFlags = 0;
 		}
@@ -395,14 +397,13 @@ namespace TestViews
 			TS_TEXTCHANGE * pttc)
 			: MockTextStoreACPSink(ptsa, NULL)
 		{
-			cout << "LockSetText constructor; ";
 			m_ichStart = ichStart;
 			m_ichEnd = ichEnd;
 			m_pszText = pszText;
 			m_pttc = pttc;
+
 			CheckHr(ptsa->RequestLock(TS_LF_READWRITE | TS_LF_SYNC, &m_hrLock));
 			CheckHr(ptsa->UnadviseSink(this));
-			//cout << "LockSetText constructor done: " <</* (void*)this << */endl;
 		}
 
 		STDMETHOD(OnLockGranted)(DWORD dwLockFlags)
@@ -1838,23 +1839,18 @@ namespace TestViews
 			//_CrtSetDbgFlag(_CRTDBG_CHECK_ALWAYS_DF | _CRTDBG_DELAY_FREE_MEM_DF );
 			if (!m_fTestable)
 			{
-				cout << "Not testable, skipping testSetTextEmpty.\n";
 				return;
 			}
-			//cout << "Testing SetText empty string to join paragraphs.\n";
 			MakeStringList2();
 			Make2ParaSel(1, s_cchPara2, 2, 0);
 			TS_TEXTCHANGE ttc1 = { 0 };
-			cout << "Fixing to construct a LockSetText...\n";
 			LockSetText xlst1(m_qtxs, s_cchPara2, s_cchPara2 + s_cchParaBreak, L"", &ttc1);
-			cout << "Constructed a LockSetText.\n";
 			_CrtCheckMemory();
 			StrUni stuNew(s_rgpsz2[1]);
 			stuNew.Append(s_rgpsz2[2]);	// no newline between them!
 			VerifyParaContents(1, stuNew.Chars(), "SetText(join paras)");
 			VerifyParaContents(0, s_rgpsz2[0], "SetText(join paras) prev para");
 			VerifyParaContents(2, s_rgpsz2[3], "SetText(join paras) next para");
-			cout << "Done testing SetText Empty\n";
 		}
 
 		// We no longer implement this method in C++
@@ -2022,8 +2018,7 @@ namespace TestViews
 			PropTag tag = 2;
 			if (m_qrootb.Ptr() == NULL)
 			{
-				cerr << "VwRootBox_PropChanged was skipped because the m_qrootb was null." <<
-					'\n';
+				cerr << "VwRootBox_PropChanged was skipped because the m_qrootb was null." << endl;
 				return;
 			}
 			VwRootBox* prootb = dynamic_cast<VwRootBox*>(m_qrootb.Ptr());

--- a/Src/views/Test/TestVwTextStore.h
+++ b/Src/views/Test/TestVwTextStore.h
@@ -123,10 +123,13 @@ namespace TestViews
 	public:
 		MockTextStoreACPSink(ITextStoreACP * ptsa, IUnknown * punkOldSink)
 		{
+			cout << "MockTextStoreACPSink constructor: ptsa=" << (void*)ptsa << ", punkOldSink=" << (void*)punkOldSink << endl;
 			m_qtsa = ptsa;
 			if (punkOldSink)
 				CheckHr(ptsa->UnadviseSink(punkOldSink));
+			cout << "Between Sinks: " << (void*)this << endl;
 			CheckHr(ptsa->AdviseSink(IID_ITextStoreACPSink, this, TS_AS_ALL_SINKS));
+			cout << "MockTextStoreACPSink constructor mostly done: " << (void*)this << endl;
 			m_fLockGranted = false;
 			m_dwLockFlags = 0;
 		}
@@ -393,13 +396,17 @@ namespace TestViews
 			TS_TEXTCHANGE * pttc)
 			: MockTextStoreACPSink(ptsa, NULL)
 		{
+			cout << "LockSetText constructor: " << (void*)this << ", ichStart=" << ichStart << ", ichEnd=" << ichEnd
+				<< ", pszText=" << (void*)pszText << ", pttc=" << (void*)pttc << endl;
 			m_ichStart = ichStart;
 			m_ichEnd = ichEnd;
 			m_pszText = pszText;
 			m_pttc = pttc;
-
+			cout << "LockSetText constructor logic begins: " << (void*)this << endl;
 			CheckHr(ptsa->RequestLock(TS_LF_READWRITE | TS_LF_SYNC, &m_hrLock));
+			cout << "LockSetText constructor between HRs: " << (void*)this << endl;
 			CheckHr(ptsa->UnadviseSink(this));
+			cout << "LockSetText constructor done: " << (void*)this << endl;
 		}
 
 		STDMETHOD(OnLockGranted)(DWORD dwLockFlags)
@@ -1834,13 +1841,23 @@ namespace TestViews
 		{
 			//_CrtSetDbgFlag(_CRTDBG_CHECK_ALWAYS_DF | _CRTDBG_DELAY_FREE_MEM_DF );
 			if (!m_fTestable)
+			{
+				cout << "Not testable, skipping testSetTextEmpty.\n";
 				return;
+			}
+			cout << "Testing SetText empty string to join paragraphs.\n";
 			MakeStringList2();
+			cout << "made string list.\n";
 			Make2ParaSel(1, s_cchPara2, 2, 0);
+			cout << "made selection.\n";
 			TS_TEXTCHANGE ttc1 = { 0 };
+			cout << "empty TS_TEXTCHANGE struct.\n";
 			LockSetText xlst1(m_qtxs, s_cchPara2, s_cchPara2 + s_cchParaBreak, L"", &ttc1);
+			cout << "called SetText.\n";
 			_CrtCheckMemory();
+			cout << "checked memory.\n";
 			StrUni stuNew(s_rgpsz2[1]);
+			cout << "created stuNew.\n";
 			stuNew.Append(s_rgpsz2[2]);	// no newline between them!
 			VerifyParaContents(1, stuNew.Chars(), "SetText(join paras)");
 			VerifyParaContents(0, s_rgpsz2[0], "SetText(join paras) prev para");
@@ -2012,7 +2029,8 @@ namespace TestViews
 			PropTag tag = 2;
 			if (m_qrootb.Ptr() == NULL)
 			{
-				cerr << "VwRootBox_PropChanged was skipped because the m_qrootb was null." << endl;
+				cerr << "VwRootBox_PropChanged was skipped because the m_qrootb was null." <<
+					'\n';
 				return;
 			}
 			VwRootBox* prootb = dynamic_cast<VwRootBox*>(m_qrootb.Ptr());

--- a/Src/views/Test/TestVwTextStore.h
+++ b/Src/views/Test/TestVwTextStore.h
@@ -123,11 +123,11 @@ namespace TestViews
 	public:
 		MockTextStoreACPSink(ITextStoreACP * ptsa, IUnknown * punkOldSink)
 		{
-			cout << "MockTextStoreACPSink constructor: ptsa=" << (void*)ptsa << ", punkOldSink=" << (void*)punkOldSink << endl;
+			cout << "MockTextStoreACPSink constructor: ";// "ptsa=" << (void*)ptsa << ", punkOldSink=" << (void*)punkOldSink << endl;
 			m_qtsa = ptsa;
 			if (punkOldSink)
 				CheckHr(ptsa->UnadviseSink(punkOldSink));
-			cout << "Between Sinks: " << (void*)this << endl;
+			//cout << "Between Sinks: " << (void*)this << endl;
 			CheckHr(ptsa->AdviseSink(IID_ITextStoreACPSink, this, TS_AS_ALL_SINKS));
 			cout << "MockTextStoreACPSink constructor mostly done: " << (void*)this << endl;
 			m_fLockGranted = false;
@@ -396,17 +396,16 @@ namespace TestViews
 			TS_TEXTCHANGE * pttc)
 			: MockTextStoreACPSink(ptsa, NULL)
 		{
-			cout << "LockSetText constructor: " << (void*)this << ", ichStart=" << ichStart << ", ichEnd=" << ichEnd
-				<< ", pszText=" << (void*)pszText << ", pttc=" << (void*)pttc << endl;
+			cout << "LockSetText constructor: ";// << (void*)this << ", ichStart=" << ichStart << ", ichEnd=" << ichEnd << ", pszText=" << (void*)pszText << ", pttc=" << (void*)pttc << endl;
 			m_ichStart = ichStart;
 			m_ichEnd = ichEnd;
 			m_pszText = pszText;
 			m_pttc = pttc;
-			cout << "LockSetText constructor logic begins: " << (void*)this << endl;
+			//cout << "LockSetText constructor logic begins: " << (void*)this << endl;
 			CheckHr(ptsa->RequestLock(TS_LF_READWRITE | TS_LF_SYNC, &m_hrLock));
-			cout << "LockSetText constructor between HRs: " << (void*)this << endl;
+			//cout << "LockSetText constructor between HRs: " << (void*)this << endl;
 			CheckHr(ptsa->UnadviseSink(this));
-			cout << "LockSetText constructor done: " << (void*)this << endl;
+			cout << "LockSetText constructor done: " <</* (void*)this << */endl;
 		}
 
 		STDMETHOD(OnLockGranted)(DWORD dwLockFlags)
@@ -1847,17 +1846,17 @@ namespace TestViews
 			}
 			cout << "Testing SetText empty string to join paragraphs.\n";
 			MakeStringList2();
-			cout << "made string list.\n";
+			//cout << "made string list.\n";
 			Make2ParaSel(1, s_cchPara2, 2, 0);
-			cout << "made selection.\n";
+			//cout << "made selection.\n";
 			TS_TEXTCHANGE ttc1 = { 0 };
-			cout << "empty TS_TEXTCHANGE struct.\n";
+			cout << "Fixing to construct a LockSetText...\n";
 			LockSetText xlst1(m_qtxs, s_cchPara2, s_cchPara2 + s_cchParaBreak, L"", &ttc1);
-			cout << "called SetText.\n";
+			cout << "Constructed a LockSetText.\n";
 			_CrtCheckMemory();
-			cout << "checked memory.\n";
+			//cout << "checked memory.\n";
 			StrUni stuNew(s_rgpsz2[1]);
-			cout << "created stuNew.\n";
+			//cout << "created stuNew.\n";
 			stuNew.Append(s_rgpsz2[2]);	// no newline between them!
 			VerifyParaContents(1, stuNew.Chars(), "SetText(join paras)");
 			VerifyParaContents(0, s_rgpsz2[0], "SetText(join paras) prev para");

--- a/Src/views/Test/TestVwTextStore.h
+++ b/Src/views/Test/TestVwTextStore.h
@@ -123,13 +123,12 @@ namespace TestViews
 	public:
 		MockTextStoreACPSink(ITextStoreACP * ptsa, IUnknown * punkOldSink)
 		{
-			cout << "MockTextStoreACPSink constructor: ";// "ptsa=" << (void*)ptsa << ", punkOldSink=" << (void*)punkOldSink << endl;
+			//cout << "MockTextStoreACPSink constructor; ";
 			m_qtsa = ptsa;
 			if (punkOldSink)
 				CheckHr(ptsa->UnadviseSink(punkOldSink));
-			//cout << "Between Sinks: " << (void*)this << endl;
 			CheckHr(ptsa->AdviseSink(IID_ITextStoreACPSink, this, TS_AS_ALL_SINKS));
-			cout << "MockTextStoreACPSink constructor mostly done: " << (void*)this << endl;
+			//cout << "MockTextStoreACPSink constructor mostly done: " << (void*)this << endl;
 			m_fLockGranted = false;
 			m_dwLockFlags = 0;
 		}
@@ -396,16 +395,14 @@ namespace TestViews
 			TS_TEXTCHANGE * pttc)
 			: MockTextStoreACPSink(ptsa, NULL)
 		{
-			cout << "LockSetText constructor: ";// << (void*)this << ", ichStart=" << ichStart << ", ichEnd=" << ichEnd << ", pszText=" << (void*)pszText << ", pttc=" << (void*)pttc << endl;
+			cout << "LockSetText constructor; ";
 			m_ichStart = ichStart;
 			m_ichEnd = ichEnd;
 			m_pszText = pszText;
 			m_pttc = pttc;
-			//cout << "LockSetText constructor logic begins: " << (void*)this << endl;
 			CheckHr(ptsa->RequestLock(TS_LF_READWRITE | TS_LF_SYNC, &m_hrLock));
-			//cout << "LockSetText constructor between HRs: " << (void*)this << endl;
 			CheckHr(ptsa->UnadviseSink(this));
-			cout << "LockSetText constructor done: " <</* (void*)this << */endl;
+			//cout << "LockSetText constructor done: " <</* (void*)this << */endl;
 		}
 
 		STDMETHOD(OnLockGranted)(DWORD dwLockFlags)
@@ -1844,23 +1841,20 @@ namespace TestViews
 				cout << "Not testable, skipping testSetTextEmpty.\n";
 				return;
 			}
-			cout << "Testing SetText empty string to join paragraphs.\n";
+			//cout << "Testing SetText empty string to join paragraphs.\n";
 			MakeStringList2();
-			//cout << "made string list.\n";
 			Make2ParaSel(1, s_cchPara2, 2, 0);
-			//cout << "made selection.\n";
 			TS_TEXTCHANGE ttc1 = { 0 };
 			cout << "Fixing to construct a LockSetText...\n";
 			LockSetText xlst1(m_qtxs, s_cchPara2, s_cchPara2 + s_cchParaBreak, L"", &ttc1);
 			cout << "Constructed a LockSetText.\n";
 			_CrtCheckMemory();
-			//cout << "checked memory.\n";
 			StrUni stuNew(s_rgpsz2[1]);
-			//cout << "created stuNew.\n";
 			stuNew.Append(s_rgpsz2[2]);	// no newline between them!
 			VerifyParaContents(1, stuNew.Chars(), "SetText(join paras)");
 			VerifyParaContents(0, s_rgpsz2[0], "SetText(join paras) prev para");
 			VerifyParaContents(2, s_rgpsz2[3], "SetText(join paras) next para");
+			cout << "Done testing SetText Empty\n";
 		}
 
 		// We no longer implement this method in C++

--- a/build.ps1
+++ b/build.ps1
@@ -165,6 +165,7 @@ param(
 	[switch]$SkipRestore,
 	[switch]$SkipNative,
 	[switch]$SkipNativeTests,
+	[switch]$SkipManagedTests,
 	[switch]$ForceBuildBuildTasks,
 	[switch]$BuildInstaller,
 	[switch]$BuildPatch,
@@ -717,6 +718,9 @@ try {
 		}
 		if ($SkipNative -or $SkipNativeTests) {
 			$testArgs["SkipNative"] = $true
+		}
+		if ($SkipManagedTests) {
+			$testArgs["SkipManaged"] = $true
 		}
 
 		Stop-ConflictingProcesses @cleanupArgs


### PR DESCRIPTION
## Summary
Sleep 1ms at the beginning of the MockTextStoreACPSink ctor to prevent an "unknown exception" in the test for VwTextStore.SetTextEmpty in Release builds (Debug builds are fine).

## Also
* Add a -SkipManagedTests switch to build.ps1
* Split tests into a separate execution step for installer builds for consistency with CI builds and more manageable log sizes

## Notes for reviewers (optional)
Another option is to `cout << "";`, which also spends enough time doing effectively nothing to cause the test to pass, and doesn't require two extra `#include`s, but sleeping rather than couting when the goal is to kill time feels more principled to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/847)
<!-- Reviewable:end -->
