### PR TITLE
Fix problem with LT-22333: Click on field in Preview pane

### DIFF
--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -502,10 +502,14 @@ namespace SIL.FieldWorks.XWorks
 			s_contextMenu.Items.Add(item);
 			item.Click += RunConfigureDialogAt;
 			item.Tag = new object[] { propertyTable, mediator, nodeId, topLevelGuid };
-			var item2 = new DisposableToolStripMenuItem(xWorksStrings.ksJumpToField);
-			s_contextMenu.Items.Add(item2);
-			item2.Click += JumpToFieldAt;
-			item2.Tag = new object[] { propertyTable, mediator, entryElement, element };
+			string tool = propertyTable.GetStringProperty("currentContentControl", null);
+			if (tool == "lexiconEdit")
+			{
+				var item2 = new DisposableToolStripMenuItem(xWorksStrings.ksJumpToField);
+				s_contextMenu.Items.Add(item2);
+				item2.Click += JumpToFieldAt;
+				item2.Tag = new object[] { propertyTable, mediator, entryElement, element };
+			}
 			if (e.CtrlKey) // show hidden menu item for tech support
 			{
 				item = new DisposableToolStripMenuItem(xWorksStrings.ksInspect);


### PR DESCRIPTION
This fixes a problem with the fix for https://jira.sil.org/browse/LT-22333 that was noticed by Marlon.  The Jump to field menu item should only appear in the Preview section of Lexicon Edit.  It shouldn't appear in the Dictionary view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/848)
<!-- Reviewable:end -->
