### PR TITLE
Fix LT-22357: problem importing a view

### DIFF
--- a/Src/Common/Controls/FwControls/ProgressDialogWithTask.cs
+++ b/Src/Common/Controls/FwControls/ProgressDialogWithTask.cs
@@ -256,7 +256,16 @@ namespace SIL.FieldWorks.Common.Controls
 				CheckDisposed();
 
 				if (m_fCreatedProgressDlg && m_synchronizeInvoke.InvokeRequired)
-					m_synchronizeInvoke.Invoke((Action<string>)(s => m_progressDialog.Message = s), new [] {value});
+				{
+					try
+					{
+						m_synchronizeInvoke.Invoke((Action<string>)(s => m_progressDialog.Message = s), new[] { value });
+					}
+					catch
+					{
+						// Fixes LT-22357.
+					}
+				}
 				else
 					m_progressDialog.Message = value;
 			}
@@ -352,7 +361,16 @@ namespace SIL.FieldWorks.Common.Controls
 				CheckDisposed();
 
 				if (m_fCreatedProgressDlg && m_synchronizeInvoke.InvokeRequired)
-					m_synchronizeInvoke.Invoke((Action<int>)(i => m_progressDialog.Minimum = i), new object[] {value});
+				{
+					try
+					{
+						m_synchronizeInvoke.Invoke((Action<int>)(i => m_progressDialog.Minimum = i), new object[] { value });
+					}
+					catch
+					{
+						// Fixes LT-22357.
+					}
+				}
 				else
 					m_progressDialog.Minimum = value;
 			}
@@ -379,7 +397,16 @@ namespace SIL.FieldWorks.Common.Controls
 				CheckDisposed();
 
 				if (m_fCreatedProgressDlg && m_synchronizeInvoke.InvokeRequired)
-					m_synchronizeInvoke.Invoke((Action<int>) (i => m_progressDialog.Maximum = i), new object[] {value});
+				{
+					try
+					{
+						m_synchronizeInvoke.Invoke((Action<int>)(i => m_progressDialog.Maximum = i), new object[] { value });
+					}
+					catch
+					{
+						// Fixes LT-22357.
+					}
+				}
 				else
 					m_progressDialog.Maximum = value;
 			}

--- a/Src/Common/Controls/FwControls/ProgressDialogWithTask.cs
+++ b/Src/Common/Controls/FwControls/ProgressDialogWithTask.cs
@@ -261,9 +261,10 @@ namespace SIL.FieldWorks.Common.Controls
 					{
 						m_synchronizeInvoke.Invoke((Action<string>)(s => m_progressDialog.Message = s), new[] { value });
 					}
-					catch
+					catch (Exception e)
 					{
 						// Fixes LT-22357.
+						Debug.Assert(false);
 					}
 				}
 				else
@@ -366,9 +367,10 @@ namespace SIL.FieldWorks.Common.Controls
 					{
 						m_synchronizeInvoke.Invoke((Action<int>)(i => m_progressDialog.Minimum = i), new object[] { value });
 					}
-					catch
+					catch (Exception e)
 					{
 						// Fixes LT-22357.
+						Debug.Assert(false);
 					}
 				}
 				else
@@ -402,9 +404,10 @@ namespace SIL.FieldWorks.Common.Controls
 					{
 						m_synchronizeInvoke.Invoke((Action<int>)(i => m_progressDialog.Maximum = i), new object[] { value });
 					}
-					catch
+					catch (Exception e)
 					{
 						// Fixes LT-22357.
+						Debug.Assert(false);
 					}
 				}
 				else


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22357.  It was crashing trying to update the progress dialog because the FxXWindow had been disposed.  The simplest solution was to catch the error and ignore it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/853)
<!-- Reviewable:end -->
