### PR TITLE
LT-22500 Crash after deleting 'new operation' item in Allomorph Generator dialog

### DIFF
--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
@@ -1091,9 +1091,17 @@ namespace SIL.AllomorphGenerator
 				if (ActionOp.ReplaceOpRefs.Count == 0)
 				{
 					// need at least one replace action
-					Replace replace = CreateNewReplace();
-					AlloGens.AddReplaceOp(replace);
-					lBoxReplaceOps.Items.Add(replace);
+					if (AlloGens.ReplaceOperations.Count > 0)
+					{
+						ActionOp.ReplaceOpRefs.Add(AlloGens.ReplaceOperations.ElementAt(0).Guid);
+					}
+					else
+					{
+						Replace replace = CreateNewReplace();
+						AlloGens.AddReplaceOp(replace);
+						lBoxReplaceOps.Items.Add(replace);
+					}
+					MarkAsChanged(true);
 				}
 				StemName = ActionOp.StemName;
 				tbStemName.Text = StemName.Name;
@@ -1105,6 +1113,7 @@ namespace SIL.AllomorphGenerator
 		protected void RefreshReplaceListBox()
 		{
 			lBoxReplaceOps.Items.Clear();
+			List<string> brokenRefs = new List<string>();
 			foreach (string guid in ReplaceOpRefs)
 			{
 				Replace replace = AlloGens.FindReplaceOp(guid);
@@ -1112,6 +1121,15 @@ namespace SIL.AllomorphGenerator
 				{
 					lBoxReplaceOps.Items.Add(replace);
 				}
+				else
+				{
+					brokenRefs.Add(guid);
+				}
+			}
+			foreach (string guid in brokenRefs)
+			{
+				ReplaceOpRefs.Remove(guid);
+				MarkAsChanged(true);
 			}
 			if (ReplaceOpRefs.Count > 0)
 				lBoxReplaceOps.SetSelected(0, true);

--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/SimpleMatchDlgAlloGen.resx
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/SimpleMatchDlgAlloGen.resx
@@ -423,7 +423,7 @@
     <value>8, 19</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>488, 172</value>
+    <value>823, 255</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Match for forms containing...</value>


### PR DESCRIPTION
Problem was due to a reference to a replace operation where there was no replace operation anymore.
Also removed adding extra replace operations when an action had no replace references.
Alos increased the size of the chooser box.  It did not show eveything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/851)
<!-- Reviewable:end -->
