### PR TITLE
LT-21669: Use WS numbers for headword numbers

### DIFF
--- a/Src/Common/Controls/Widgets/FwTextBox.cs
+++ b/Src/Common/Controls/Widgets/FwTextBox.cs
@@ -965,25 +965,6 @@ namespace SIL.FieldWorks.Common.Widgets
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets a value indicating whether the text box is read-only.
-		/// </summary>
-		/// <value><c>true</c> if the text box is read-only; otherwise, <c>false</c>.</value>
-		[Browsable(true), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public bool ReadOnlyView
-		{
-			get
-			{
-				CheckDisposed();
-				return m_innerFwTextBox.ReadOnlyView;
-			}
-			set
-			{
-				CheckDisposed();
-				m_innerFwTextBox.ReadOnlyView = value;
-			}
-		}
-
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Allows the control to function like an ordinary text box, setting and reading its text.

--- a/Src/Common/Controls/Widgets/FwTextBox.cs
+++ b/Src/Common/Controls/Widgets/FwTextBox.cs
@@ -965,6 +965,25 @@ namespace SIL.FieldWorks.Common.Widgets
 			}
 		}
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the text box is read-only.
+		/// </summary>
+		/// <value><c>true</c> if the text box is read-only; otherwise, <c>false</c>.</value>
+		[Browsable(true), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public bool ReadOnlyView
+		{
+			get
+			{
+				CheckDisposed();
+				return m_innerFwTextBox.ReadOnlyView;
+			}
+			set
+			{
+				CheckDisposed();
+				m_innerFwTextBox.ReadOnlyView = value;
+			}
+		}
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Allows the control to function like an ordinary text box, setting and reading its text.

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2479,11 +2479,12 @@ namespace SIL.FieldWorks.XWorks
 					// Use writing system's numbering system for sense numbers.
 					var wsString = GetWsForEntryType(sense, sense?.Cache);
 					var writingSystem = sense?.Cache.ServiceLocator.WritingSystemManager.Get(wsString);
-					if (writingSystem != null && writingSystem.NumberingSystem.Digits.Length == 10)
+					var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
+					if (unicodeCharacters != null)
 					{
 						for (var digit = 0; digit < 10; ++digit)
 						{
-							nextNumber = nextNumber.Replace(digit.ToString(), writingSystem.NumberingSystem.Digits[digit].ToString());
+							nextNumber = nextNumber.Replace(digit.ToString(), unicodeCharacters[digit]);
 						}
 					}
 					break;

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2476,15 +2476,28 @@ namespace SIL.FieldWorks.XWorks
 					break;
 				default: // handles %d and %O. We no longer support "%z" (1  b  iii) because users can hand-configure its equivalent
 					nextNumber = senseCount.ToString();
-					// Use writing system's numbering system for sense numbers.
-					var wsString = GetWsForEntryType(sense, sense?.Cache);
-					var writingSystem = sense?.Cache.ServiceLocator.WritingSystemManager.Get(wsString);
-					var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
-					if (unicodeCharacters != null)
+					// For the sense numbers, use the numbering system associated with the sense number writing system, if there is one.
+					var senseNumberWs = info.HomographConfig.WritingSystem;
+					if (senseNumberWs != null)
 					{
-						for (var digit = 0; digit < 10; ++digit)
+						CoreWritingSystemDefinition writingSystem = null;
+						try
 						{
-							nextNumber = nextNumber.Replace(digit.ToString(), unicodeCharacters[digit]);
+							writingSystem = sense?.Cache.ServiceLocator.WritingSystemManager.Get(senseNumberWs);
+						}
+						catch (KeyNotFoundException)
+						{
+							//Don't replace sense number digits.
+							break;
+						}
+						var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
+						if (unicodeCharacters != null)
+						{
+							for (var digit = 0; digit < 10; ++digit)
+							{
+								nextNumber = nextNumber.Replace(digit.ToString(),
+									unicodeCharacters[digit]);
+							}
 						}
 					}
 					break;

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2476,12 +2476,14 @@ namespace SIL.FieldWorks.XWorks
 					break;
 				default: // handles %d and %O. We no longer support "%z" (1  b  iii) because users can hand-configure its equivalent
 					nextNumber = senseCount.ToString();
-					// Use the digits from the CustomHomographNumbers if they are defined
-					if (info.HomographConfig.CustomHomographNumbers.Count == 10)
+					// Use writing system's numbering system for sense numbers.
+					var wsString = GetWsForEntryType(sense, sense?.Cache);
+					var writingSystem = sense?.Cache.ServiceLocator.WritingSystemManager.Get(wsString);
+					if (writingSystem != null && writingSystem.NumberingSystem.Digits.Length == 10)
 					{
 						for (var digit = 0; digit < 10; ++digit)
 						{
-							nextNumber = nextNumber.Replace(digit.ToString(), info.HomographConfig.CustomHomographNumbers[digit]);
+							nextNumber = nextNumber.Replace(digit.ToString(), writingSystem.NumberingSystem.Digits[digit].ToString());
 						}
 					}
 					break;

--- a/Src/xWorks/DictionaryConfigurationModel.cs
+++ b/Src/xWorks/DictionaryConfigurationModel.cs
@@ -201,7 +201,7 @@ namespace SIL.FieldWorks.XWorks
 				else
 				{
 					HomographConfiguration.HomographWritingSystem = string.Empty;
-					HomographConfiguration.CustomHomographNumbers = string.Empty;
+					//HomographConfiguration.CustomHomographNumbers = string.Empty;
 				}
 			}
 
@@ -370,7 +370,7 @@ namespace SIL.FieldWorks.XWorks
 			ShowSenseNumberReversal = other.ShowSenseNumberReversal;
 			HomographNumberBefore = other.HomographNumberBefore;
 			HomographWritingSystem = other.HomographWritingSystem;
-			CustomHomographNumberList = other.CustomHomographNumberList != null ? new List<string>(other.CustomHomographNumberList) : null;
+			//CustomHomographNumberList = other.CustomHomographNumberList != null ? new List<string>(other.CustomHomographNumberList) : null;
 		}
 
 		public DictionaryHomographConfiguration(HomographConfiguration config)
@@ -382,7 +382,7 @@ namespace SIL.FieldWorks.XWorks
 			ShowHwNumInCrossRef = config.ShowHomographNumber(HomographConfiguration.HeadwordVariant.DictionaryCrossRef);
 			ShowHwNumInReversalCrossRef = config.ShowHomographNumber(HomographConfiguration.HeadwordVariant.ReversalCrossRef);
 			HomographWritingSystem = config.WritingSystem;
-			CustomHomographNumberList = config.CustomHomographNumbers;
+			//CustomHomographNumberList = config.CustomHomographNumbers;
 		}
 
 		/// <summary>
@@ -397,11 +397,11 @@ namespace SIL.FieldWorks.XWorks
 			config.SetShowHomographNumber(HomographConfiguration.HeadwordVariant.DictionaryCrossRef, ShowHwNumInCrossRef);
 			config.SetShowHomographNumber(HomographConfiguration.HeadwordVariant.ReversalCrossRef, ShowHwNumInReversalCrossRef);
 			config.WritingSystem = HomographWritingSystem;
-			config.CustomHomographNumbers = CustomHomographNumberList;
+			//config.CustomHomographNumbers = CustomHomographNumberList;
 		}
 
-		[XmlIgnore]
-		public List<string> CustomHomographNumberList { get; internal set; }
+		//[XmlIgnore]
+		//public List<string> CustomHomographNumberList { get; internal set; }
 
 		[XmlAttribute("showHwNumInReversalCrossRef")]
 		public bool ShowHwNumInReversalCrossRef { get; set; }
@@ -421,8 +421,8 @@ namespace SIL.FieldWorks.XWorks
 		[XmlAttribute("homographNumberBefore")]
 		public bool HomographNumberBefore { get; set; }
 
-		[XmlAttribute("customHomographNumbers")]
-		public string CustomHomographNumbers
+		//[XmlAttribute("customHomographNumbers")]
+		/*public string CustomHomographNumbers
 		{
 			get
 			{
@@ -432,7 +432,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				CustomHomographNumberList = new List<string>(WebUtility.HtmlDecode(value).Split(new []{','}, StringSplitOptions.RemoveEmptyEntries));
 			}
-		}
+		}*/
 
 		[XmlAttribute("homographWritingSystem")]
 		public string HomographWritingSystem { get; set; }

--- a/Src/xWorks/DictionaryConfigurationModel.cs
+++ b/Src/xWorks/DictionaryConfigurationModel.cs
@@ -201,7 +201,6 @@ namespace SIL.FieldWorks.XWorks
 				else
 				{
 					HomographConfiguration.HomographWritingSystem = string.Empty;
-					//HomographConfiguration.CustomHomographNumbers = string.Empty;
 				}
 			}
 
@@ -370,7 +369,6 @@ namespace SIL.FieldWorks.XWorks
 			ShowSenseNumberReversal = other.ShowSenseNumberReversal;
 			HomographNumberBefore = other.HomographNumberBefore;
 			HomographWritingSystem = other.HomographWritingSystem;
-			//CustomHomographNumberList = other.CustomHomographNumberList != null ? new List<string>(other.CustomHomographNumberList) : null;
 		}
 
 		public DictionaryHomographConfiguration(HomographConfiguration config)
@@ -382,7 +380,6 @@ namespace SIL.FieldWorks.XWorks
 			ShowHwNumInCrossRef = config.ShowHomographNumber(HomographConfiguration.HeadwordVariant.DictionaryCrossRef);
 			ShowHwNumInReversalCrossRef = config.ShowHomographNumber(HomographConfiguration.HeadwordVariant.ReversalCrossRef);
 			HomographWritingSystem = config.WritingSystem;
-			//CustomHomographNumberList = config.CustomHomographNumbers;
 		}
 
 		/// <summary>
@@ -397,11 +394,7 @@ namespace SIL.FieldWorks.XWorks
 			config.SetShowHomographNumber(HomographConfiguration.HeadwordVariant.DictionaryCrossRef, ShowHwNumInCrossRef);
 			config.SetShowHomographNumber(HomographConfiguration.HeadwordVariant.ReversalCrossRef, ShowHwNumInReversalCrossRef);
 			config.WritingSystem = HomographWritingSystem;
-			//config.CustomHomographNumbers = CustomHomographNumberList;
 		}
-
-		//[XmlIgnore]
-		//public List<string> CustomHomographNumberList { get; internal set; }
 
 		[XmlAttribute("showHwNumInReversalCrossRef")]
 		public bool ShowHwNumInReversalCrossRef { get; set; }
@@ -420,19 +413,6 @@ namespace SIL.FieldWorks.XWorks
 
 		[XmlAttribute("homographNumberBefore")]
 		public bool HomographNumberBefore { get; set; }
-
-		//[XmlAttribute("customHomographNumbers")]
-		/*public string CustomHomographNumbers
-		{
-			get
-			{
-				return CustomHomographNumberList == null ? string.Empty : WebUtility.HtmlEncode(string.Join(",", CustomHomographNumberList));
-			}
-			set
-			{
-				CustomHomographNumberList = new List<string>(WebUtility.HtmlDecode(value).Split(new []{','}, StringSplitOptions.RemoveEmptyEntries));
-			}
-		}*/
 
 		[XmlAttribute("homographWritingSystem")]
 		public string HomographWritingSystem { get; set; }

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -873,7 +873,6 @@ namespace SIL.FieldWorks.XWorks
 				// ReSharper disable once AccessToDisposedClosure - can only be used before the dialog is disposed
 				dlg.RunStylesDialog += (sender, e) => HandleStylesBtn((ComboBox) sender, ((ComboBox)sender).Text);
 				dlg.SetupDialog(m_propertyTable.GetValue<IHelpTopicProvider>("HelpTopicProvider"));
-				dlg.SetStyleSheet = FontHeightAdjuster.StyleSheetFromPropertyTable(m_propertyTable);
 				//dlg.StartPosition = FormStartPosition.CenterScreen;
 				if (dlg.ShowDialog(View.TopLevelControl) != DialogResult.OK)
 					return;

--- a/Src/xWorks/HeadWordNumbersController.cs
+++ b/Src/xWorks/HeadWordNumbersController.cs
@@ -33,7 +33,7 @@ namespace SIL.FieldWorks.XWorks
 				model.IsReversal ? xWorksStrings.ReversalIndex : xWorksStrings.Dictionary,
 				Environment.NewLine,
 				model.Label);
-			_view.SetWsFactoryForCustomDigits(cache.WritingSystemFactory);
+			//_view.SetWsFactoryForCustomDigits(cache.WritingSystemFactory);
 			_view.AvailableWritingSystems = cache.LangProject.CurrentAnalysisWritingSystems.Union(cache.LangProject.CurrentVernacularWritingSystems);
 			if (_cache.LangProject.AllWritingSystems.Any(ws => ws.Id == _homographConfig.HomographWritingSystem))
 			{
@@ -49,12 +49,10 @@ namespace SIL.FieldWorks.XWorks
 			// otherwise use an empty list (which will be treated as default digits in the view).
 			IEnumerable<string> wsCustomDigits = new List<string>();
 			var writingSystem = cache.ServiceLocator.WritingSystemManager.Get(_homographConfig.HomographWritingSystem);
-			if (writingSystem != null && writingSystem.NumberingSystem.Digits.Length == 10)
+			var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
+			if (unicodeCharacters != null)
 			{
-				for (var digit = 0; digit < 10; ++digit)
-				{
-					wsCustomDigits = wsCustomDigits.Append(writingSystem.NumberingSystem.Digits[digit].ToString());
-				}
+				wsCustomDigits = unicodeCharacters;
 			}
 			_view.CustomDigits = wsCustomDigits;
 			_view.HomographBefore = _homographConfig.HomographNumberBefore;

--- a/Src/xWorks/HeadWordNumbersController.cs
+++ b/Src/xWorks/HeadWordNumbersController.cs
@@ -34,7 +34,6 @@ namespace SIL.FieldWorks.XWorks
 				model.IsReversal ? xWorksStrings.ReversalIndex : xWorksStrings.Dictionary,
 				Environment.NewLine,
 				model.Label);
-			//_view.SetWsFactoryForCustomDigits(cache.WritingSystemFactory);
 			_view.AvailableWritingSystems = cache.LangProject.CurrentAnalysisWritingSystems.Union(cache.LangProject.CurrentVernacularWritingSystems);
 			if (_cache.LangProject.AllWritingSystems.Any(ws => ws.Id == _homographConfig.HomographWritingSystem))
 			{
@@ -58,7 +57,6 @@ namespace SIL.FieldWorks.XWorks
 			{
 				// Do nothing; writingSystem is already null.
 			}
-			//var writingSystem = cache.ServiceLocator.WritingSystemManager?.Get(_homographConfig.HomographWritingSystem);
 			var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
 			if (unicodeCharacters != null)
 			{

--- a/Src/xWorks/HeadWordNumbersController.cs
+++ b/Src/xWorks/HeadWordNumbersController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using SIL.LCModel;
+using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.DomainImpl;
 
 namespace SIL.FieldWorks.XWorks
@@ -48,7 +49,16 @@ namespace SIL.FieldWorks.XWorks
 			// If possible, get digits from the writing system's numbering system,
 			// otherwise use an empty list (which will be treated as default digits in the view).
 			IEnumerable<string> wsCustomDigits = new List<string>();
-			var writingSystem = cache.ServiceLocator.WritingSystemManager.Get(_homographConfig.HomographWritingSystem);
+			CoreWritingSystemDefinition writingSystem = null;
+			try
+			{
+				writingSystem = cache.ServiceLocator.WritingSystemManager?.Get(_homographConfig.HomographWritingSystem);
+			}
+			catch(KeyNotFoundException)
+			{
+				// Do nothing; writingSystem is already null.
+			}
+			//var writingSystem = cache.ServiceLocator.WritingSystemManager?.Get(_homographConfig.HomographWritingSystem);
 			var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem?.NumberingSystem?.Digits);
 			if (unicodeCharacters != null)
 			{

--- a/Src/xWorks/HeadWordNumbersController.cs
+++ b/Src/xWorks/HeadWordNumbersController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -35,7 +35,6 @@ namespace SIL.FieldWorks.XWorks
 				model.Label);
 			_view.SetWsFactoryForCustomDigits(cache.WritingSystemFactory);
 			_view.AvailableWritingSystems = cache.LangProject.CurrentAnalysisWritingSystems.Union(cache.LangProject.CurrentVernacularWritingSystems);
-			_view.CustomDigits = _homographConfig.CustomHomographNumberList;
 			if (_cache.LangProject.AllWritingSystems.Any(ws => ws.Id == _homographConfig.HomographWritingSystem))
 			{
 				_view.HomographWritingSystem = string.IsNullOrEmpty(_homographConfig.HomographWritingSystem)
@@ -46,19 +45,23 @@ namespace SIL.FieldWorks.XWorks
 			{
 				_view.HomographWritingSystem = _cache.LangProject.AllWritingSystems.First().DisplayLabel;
 			}
+			// If possible, get digits from the writing system's numbering system,
+			// otherwise use an empty list (which will be treated as default digits in the view).
+			IEnumerable<string> wsCustomDigits = new List<string>();
+			var writingSystem = cache.ServiceLocator.WritingSystemManager.Get(_homographConfig.HomographWritingSystem);
+			if (writingSystem != null && writingSystem.NumberingSystem.Digits.Length == 10)
+			{
+				for (var digit = 0; digit < 10; ++digit)
+				{
+					wsCustomDigits = wsCustomDigits.Append(writingSystem.NumberingSystem.Digits[digit].ToString());
+				}
+			}
+			_view.CustomDigits = wsCustomDigits;
 			_view.HomographBefore = _homographConfig.HomographNumberBefore;
 			_view.ShowHomograph = _homographConfig.ShowHwNumber;
 			_view.ShowHomographOnCrossRef = _model.IsReversal ? _homographConfig.ShowHwNumInReversalCrossRef : _homographConfig.ShowHwNumInCrossRef;
 			_view.ShowSenseNumber = _model.IsReversal ? _homographConfig.ShowSenseNumberReversal : _homographConfig.ShowSenseNumber;
-			_view.OkButtonEnabled = _homographConfig.CustomHomographNumberList == null
-				|| !_homographConfig.CustomHomographNumberList.Any() || _homographConfig.CustomHomographNumberList.Count == 10;
-			_view.CustomDigitsChanged += OnViewCustomDigitsChanged;
-		}
-
-		private void OnViewCustomDigitsChanged(object sender, EventArgs eventArgs)
-		{
-			_view.OkButtonEnabled = !_view.CustomDigits.Any()
-				|| _view.CustomDigits.Count(digit => !string.IsNullOrWhiteSpace(digit)) == 10;
+			_view.OkButtonEnabled = true;
 		}
 
 		/// <summary>
@@ -93,7 +96,6 @@ namespace SIL.FieldWorks.XWorks
 			}
 			_homographConfig.HomographWritingSystem = string.IsNullOrEmpty(_view.HomographWritingSystem) ? null :
 				_cache.LangProject.AllWritingSystems.First(ws => ws.DisplayLabel == _view.HomographWritingSystem).Id;
-			_homographConfig.CustomHomographNumberList = _view.CustomDigits == null ? new List<string>() : new List<string>(_view.CustomDigits);
 			_model.HomographConfiguration = _homographConfig;
 			_homographConfig.ExportToHomographConfiguration(_cache.ServiceLocator.GetInstance<HomographConfiguration>());
 		}

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -213,6 +213,17 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
+		/// <summary>
+		/// Set the font in each digit textbox
+		/// </summary>
+		private void UpdateFontInDigits(System.Drawing.Font digitFont)
+		{
+			foreach (var digit in _digitBoxes)
+			{
+				digit.Font = digitFont;
+			}
+		}
+
 		public IEnumerable<CoreWritingSystemDefinition> AvailableWritingSystems
 		{
 			set
@@ -238,24 +249,6 @@ namespace SIL.FieldWorks.XWorks
 			}
 
 			get { return _digitBoxes.Select(db => db.Text).Where(text => !string.IsNullOrEmpty(text)); }
-		}
-
-		public event EventHandler CustomDigitsChanged
-		{
-			add
-			{
-				foreach (var textBox in _digitBoxes)
-				{
-					textBox.TextChanged += value;
-				}
-			}
-			remove
-			{
-				foreach (var textBox in _digitBoxes)
-				{
-					textBox.TextChanged -= value;
-				}
-			}
 		}
 
 		public bool OkButtonEnabled { get { return m_btnOk.Enabled; } set { m_btnOk.Enabled = value; } }
@@ -288,7 +281,8 @@ namespace SIL.FieldWorks.XWorks
 			if (selectedWs?.NumberingSystem != null)
 			{
 				var digits = selectedWs.NumberingSystem.Digits;
-
+				UpdateFontInDigits(new System.Drawing.Font(string.IsNullOrWhiteSpace(selectedWs.DefaultFontName) ? "Segoe" : selectedWs.DefaultFontName,
+					selectedWs.DefaultFontSize == 0.0f ? 12 : selectedWs.DefaultFontSize)); ;
 				if (!string.IsNullOrEmpty(digits))
 				{
 					// Populate the custom digits from writing system, if all 10 digits are specified

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -24,7 +24,7 @@ namespace SIL.FieldWorks.XWorks
 	/// </summary>
 	public partial class HeadwordNumbersDlg : Form, IHeadwordNumbersView
 	{
-		private FwTextBox[] _digitBoxes;
+		private Label[] _digitBoxes;
 
 		public HeadwordNumbersDlg()
 		{
@@ -42,7 +42,6 @@ namespace SIL.FieldWorks.XWorks
 				m_digitZero, m_digitOne, m_digitTwo, m_digitThree, m_digitFour, m_digitFive,
 				m_digitSix, m_digitSeven, m_digitEight, m_digitNine
 			};
-			Shown += (sender, args) => { UpdateWritingSystemCodeInDigits(); };
 		}
 
 		/// <summary>
@@ -198,22 +197,6 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Set the writing system code in each digit textbox
-		/// </summary>
-		private void UpdateWritingSystemCodeInDigits()
-		{
-			var wsHandle = ((CoreWritingSystemDefinition)m_writingSystemCombo.SelectedItem).Handle;
-			foreach (var digit in _digitBoxes)
-			{
-				digit.WritingSystemCode = wsHandle;
-				digit.SelectAll();
-				digit.ApplyWS(wsHandle);
-				digit.ApplyStyle("UiElement");
-				digit.RemoveSelection();
-			}
-		}
-
-		/// <summary>
 		/// Set the font in each digit textbox
 		/// </summary>
 		private void UpdateFontInDigits(System.Drawing.Font digitFont)
@@ -245,6 +228,7 @@ namespace SIL.FieldWorks.XWorks
 				for (var i = 0; i < 10; ++i)
 				{
 					_digitBoxes[i].Text = digitsArray[i];
+					_digitBoxes[i].Visible = true;
 				}
 			}
 
@@ -253,41 +237,19 @@ namespace SIL.FieldWorks.XWorks
 
 		public bool OkButtonEnabled { get { return m_btnOk.Enabled; } set { m_btnOk.Enabled = value; } }
 
-		public LcmStyleSheet SetStyleSheet
-		{
-			set
-			{
-				for (var i = 0; i < 10; ++i)
-				{
-					_digitBoxes[i].StyleSheet = value;
-				}
-			}
-		}
-
-		public void SetWsFactoryForCustomDigits(ILgWritingSystemFactory factory)
-		{
-			for (var i = 0; i < 10; ++i)
-			{
-				_digitBoxes[i].WritingSystemFactory = factory;
-			}
-		}
-
 		private void m_writingSystemCombo_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			UpdateWritingSystemCodeInDigits();
-
 			// Populate digits from ws.
 			var selectedWs = m_writingSystemCombo.SelectedItem as CoreWritingSystemDefinition;
 			if (selectedWs?.NumberingSystem != null)
 			{
 				var digits = selectedWs.NumberingSystem.Digits;
-				UpdateFontInDigits(new System.Drawing.Font(string.IsNullOrWhiteSpace(selectedWs.DefaultFontName) ? "Segoe" : selectedWs.DefaultFontName,
-					selectedWs.DefaultFontSize == 0.0f ? 12 : selectedWs.DefaultFontSize)); ;
 				if (!string.IsNullOrEmpty(digits))
 				{
-					// Populate the custom digits from writing system, if all 10 digits are specified
-					if (digits.Length == 10)
-						CustomDigits = digits.ToCharArray().Select(c => c.ToString()).ToArray();
+					// Populate the custom digits from writing system, if all digits are specified.
+					var unicodeCharacters = HeadWordNumbersHelper.GetUnicodeCharacters(digits);
+					if (unicodeCharacters != null)
+						CustomDigits = unicodeCharacters;
 				}
 			}
 		}

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -25,7 +25,6 @@ namespace SIL.FieldWorks.XWorks
 	public partial class HeadwordNumbersDlg : Form, IHeadwordNumbersView
 	{
 		private FwTextBox[] _digitBoxes;
-		private bool _isInitializing = false;
 
 		public HeadwordNumbersDlg()
 		{
@@ -192,17 +191,9 @@ namespace SIL.FieldWorks.XWorks
 			get { return m_writingSystemCombo.Text; }
 			set
 			{
-				_isInitializing = true;
-				try
-				{
-					m_writingSystemCombo.SelectedIndex = m_writingSystemCombo.FindString(value);
-					if (m_writingSystemCombo.SelectedIndex < 0)
-						m_writingSystemCombo.SelectedIndex = 0;
-				}
-				finally
-				{
-					_isInitializing = false;
-				}
+				m_writingSystemCombo.SelectedIndex = m_writingSystemCombo.FindString(value);
+				if (m_writingSystemCombo.SelectedIndex < 0)
+					m_writingSystemCombo.SelectedIndex = 0;
 			}
 		}
 
@@ -291,9 +282,6 @@ namespace SIL.FieldWorks.XWorks
 		private void m_writingSystemCombo_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			UpdateWritingSystemCodeInDigits();
-
-			if (_isInitializing)
-				return;
 
 			// Populate digits from ws.
 			var selectedWs = m_writingSystemCombo.SelectedItem as CoreWritingSystemDefinition;

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -196,17 +196,6 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		/// <summary>
-		/// Set the font in each digit textbox
-		/// </summary>
-		private void UpdateFontInDigits(System.Drawing.Font digitFont)
-		{
-			foreach (var digit in _digitBoxes)
-			{
-				digit.Font = digitFont;
-			}
-		}
-
 		public IEnumerable<CoreWritingSystemDefinition> AvailableWritingSystems
 		{
 			set

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -25,6 +25,7 @@ namespace SIL.FieldWorks.XWorks
 	public partial class HeadwordNumbersDlg : Form, IHeadwordNumbersView
 	{
 		private FwTextBox[] _digitBoxes;
+		private bool _isInitializing = false;
 
 		public HeadwordNumbersDlg()
 		{
@@ -191,9 +192,17 @@ namespace SIL.FieldWorks.XWorks
 			get { return m_writingSystemCombo.Text; }
 			set
 			{
-				m_writingSystemCombo.SelectedIndex = m_writingSystemCombo.FindString(value);
-				if (m_writingSystemCombo.SelectedIndex < 0)
-					m_writingSystemCombo.SelectedIndex = 0;
+				_isInitializing = true;
+				try
+				{
+					m_writingSystemCombo.SelectedIndex = m_writingSystemCombo.FindString(value);
+					if (m_writingSystemCombo.SelectedIndex < 0)
+						m_writingSystemCombo.SelectedIndex = 0;
+				}
+				finally
+				{
+					_isInitializing = false;
+				}
 			}
 		}
 
@@ -282,6 +291,23 @@ namespace SIL.FieldWorks.XWorks
 		private void m_writingSystemCombo_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			UpdateWritingSystemCodeInDigits();
+
+			if (_isInitializing)
+				return;
+
+			// Populate digits from ws.
+			var selectedWs = m_writingSystemCombo.SelectedItem as CoreWritingSystemDefinition;
+			if (selectedWs?.NumberingSystem != null)
+			{
+				var digits = selectedWs.NumberingSystem.Digits;
+
+				if (!string.IsNullOrEmpty(digits))
+				{
+					// Populate the custom digits from writing system, if all 10 digits are specified
+					if (digits.Length == 10)
+						CustomDigits = digits.ToCharArray().Select(c => c.ToString()).ToArray();
+				}
+			}
 		}
 	}
 }

--- a/Src/xWorks/HeadWordNumbersDlg.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.cs
@@ -229,6 +229,8 @@ namespace SIL.FieldWorks.XWorks
 				{
 					_digitBoxes[i].Text = digitsArray[i];
 					_digitBoxes[i].Visible = true;
+					// Set UseCompatibleTextRendering to false. This causes WindowsForms to use TextRenderer, which provides better fallback font performance.
+					_digitBoxes[i].UseCompatibleTextRendering = false;
 				}
 			}
 

--- a/Src/xWorks/HeadWordNumbersDlg.designer.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.designer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 

--- a/Src/xWorks/HeadWordNumbersDlg.designer.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.designer.cs
@@ -270,6 +270,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitNine.controlID = null;
 			this.m_digitNine.HasBorder = true;
 			this.m_digitNine.Name = "m_digitNine";
+			this.m_digitNine.ReadOnlyView = true;
 			this.m_digitNine.SuppressEnter = false;
 			this.m_digitNine.WordWrap = false;
 			// 
@@ -282,6 +283,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitEight.controlID = null;
 			this.m_digitEight.HasBorder = true;
 			this.m_digitEight.Name = "m_digitEight";
+			this.m_digitEight.ReadOnlyView = true;
 			this.m_digitEight.SuppressEnter = false;
 			this.m_digitEight.WordWrap = false;
 			// 
@@ -294,6 +296,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitSeven.controlID = null;
 			this.m_digitSeven.HasBorder = true;
 			this.m_digitSeven.Name = "m_digitSeven";
+			this.m_digitSeven.ReadOnlyView = true;
 			this.m_digitSeven.SuppressEnter = false;
 			this.m_digitSeven.WordWrap = false;
 			// 
@@ -306,6 +309,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitSix.controlID = null;
 			this.m_digitSix.HasBorder = true;
 			this.m_digitSix.Name = "m_digitSix";
+			this.m_digitSix.ReadOnlyView = true;
 			this.m_digitSix.SuppressEnter = false;
 			this.m_digitSix.WordWrap = false;
 			// 
@@ -318,6 +322,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitFive.controlID = null;
 			this.m_digitFive.HasBorder = true;
 			this.m_digitFive.Name = "m_digitFive";
+			this.m_digitFive.ReadOnlyView = true;
 			this.m_digitFive.SuppressEnter = false;
 			this.m_digitFive.WordWrap = false;
 			// 
@@ -330,6 +335,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitFour.controlID = null;
 			this.m_digitFour.HasBorder = true;
 			this.m_digitFour.Name = "m_digitFour";
+			this.m_digitFour.ReadOnlyView = true;
 			this.m_digitFour.SuppressEnter = false;
 			this.m_digitFour.WordWrap = false;
 			// 
@@ -342,6 +348,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitThree.controlID = null;
 			this.m_digitThree.HasBorder = true;
 			this.m_digitThree.Name = "m_digitThree";
+			this.m_digitThree.ReadOnlyView = true;
 			this.m_digitThree.SuppressEnter = false;
 			this.m_digitThree.WordWrap = false;
 			// 
@@ -354,6 +361,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitTwo.controlID = null;
 			this.m_digitTwo.HasBorder = true;
 			this.m_digitTwo.Name = "m_digitTwo";
+			this.m_digitTwo.ReadOnlyView = true;
 			this.m_digitTwo.SuppressEnter = false;
 			this.m_digitTwo.WordWrap = false;
 			// 
@@ -366,6 +374,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitOne.controlID = null;
 			this.m_digitOne.HasBorder = true;
 			this.m_digitOne.Name = "m_digitOne";
+			this.m_digitOne.ReadOnlyView = true;
 			this.m_digitOne.SuppressEnter = false;
 			this.m_digitOne.WordWrap = false;
 			// 
@@ -378,6 +387,7 @@ namespace SIL.FieldWorks.XWorks
 			this.m_digitZero.controlID = null;
 			this.m_digitZero.HasBorder = true;
 			this.m_digitZero.Name = "m_digitZero";
+			this.m_digitZero.ReadOnlyView = true;
 			this.m_digitZero.SuppressEnter = false;
 			this.m_digitZero.WordWrap = false;
 			// 

--- a/Src/xWorks/HeadWordNumbersDlg.designer.cs
+++ b/Src/xWorks/HeadWordNumbersDlg.designer.cs
@@ -52,16 +52,16 @@ namespace SIL.FieldWorks.XWorks
 			this.buttonLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
 			this.customNumbersPanel = new System.Windows.Forms.Panel();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.m_digitNine = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitEight = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitSeven = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitSix = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitFive = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitFour = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitThree = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitTwo = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitOne = new SIL.FieldWorks.Common.Widgets.FwTextBox();
-			this.m_digitZero = new SIL.FieldWorks.Common.Widgets.FwTextBox();
+			this.m_digitNine = new System.Windows.Forms.Label();
+			this.m_digitEight = new System.Windows.Forms.Label();
+			this.m_digitSeven = new System.Windows.Forms.Label();
+			this.m_digitSix = new System.Windows.Forms.Label();
+			this.m_digitFive = new System.Windows.Forms.Label();
+			this.m_digitFour = new System.Windows.Forms.Label();
+			this.m_digitThree = new System.Windows.Forms.Label();
+			this.m_digitTwo = new System.Windows.Forms.Label();
+			this.m_digitOne = new System.Windows.Forms.Label();
+			this.m_digitZero = new System.Windows.Forms.Label();
 			this.label11 = new System.Windows.Forms.Label();
 			this.label10 = new System.Windows.Forms.Label();
 			this.label9 = new System.Windows.Forms.Label();
@@ -90,16 +90,6 @@ namespace SIL.FieldWorks.XWorks
 			this.buttonLayoutPanel.SuspendLayout();
 			this.customNumbersPanel.SuspendLayout();
 			this.tableLayoutPanel1.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitNine)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitEight)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitSeven)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitSix)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitFive)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitFour)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitThree)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitTwo)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitOne)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitZero)).BeginInit();
 			this.homographStylePanel.SuspendLayout();
 			this.senseNumberStylePanel.SuspendLayout();
 			this.SuspendLayout();
@@ -263,133 +253,54 @@ namespace SIL.FieldWorks.XWorks
 			// 
 			// m_digitNine
 			// 
-			this.m_digitNine.AcceptsReturn = false;
-			this.m_digitNine.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitNine, "m_digitNine");
-			this.m_digitNine.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitNine.controlID = null;
-			this.m_digitNine.HasBorder = true;
+			this.m_digitNine.BackColor = System.Drawing.SystemColors.Control;
 			this.m_digitNine.Name = "m_digitNine";
-			this.m_digitNine.ReadOnlyView = true;
-			this.m_digitNine.SuppressEnter = false;
-			this.m_digitNine.WordWrap = false;
 			// 
 			// m_digitEight
 			// 
-			this.m_digitEight.AcceptsReturn = false;
-			this.m_digitEight.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitEight, "m_digitEight");
-			this.m_digitEight.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitEight.controlID = null;
-			this.m_digitEight.HasBorder = true;
 			this.m_digitEight.Name = "m_digitEight";
-			this.m_digitEight.ReadOnlyView = true;
-			this.m_digitEight.SuppressEnter = false;
-			this.m_digitEight.WordWrap = false;
 			// 
 			// m_digitSeven
 			// 
-			this.m_digitSeven.AcceptsReturn = false;
-			this.m_digitSeven.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitSeven, "m_digitSeven");
-			this.m_digitSeven.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitSeven.controlID = null;
-			this.m_digitSeven.HasBorder = true;
 			this.m_digitSeven.Name = "m_digitSeven";
-			this.m_digitSeven.ReadOnlyView = true;
-			this.m_digitSeven.SuppressEnter = false;
-			this.m_digitSeven.WordWrap = false;
 			// 
 			// m_digitSix
 			// 
-			this.m_digitSix.AcceptsReturn = false;
-			this.m_digitSix.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitSix, "m_digitSix");
-			this.m_digitSix.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitSix.controlID = null;
-			this.m_digitSix.HasBorder = true;
 			this.m_digitSix.Name = "m_digitSix";
-			this.m_digitSix.ReadOnlyView = true;
-			this.m_digitSix.SuppressEnter = false;
-			this.m_digitSix.WordWrap = false;
 			// 
 			// m_digitFive
 			// 
-			this.m_digitFive.AcceptsReturn = false;
-			this.m_digitFive.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitFive, "m_digitFive");
-			this.m_digitFive.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitFive.controlID = null;
-			this.m_digitFive.HasBorder = true;
 			this.m_digitFive.Name = "m_digitFive";
-			this.m_digitFive.ReadOnlyView = true;
-			this.m_digitFive.SuppressEnter = false;
-			this.m_digitFive.WordWrap = false;
 			// 
 			// m_digitFour
 			// 
-			this.m_digitFour.AcceptsReturn = false;
-			this.m_digitFour.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitFour, "m_digitFour");
-			this.m_digitFour.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitFour.controlID = null;
-			this.m_digitFour.HasBorder = true;
 			this.m_digitFour.Name = "m_digitFour";
-			this.m_digitFour.ReadOnlyView = true;
-			this.m_digitFour.SuppressEnter = false;
-			this.m_digitFour.WordWrap = false;
 			// 
 			// m_digitThree
 			// 
-			this.m_digitThree.AcceptsReturn = false;
-			this.m_digitThree.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitThree, "m_digitThree");
-			this.m_digitThree.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitThree.controlID = null;
-			this.m_digitThree.HasBorder = true;
 			this.m_digitThree.Name = "m_digitThree";
-			this.m_digitThree.ReadOnlyView = true;
-			this.m_digitThree.SuppressEnter = false;
-			this.m_digitThree.WordWrap = false;
 			// 
 			// m_digitTwo
 			// 
-			this.m_digitTwo.AcceptsReturn = false;
-			this.m_digitTwo.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitTwo, "m_digitTwo");
-			this.m_digitTwo.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitTwo.controlID = null;
-			this.m_digitTwo.HasBorder = true;
 			this.m_digitTwo.Name = "m_digitTwo";
-			this.m_digitTwo.ReadOnlyView = true;
-			this.m_digitTwo.SuppressEnter = false;
-			this.m_digitTwo.WordWrap = false;
 			// 
 			// m_digitOne
 			// 
-			this.m_digitOne.AcceptsReturn = false;
-			this.m_digitOne.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitOne, "m_digitOne");
-			this.m_digitOne.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitOne.controlID = null;
-			this.m_digitOne.HasBorder = true;
 			this.m_digitOne.Name = "m_digitOne";
-			this.m_digitOne.ReadOnlyView = true;
-			this.m_digitOne.SuppressEnter = false;
-			this.m_digitOne.WordWrap = false;
 			// 
 			// m_digitZero
 			// 
-			this.m_digitZero.AcceptsReturn = false;
-			this.m_digitZero.AdjustStringHeight = true;
 			resources.ApplyResources(this.m_digitZero, "m_digitZero");
-			this.m_digitZero.BackColor = System.Drawing.SystemColors.Window;
-			this.m_digitZero.controlID = null;
-			this.m_digitZero.HasBorder = true;
 			this.m_digitZero.Name = "m_digitZero";
-			this.m_digitZero.ReadOnlyView = true;
-			this.m_digitZero.SuppressEnter = false;
-			this.m_digitZero.WordWrap = false;
 			// 
 			// label11
 			// 
@@ -543,16 +454,6 @@ namespace SIL.FieldWorks.XWorks
 			this.customNumbersPanel.PerformLayout();
 			this.tableLayoutPanel1.ResumeLayout(false);
 			this.tableLayoutPanel1.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitNine)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitEight)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitSeven)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitSix)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitFive)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitFour)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitThree)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitTwo)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitOne)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.m_digitZero)).EndInit();
 			this.homographStylePanel.ResumeLayout(false);
 			this.homographStylePanel.PerformLayout();
 			this.senseNumberStylePanel.ResumeLayout(false);
@@ -603,15 +504,15 @@ namespace SIL.FieldWorks.XWorks
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.Label label1;
-		private Common.Widgets.FwTextBox m_digitNine;
-		private Common.Widgets.FwTextBox m_digitEight;
-		private Common.Widgets.FwTextBox m_digitSeven;
-		private Common.Widgets.FwTextBox m_digitSix;
-		private Common.Widgets.FwTextBox m_digitFive;
-		private Common.Widgets.FwTextBox m_digitFour;
-		private Common.Widgets.FwTextBox m_digitThree;
-		private Common.Widgets.FwTextBox m_digitTwo;
-		private Common.Widgets.FwTextBox m_digitOne;
-		private Common.Widgets.FwTextBox m_digitZero;
+		private System.Windows.Forms.Label m_digitNine;
+		private System.Windows.Forms.Label m_digitEight;
+		private System.Windows.Forms.Label m_digitSeven;
+		private System.Windows.Forms.Label m_digitSix;
+		private System.Windows.Forms.Label m_digitFive;
+		private System.Windows.Forms.Label m_digitFour;
+		private System.Windows.Forms.Label m_digitThree;
+		private System.Windows.Forms.Label m_digitTwo;
+		private System.Windows.Forms.Label m_digitOne;
+		private System.Windows.Forms.Label m_digitZero;
 	}
 }

--- a/Src/xWorks/HeadWordNumbersDlg.resx
+++ b/Src/xWorks/HeadWordNumbersDlg.resx
@@ -1309,7 +1309,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>2</value>
   </data>
   <data name="m_customNumbersLabel.Text" xml:space="preserve">
-    <value>If the selected Writing System uses custom numbers, they will be displayed below and used for homograph and sense numbers. Custom numbers can be specified in the Writing System configuration.</value>
+    <value>If the writing system uses custom numbers, they will be displayed below. Custom numbers can be specified in writing system configuration.</value>
   </data>
   <data name="&gt;&gt;m_customNumbersLabel.Name" xml:space="preserve">
     <value>m_customNumbersLabel</value>

--- a/Src/xWorks/HeadWordNumbersDlg.resx
+++ b/Src/xWorks/HeadWordNumbersDlg.resx
@@ -123,10 +123,14 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 161</value>
+    <value>20, 198</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>287, 13</value>
+    <value>356, 16</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -150,10 +154,13 @@
     <value>True</value>
   </data>
   <data name="m_chkShowHomographNumInDict.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 21</value>
+    <value>8, 26</value>
+  </data>
+  <data name="m_chkShowHomographNumInDict.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkShowHomographNumInDict.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 17</value>
+    <value>152, 20</value>
   </data>
   <data name="m_chkShowHomographNumInDict.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -176,15 +183,17 @@
   <data name="m_chkShowSenseNumber.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="m_chkShowSenseNumber.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="m_chkShowSenseNumber.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 40</value>
+    <value>35, 49</value>
+  </data>
+  <data name="m_chkShowSenseNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkShowSenseNumber.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 17</value>
+    <value>119, 20</value>
   </data>
   <data name="m_chkShowSenseNumber.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -205,10 +214,13 @@
     <value>1</value>
   </data>
   <data name="m_btnOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 3</value>
+    <value>160, 4</value>
+  </data>
+  <data name="m_btnOk.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_btnOk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>100, 28</value>
   </data>
   <data name="m_btnOk.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -229,10 +241,13 @@
     <value>2</value>
   </data>
   <data name="m_btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>201, 3</value>
+    <value>268, 4</value>
+  </data>
+  <data name="m_btnCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_btnCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>100, 28</value>
   </data>
   <data name="m_btnCancel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -253,10 +268,13 @@
     <value>1</value>
   </data>
   <data name="m_btnHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 3</value>
+    <value>376, 4</value>
+  </data>
+  <data name="m_btnHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_btnHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>100, 28</value>
   </data>
   <data name="m_btnHelp.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -280,10 +298,13 @@
     <value>True</value>
   </data>
   <data name="m_radioBefore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 19</value>
+    <value>7, 23</value>
+  </data>
+  <data name="m_radioBefore.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_radioBefore.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>68, 20</value>
   </data>
   <data name="m_radioBefore.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -307,10 +328,13 @@
     <value>True</value>
   </data>
   <data name="m_radioAfter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 20</value>
+    <value>107, 25</value>
+  </data>
+  <data name="m_radioAfter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_radioAfter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 17</value>
+    <value>55, 20</value>
   </data>
   <data name="m_radioAfter.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -340,10 +364,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="dialogDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="dialogDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="dialogDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>338, 46</value>
+    <value>451, 57</value>
   </data>
   <data name="dialogDescription.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -366,13 +393,16 @@
     <value>0</value>
   </data>
   <data name="m_configurationDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 55</value>
+    <value>4, 69</value>
+  </data>
+  <data name="m_configurationDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_configurationDescription.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="m_configurationDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>338, 31</value>
+    <value>451, 38</value>
   </data>
   <data name="m_configurationDescription.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -397,10 +427,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>TopDown</value>
   </data>
   <data name="descriptionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>8, 4</value>
+  </data>
+  <data name="descriptionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="descriptionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 97</value>
+    <value>480, 119</value>
   </data>
   <data name="descriptionPanel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -418,10 +451,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>0</value>
   </data>
   <data name="referenceNumberGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 279</value>
+    <value>8, 345</value>
+  </data>
+  <data name="referenceNumberGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="referenceNumberGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="referenceNumberGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>270, 61</value>
+    <value>360, 75</value>
   </data>
   <data name="referenceNumberGroup.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -448,10 +487,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="m_radioNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>153, 20</value>
+    <value>204, 25</value>
+  </data>
+  <data name="m_radioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_radioNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
+    <value>61, 20</value>
   </data>
   <data name="m_radioNone.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -472,10 +514,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>0</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 106</value>
+    <value>8, 131</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>270, 44</value>
+    <value>360, 54</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -502,10 +550,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>RightToLeft</value>
   </data>
   <data name="buttonLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 507</value>
+    <value>8, 624</value>
+  </data>
+  <data name="buttonLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="buttonLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 31</value>
+    <value>480, 38</value>
   </data>
   <data name="buttonLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -532,10 +583,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitNine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 31</value>
+    <value>364, 39</value>
+  </data>
+  <data name="m_digitNine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitNine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 23</value>
+    <value>33, 27</value>
   </data>
   <data name="m_digitNine.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -544,7 +598,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitNine</value>
   </data>
   <data name="&gt;&gt;m_digitNine.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitNine.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -559,10 +613,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitEight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>243, 31</value>
+    <value>324, 39</value>
+  </data>
+  <data name="m_digitEight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitEight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitEight.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -571,7 +628,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitEight</value>
   </data>
   <data name="&gt;&gt;m_digitEight.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitEight.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -586,10 +643,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitSeven.Location" type="System.Drawing.Point, System.Drawing">
-    <value>213, 31</value>
+    <value>284, 39</value>
+  </data>
+  <data name="m_digitSeven.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitSeven.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitSeven.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -598,7 +658,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitSeven</value>
   </data>
   <data name="&gt;&gt;m_digitSeven.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitSeven.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -613,10 +673,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitSix.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 31</value>
+    <value>244, 39</value>
+  </data>
+  <data name="m_digitSix.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitSix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitSix.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -625,7 +688,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitSix</value>
   </data>
   <data name="&gt;&gt;m_digitSix.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitSix.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -640,10 +703,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitFive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>153, 31</value>
+    <value>204, 39</value>
+  </data>
+  <data name="m_digitFive.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitFive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitFive.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -652,7 +718,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitFive</value>
   </data>
   <data name="&gt;&gt;m_digitFive.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitFive.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -667,10 +733,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitFour.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 31</value>
+    <value>164, 39</value>
+  </data>
+  <data name="m_digitFour.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitFour.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitFour.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -679,7 +748,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitFour</value>
   </data>
   <data name="&gt;&gt;m_digitFour.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitFour.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -694,10 +763,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitThree.Location" type="System.Drawing.Point, System.Drawing">
-    <value>93, 31</value>
+    <value>124, 39</value>
+  </data>
+  <data name="m_digitThree.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitThree.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitThree.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -706,7 +778,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitThree</value>
   </data>
   <data name="&gt;&gt;m_digitThree.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitThree.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -721,10 +793,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitTwo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>63, 31</value>
+    <value>84, 39</value>
+  </data>
+  <data name="m_digitTwo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitTwo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitTwo.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -733,7 +808,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitTwo</value>
   </data>
   <data name="&gt;&gt;m_digitTwo.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitTwo.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -748,10 +823,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitOne.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 31</value>
+    <value>44, 39</value>
+  </data>
+  <data name="m_digitOne.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitOne.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitOne.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -760,7 +838,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitOne</value>
   </data>
   <data name="&gt;&gt;m_digitOne.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitOne.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -775,10 +853,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Microsoft Sans Serif, 100pt</value>
   </data>
   <data name="m_digitZero.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 31</value>
+    <value>4, 39</value>
+  </data>
+  <data name="m_digitZero.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_digitZero.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 23</value>
+    <value>32, 27</value>
   </data>
   <data name="m_digitZero.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -787,7 +868,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>m_digitZero</value>
   </data>
   <data name="&gt;&gt;m_digitZero.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=8.3.5.25382, Culture=neutral, PublicKeyToken=null</value>
+    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;m_digitZero.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -805,10 +886,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 0</value>
+    <value>364, 0</value>
+  </data>
+  <data name="label11.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 28</value>
+    <value>33, 35</value>
   </data>
   <data name="label11.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -841,10 +925,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>243, 0</value>
+    <value>324, 0</value>
+  </data>
+  <data name="label10.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -877,10 +964,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>213, 0</value>
+    <value>284, 0</value>
+  </data>
+  <data name="label9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -913,10 +1003,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 0</value>
+    <value>244, 0</value>
+  </data>
+  <data name="label8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -949,10 +1042,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>153, 0</value>
+    <value>204, 0</value>
+  </data>
+  <data name="label7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -985,10 +1081,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 0</value>
+    <value>164, 0</value>
+  </data>
+  <data name="label6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1021,10 +1120,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>93, 0</value>
+    <value>124, 0</value>
+  </data>
+  <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1057,10 +1159,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>63, 0</value>
+    <value>84, 0</value>
+  </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1093,10 +1198,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 0</value>
+    <value>44, 0</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1126,10 +1234,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>True</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
+    <value>4, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 28</value>
+    <value>32, 35</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1153,13 +1264,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>19</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 75</value>
+    <value>9, 92</value>
+  </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>301, 57</value>
+    <value>401, 70</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1180,19 +1294,22 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="m_digitNine" Row="1" RowSpan="1" Column="9" ColumnSpan="1" /&gt;&lt;Control Name="m_digitEight" Row="1" RowSpan="1" Column="8" ColumnSpan="1" /&gt;&lt;Control Name="m_digitSeven" Row="1" RowSpan="1" Column="7" ColumnSpan="1" /&gt;&lt;Control Name="m_digitSix" Row="1" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="m_digitFive" Row="1" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="m_digitFour" Row="1" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="m_digitThree" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="m_digitTwo" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="m_digitOne" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="m_digitZero" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label11" Row="0" RowSpan="1" Column="9" ColumnSpan="1" /&gt;&lt;Control Name="label10" Row="0" RowSpan="1" Column="8" ColumnSpan="1" /&gt;&lt;Control Name="label9" Row="0" RowSpan="1" Column="7" ColumnSpan="1" /&gt;&lt;Control Name="label8" Row="0" RowSpan="1" Column="6" ColumnSpan="1" /&gt;&lt;Control Name="label7" Row="0" RowSpan="1" Column="5" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="0" RowSpan="1" Column="4" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,10,Percent,10,Percent,10,Percent,10,Percent,10,Percent,10,Percent,10,Percent,10,Percent,10,Percent,10" /&gt;&lt;Rows Styles="Percent,50,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="m_customNumbersLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 45</value>
+    <value>8, 55</value>
+  </data>
+  <data name="m_customNumbersLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_customNumbersLabel.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="m_customNumbersLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 38</value>
+    <value>461, 47</value>
   </data>
   <data name="m_customNumbersLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="m_customNumbersLabel.Text" xml:space="preserve">
-    <value>To use characters other than 0-9 for homograph and sense numbers enter the characters here:</value>
+    <value>If the selected Writing System uses custom numbers, they will be displayed below and used for homograph and sense numbers. Custom numbers can be specified in the Writing System configuration.</value>
   </data>
   <data name="&gt;&gt;m_customNumbersLabel.Name" xml:space="preserve">
     <value>m_customNumbersLabel</value>
@@ -1207,10 +1324,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>1</value>
   </data>
   <data name="m_writingSystemCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 18</value>
+    <value>7, 22</value>
+  </data>
+  <data name="m_writingSystemCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_writingSystemCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>244, 24</value>
   </data>
   <data name="m_writingSystemCombo.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1231,10 +1351,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>True</value>
   </data>
   <data name="m_writingSystemLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 2</value>
+    <value>4, 2</value>
+  </data>
+  <data name="m_writingSystemLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="m_writingSystemLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 13</value>
+    <value>310, 16</value>
   </data>
   <data name="m_writingSystemLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1255,10 +1378,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>3</value>
   </data>
   <data name="customNumbersPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 346</value>
+    <value>8, 428</value>
+  </data>
+  <data name="customNumbersPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="customNumbersPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 138</value>
+    <value>455, 170</value>
   </data>
   <data name="customNumbersPanel.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -1276,10 +1402,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>4</value>
   </data>
   <data name="_homographStyleButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>195, 29</value>
+    <value>260, 36</value>
+  </data>
+  <data name="_homographStyleButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_homographStyleButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
+    <value>100, 26</value>
   </data>
   <data name="_homographStyleButton.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1300,13 +1429,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>0</value>
   </data>
   <data name="styleLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="styleLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="styleLabel.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="styleLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 24</value>
+    <value>447, 30</value>
   </data>
   <data name="styleLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1327,10 +1459,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>1</value>
   </data>
   <data name="_homographStyleCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 29</value>
+    <value>4, 36</value>
+  </data>
+  <data name="_homographStyleCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_homographStyleCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 21</value>
+    <value>247, 24</value>
   </data>
   <data name="_homographStyleCombo.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1348,10 +1483,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>2</value>
   </data>
   <data name="homographStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 156</value>
+    <value>8, 193</value>
+  </data>
+  <data name="homographStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="homographStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 57</value>
+    <value>455, 70</value>
   </data>
   <data name="homographStylePanel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -1372,10 +1510,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>NoControl</value>
   </data>
   <data name="_senseNumberStyleBtn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>195, 27</value>
+    <value>260, 33</value>
+  </data>
+  <data name="_senseNumberStyleBtn.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_senseNumberStyleBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
+    <value>100, 26</value>
   </data>
   <data name="_senseNumberStyleBtn.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1396,13 +1537,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>0</value>
   </data>
   <data name="_senseStyleLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
+    <value>4, 0</value>
+  </data>
+  <data name="_senseStyleLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_senseStyleLabel.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="_senseStyleLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 24</value>
+    <value>447, 30</value>
   </data>
   <data name="_senseStyleLabel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1423,10 +1567,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>1</value>
   </data>
   <data name="_senseStyleCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 27</value>
+    <value>4, 33</value>
+  </data>
+  <data name="_senseStyleCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_senseStyleCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 21</value>
+    <value>247, 24</value>
   </data>
   <data name="_senseStyleCombo.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1444,10 +1591,13 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>2</value>
   </data>
   <data name="senseNumberStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 219</value>
+    <value>8, 271</value>
+  </data>
+  <data name="senseNumberStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="senseNumberStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 54</value>
+    <value>455, 66</value>
   </data>
   <data name="senseNumberStylePanel.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -1471,16 +1621,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>0, 0</value>
   </data>
   <data name="mainLayoutTable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
+    <value>7, 6, 7, 6</value>
   </data>
   <data name="mainLayoutTable.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>4, 0, 0, 0</value>
   </data>
   <data name="mainLayoutTable.RowCount" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
   <data name="mainLayoutTable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>369, 541</value>
+    <value>492, 666</value>
   </data>
   <data name="mainLayoutTable.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1504,13 +1654,16 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>8, 16</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>369, 541</value>
+    <value>492, 666</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>385, 580</value>
+    <value>507, 703</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Configure Headword Numbers</value>

--- a/Src/xWorks/HeadWordNumbersDlg.resx
+++ b/Src/xWorks/HeadWordNumbersDlg.resx
@@ -360,6 +360,26 @@
   <data name="descriptionPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="dialogDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="dialogDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="dialogDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="dialogDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 57</value>
+  </data>
+  <data name="dialogDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="dialogDescription.Text" xml:space="preserve">
+    <value>Configure the homograph and sense numbers that appear on:
+• entry headwords
+• references to entries and senses</value>
+  </data>
   <data name="&gt;&gt;dialogDescription.Name" xml:space="preserve">
     <value>dialogDescription</value>
   </data>
@@ -371,6 +391,25 @@
   </data>
   <data name="&gt;&gt;dialogDescription.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="m_configurationDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 69</value>
+  </data>
+  <data name="m_configurationDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="m_configurationDescription.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_configurationDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 38</value>
+  </data>
+  <data name="m_configurationDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="m_configurationDescription.Text" xml:space="preserve">
+    <value>These settings affect the current TYPESTRING configuration:
+Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;m_configurationDescription.Name" xml:space="preserve">
     <value>m_configurationDescription</value>
@@ -440,6 +479,27 @@
   </data>
   <data name="&gt;&gt;referenceNumberGroup.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="m_radioNone.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_radioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="m_radioNone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>204, 25</value>
+  </data>
+  <data name="m_radioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="m_radioNone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="m_radioNone.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="m_radioNone.Text" xml:space="preserve">
+    <value>None</value>
   </data>
   <data name="&gt;&gt;m_radioNone.Name" xml:space="preserve">
     <value>m_radioNone</value>
@@ -520,7 +580,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="m_digitNine.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitNine.Location" type="System.Drawing.Point, System.Drawing">
     <value>364, 39</value>
@@ -556,7 +616,7 @@
     <value>True</value>
   </data>
   <data name="m_digitEight.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitEight.Location" type="System.Drawing.Point, System.Drawing">
     <value>324, 39</value>
@@ -592,7 +652,7 @@
     <value>True</value>
   </data>
   <data name="m_digitSeven.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitSeven.Location" type="System.Drawing.Point, System.Drawing">
     <value>284, 39</value>
@@ -628,7 +688,7 @@
     <value>True</value>
   </data>
   <data name="m_digitSix.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitSix.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 39</value>
@@ -664,7 +724,7 @@
     <value>True</value>
   </data>
   <data name="m_digitFive.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitFive.Location" type="System.Drawing.Point, System.Drawing">
     <value>204, 39</value>
@@ -700,7 +760,7 @@
     <value>True</value>
   </data>
   <data name="m_digitFour.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitFour.Location" type="System.Drawing.Point, System.Drawing">
     <value>164, 39</value>
@@ -736,7 +796,7 @@
     <value>True</value>
   </data>
   <data name="m_digitThree.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitThree.Location" type="System.Drawing.Point, System.Drawing">
     <value>124, 39</value>
@@ -772,7 +832,7 @@
     <value>True</value>
   </data>
   <data name="m_digitTwo.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitTwo.Location" type="System.Drawing.Point, System.Drawing">
     <value>84, 39</value>
@@ -808,7 +868,7 @@
     <value>True</value>
   </data>
   <data name="m_digitOne.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitOne.Location" type="System.Drawing.Point, System.Drawing">
     <value>44, 39</value>
@@ -844,7 +904,7 @@
     <value>True</value>
   </data>
   <data name="m_digitZero.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI Symbol, 7.8pt</value>
+    <value>Segoe UI, 7.8pt</value>
   </data>
   <data name="m_digitZero.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 39</value>
@@ -1398,258 +1458,6 @@
   <data name="&gt;&gt;customNumbersPanel.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;_homographStyleButton.Name" xml:space="preserve">
-    <value>_homographStyleButton</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleButton.Parent" xml:space="preserve">
-    <value>homographStylePanel</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;styleLabel.Name" xml:space="preserve">
-    <value>styleLabel</value>
-  </data>
-  <data name="&gt;&gt;styleLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;styleLabel.Parent" xml:space="preserve">
-    <value>homographStylePanel</value>
-  </data>
-  <data name="&gt;&gt;styleLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleCombo.Name" xml:space="preserve">
-    <value>_homographStyleCombo</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleCombo.Parent" xml:space="preserve">
-    <value>homographStylePanel</value>
-  </data>
-  <data name="&gt;&gt;_homographStyleCombo.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="homographStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 193</value>
-  </data>
-  <data name="homographStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="homographStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 70</value>
-  </data>
-  <data name="homographStylePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Name" xml:space="preserve">
-    <value>homographStylePanel</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Parent" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;_senseNumberStyleBtn.Name" xml:space="preserve">
-    <value>_senseNumberStyleBtn</value>
-  </data>
-  <data name="&gt;&gt;_senseNumberStyleBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_senseNumberStyleBtn.Parent" xml:space="preserve">
-    <value>senseNumberStylePanel</value>
-  </data>
-  <data name="&gt;&gt;_senseNumberStyleBtn.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleLabel.Name" xml:space="preserve">
-    <value>_senseStyleLabel</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleLabel.Parent" xml:space="preserve">
-    <value>senseNumberStylePanel</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleCombo.Name" xml:space="preserve">
-    <value>_senseStyleCombo</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleCombo.Parent" xml:space="preserve">
-    <value>senseNumberStylePanel</value>
-  </data>
-  <data name="&gt;&gt;_senseStyleCombo.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="senseNumberStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 271</value>
-  </data>
-  <data name="senseNumberStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="senseNumberStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 66</value>
-  </data>
-  <data name="senseNumberStylePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Name" xml:space="preserve">
-    <value>senseNumberStylePanel</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Parent" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="mainLayoutTable.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="mainLayoutTable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="mainLayoutTable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>7, 6, 7, 6</value>
-  </data>
-  <data name="mainLayoutTable.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 0, 0</value>
-  </data>
-  <data name="mainLayoutTable.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="mainLayoutTable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>492, 666</value>
-  </data>
-  <data name="mainLayoutTable.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Name" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="mainLayoutTable.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="descriptionPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="referenceNumberGroup" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonLayoutPanel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="customNumbersPanel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="homographStylePanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="senseNumberStylePanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="dialogDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="dialogDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
-  </data>
-  <data name="dialogDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="dialogDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 57</value>
-  </data>
-  <data name="dialogDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="dialogDescription.Text" xml:space="preserve">
-    <value>Configure the homograph and sense numbers that appear on:
-• entry headwords
-• references to entries and senses</value>
-  </data>
-  <data name="&gt;&gt;dialogDescription.Name" xml:space="preserve">
-    <value>dialogDescription</value>
-  </data>
-  <data name="&gt;&gt;dialogDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dialogDescription.Parent" xml:space="preserve">
-    <value>descriptionPanel</value>
-  </data>
-  <data name="&gt;&gt;dialogDescription.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="m_configurationDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 69</value>
-  </data>
-  <data name="m_configurationDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="m_configurationDescription.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="m_configurationDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 38</value>
-  </data>
-  <data name="m_configurationDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="m_configurationDescription.Text" xml:space="preserve">
-    <value>These settings affect the current TYPESTRING configuration:
-Example-string DO NOT LOCALIZE THIS STRING</value>
-  </data>
-  <data name="&gt;&gt;m_configurationDescription.Name" xml:space="preserve">
-    <value>m_configurationDescription</value>
-  </data>
-  <data name="&gt;&gt;m_configurationDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;m_configurationDescription.Parent" xml:space="preserve">
-    <value>descriptionPanel</value>
-  </data>
-  <data name="&gt;&gt;m_configurationDescription.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="m_radioNone.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="m_radioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="m_radioNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>204, 25</value>
-  </data>
-  <data name="m_radioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="m_radioNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
-  </data>
-  <data name="m_radioNone.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="m_radioNone.Text" xml:space="preserve">
-    <value>None</value>
-  </data>
-  <data name="&gt;&gt;m_radioNone.Name" xml:space="preserve">
-    <value>m_radioNone</value>
-  </data>
-  <data name="&gt;&gt;m_radioNone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;m_radioNone.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;m_radioNone.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="_homographStyleButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>260, 36</value>
   </data>
@@ -1730,6 +1538,30 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;_homographStyleCombo.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="homographStylePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 193</value>
+  </data>
+  <data name="homographStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="homographStylePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 70</value>
+  </data>
+  <data name="homographStylePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Name" xml:space="preserve">
+    <value>homographStylePanel</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Parent" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="_senseNumberStyleBtn.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1814,6 +1646,66 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;_senseStyleCombo.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="senseNumberStylePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 271</value>
+  </data>
+  <data name="senseNumberStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="senseNumberStylePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 66</value>
+  </data>
+  <data name="senseNumberStylePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Name" xml:space="preserve">
+    <value>senseNumberStylePanel</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Parent" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="mainLayoutTable.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="mainLayoutTable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="mainLayoutTable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 6, 7, 6</value>
+  </data>
+  <data name="mainLayoutTable.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="mainLayoutTable.RowCount" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="mainLayoutTable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>492, 666</value>
+  </data>
+  <data name="mainLayoutTable.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Name" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="mainLayoutTable.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="descriptionPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="referenceNumberGroup" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonLayoutPanel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="customNumbersPanel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="homographStylePanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="senseNumberStylePanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Src/xWorks/HeadWordNumbersDlg.resx
+++ b/Src/xWorks/HeadWordNumbersDlg.resx
@@ -360,26 +360,6 @@
   <data name="descriptionPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="dialogDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="dialogDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
-  </data>
-  <data name="dialogDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="dialogDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 57</value>
-  </data>
-  <data name="dialogDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="dialogDescription.Text" xml:space="preserve">
-    <value>Configure the homograph and sense numbers that appear on:
-• entry headwords
-• references to entries and senses</value>
-  </data>
   <data name="&gt;&gt;dialogDescription.Name" xml:space="preserve">
     <value>dialogDescription</value>
   </data>
@@ -391,25 +371,6 @@
   </data>
   <data name="&gt;&gt;dialogDescription.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="m_configurationDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 69</value>
-  </data>
-  <data name="m_configurationDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="m_configurationDescription.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="m_configurationDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 38</value>
-  </data>
-  <data name="m_configurationDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="m_configurationDescription.Text" xml:space="preserve">
-    <value>These settings affect the current TYPESTRING configuration:
-Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;m_configurationDescription.Name" xml:space="preserve">
     <value>m_configurationDescription</value>
@@ -479,27 +440,6 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;referenceNumberGroup.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="m_radioNone.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="m_radioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="m_radioNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>204, 25</value>
-  </data>
-  <data name="m_radioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="m_radioNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
-  </data>
-  <data name="m_radioNone.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="m_radioNone.Text" xml:space="preserve">
-    <value>None</value>
   </data>
   <data name="&gt;&gt;m_radioNone.Name" xml:space="preserve">
     <value>m_radioNone</value>
@@ -580,7 +520,7 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="m_digitNine.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitNine.Location" type="System.Drawing.Point, System.Drawing">
     <value>364, 39</value>
@@ -594,11 +534,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitNine.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
+  <data name="m_digitNine.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitNine.Name" xml:space="preserve">
     <value>m_digitNine</value>
   </data>
   <data name="&gt;&gt;m_digitNine.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitNine.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -609,8 +552,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitEight.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitEight.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitEight.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitEight.Location" type="System.Drawing.Point, System.Drawing">
     <value>324, 39</value>
@@ -624,11 +570,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitEight.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
+  <data name="m_digitEight.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitEight.Name" xml:space="preserve">
     <value>m_digitEight</value>
   </data>
   <data name="&gt;&gt;m_digitEight.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitEight.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -639,8 +588,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitSeven.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitSeven.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitSeven.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitSeven.Location" type="System.Drawing.Point, System.Drawing">
     <value>284, 39</value>
@@ -654,11 +606,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitSeven.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
+  <data name="m_digitSeven.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitSeven.Name" xml:space="preserve">
     <value>m_digitSeven</value>
   </data>
   <data name="&gt;&gt;m_digitSeven.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitSeven.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -669,8 +624,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitSix.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitSix.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitSix.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitSix.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 39</value>
@@ -684,11 +642,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitSix.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
+  <data name="m_digitSix.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitSix.Name" xml:space="preserve">
     <value>m_digitSix</value>
   </data>
   <data name="&gt;&gt;m_digitSix.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitSix.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -699,8 +660,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitFive.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitFive.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitFive.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitFive.Location" type="System.Drawing.Point, System.Drawing">
     <value>204, 39</value>
@@ -714,11 +678,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitFive.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
+  <data name="m_digitFive.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitFive.Name" xml:space="preserve">
     <value>m_digitFive</value>
   </data>
   <data name="&gt;&gt;m_digitFive.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitFive.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -729,8 +696,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitFour.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitFour.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitFour.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitFour.Location" type="System.Drawing.Point, System.Drawing">
     <value>164, 39</value>
@@ -744,11 +714,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitFour.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
+  <data name="m_digitFour.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitFour.Name" xml:space="preserve">
     <value>m_digitFour</value>
   </data>
   <data name="&gt;&gt;m_digitFour.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitFour.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -759,8 +732,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitThree.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitThree.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitThree.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitThree.Location" type="System.Drawing.Point, System.Drawing">
     <value>124, 39</value>
@@ -774,11 +750,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitThree.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
+  <data name="m_digitThree.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitThree.Name" xml:space="preserve">
     <value>m_digitThree</value>
   </data>
   <data name="&gt;&gt;m_digitThree.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitThree.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -789,8 +768,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitTwo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitTwo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitTwo.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitTwo.Location" type="System.Drawing.Point, System.Drawing">
     <value>84, 39</value>
@@ -804,11 +786,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitTwo.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
+  <data name="m_digitTwo.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitTwo.Name" xml:space="preserve">
     <value>m_digitTwo</value>
   </data>
   <data name="&gt;&gt;m_digitTwo.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitTwo.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -819,8 +804,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitOne.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitOne.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitOne.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitOne.Location" type="System.Drawing.Point, System.Drawing">
     <value>44, 39</value>
@@ -834,11 +822,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitOne.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
+  <data name="m_digitOne.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitOne.Name" xml:space="preserve">
     <value>m_digitOne</value>
   </data>
   <data name="&gt;&gt;m_digitOne.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitOne.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -849,8 +840,11 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitZero.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="m_digitZero.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="m_digitZero.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 100pt</value>
+    <value>Segoe UI Symbol, 7.8pt</value>
   </data>
   <data name="m_digitZero.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 39</value>
@@ -864,11 +858,14 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="m_digitZero.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
+  <data name="m_digitZero.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
   <data name="&gt;&gt;m_digitZero.Name" xml:space="preserve">
     <value>m_digitZero</value>
   </data>
   <data name="&gt;&gt;m_digitZero.Type" xml:space="preserve">
-    <value>SIL.FieldWorks.Common.Widgets.FwTextBox, Widgets, Version=9.3.8.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_digitZero.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -1401,6 +1398,258 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   <data name="&gt;&gt;customNumbersPanel.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="&gt;&gt;_homographStyleButton.Name" xml:space="preserve">
+    <value>_homographStyleButton</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleButton.Parent" xml:space="preserve">
+    <value>homographStylePanel</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;styleLabel.Name" xml:space="preserve">
+    <value>styleLabel</value>
+  </data>
+  <data name="&gt;&gt;styleLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;styleLabel.Parent" xml:space="preserve">
+    <value>homographStylePanel</value>
+  </data>
+  <data name="&gt;&gt;styleLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleCombo.Name" xml:space="preserve">
+    <value>_homographStyleCombo</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleCombo.Parent" xml:space="preserve">
+    <value>homographStylePanel</value>
+  </data>
+  <data name="&gt;&gt;_homographStyleCombo.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="homographStylePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 193</value>
+  </data>
+  <data name="homographStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="homographStylePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 70</value>
+  </data>
+  <data name="homographStylePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Name" xml:space="preserve">
+    <value>homographStylePanel</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.Parent" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;homographStylePanel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;_senseNumberStyleBtn.Name" xml:space="preserve">
+    <value>_senseNumberStyleBtn</value>
+  </data>
+  <data name="&gt;&gt;_senseNumberStyleBtn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_senseNumberStyleBtn.Parent" xml:space="preserve">
+    <value>senseNumberStylePanel</value>
+  </data>
+  <data name="&gt;&gt;_senseNumberStyleBtn.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleLabel.Name" xml:space="preserve">
+    <value>_senseStyleLabel</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleLabel.Parent" xml:space="preserve">
+    <value>senseNumberStylePanel</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleCombo.Name" xml:space="preserve">
+    <value>_senseStyleCombo</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleCombo.Parent" xml:space="preserve">
+    <value>senseNumberStylePanel</value>
+  </data>
+  <data name="&gt;&gt;_senseStyleCombo.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="senseNumberStylePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 271</value>
+  </data>
+  <data name="senseNumberStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="senseNumberStylePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 66</value>
+  </data>
+  <data name="senseNumberStylePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Name" xml:space="preserve">
+    <value>senseNumberStylePanel</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.Parent" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;senseNumberStylePanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="mainLayoutTable.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="mainLayoutTable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="mainLayoutTable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>7, 6, 7, 6</value>
+  </data>
+  <data name="mainLayoutTable.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 0, 0</value>
+  </data>
+  <data name="mainLayoutTable.RowCount" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="mainLayoutTable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>492, 666</value>
+  </data>
+  <data name="mainLayoutTable.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Name" xml:space="preserve">
+    <value>mainLayoutTable</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mainLayoutTable.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="mainLayoutTable.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="descriptionPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="referenceNumberGroup" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonLayoutPanel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="customNumbersPanel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="homographStylePanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="senseNumberStylePanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="dialogDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="dialogDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="dialogDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="dialogDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 57</value>
+  </data>
+  <data name="dialogDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="dialogDescription.Text" xml:space="preserve">
+    <value>Configure the homograph and sense numbers that appear on:
+• entry headwords
+• references to entries and senses</value>
+  </data>
+  <data name="&gt;&gt;dialogDescription.Name" xml:space="preserve">
+    <value>dialogDescription</value>
+  </data>
+  <data name="&gt;&gt;dialogDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dialogDescription.Parent" xml:space="preserve">
+    <value>descriptionPanel</value>
+  </data>
+  <data name="&gt;&gt;dialogDescription.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="m_configurationDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 69</value>
+  </data>
+  <data name="m_configurationDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="m_configurationDescription.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_configurationDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 38</value>
+  </data>
+  <data name="m_configurationDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="m_configurationDescription.Text" xml:space="preserve">
+    <value>These settings affect the current TYPESTRING configuration:
+Example-string DO NOT LOCALIZE THIS STRING</value>
+  </data>
+  <data name="&gt;&gt;m_configurationDescription.Name" xml:space="preserve">
+    <value>m_configurationDescription</value>
+  </data>
+  <data name="&gt;&gt;m_configurationDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_configurationDescription.Parent" xml:space="preserve">
+    <value>descriptionPanel</value>
+  </data>
+  <data name="&gt;&gt;m_configurationDescription.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="m_radioNone.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_radioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="m_radioNone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>204, 25</value>
+  </data>
+  <data name="m_radioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="m_radioNone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="m_radioNone.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="m_radioNone.Text" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="&gt;&gt;m_radioNone.Name" xml:space="preserve">
+    <value>m_radioNone</value>
+  </data>
+  <data name="&gt;&gt;m_radioNone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_radioNone.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;m_radioNone.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="_homographStyleButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>260, 36</value>
   </data>
@@ -1481,30 +1730,6 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;_homographStyleCombo.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="homographStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 193</value>
-  </data>
-  <data name="homographStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="homographStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 70</value>
-  </data>
-  <data name="homographStylePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Name" xml:space="preserve">
-    <value>homographStylePanel</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.Parent" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;homographStylePanel.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="_senseNumberStyleBtn.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1589,66 +1814,6 @@ Example-string DO NOT LOCALIZE THIS STRING</value>
   </data>
   <data name="&gt;&gt;_senseStyleCombo.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="senseNumberStylePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 271</value>
-  </data>
-  <data name="senseNumberStylePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="senseNumberStylePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 66</value>
-  </data>
-  <data name="senseNumberStylePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Name" xml:space="preserve">
-    <value>senseNumberStylePanel</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.Parent" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;senseNumberStylePanel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="mainLayoutTable.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="mainLayoutTable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="mainLayoutTable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>7, 6, 7, 6</value>
-  </data>
-  <data name="mainLayoutTable.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 0, 0</value>
-  </data>
-  <data name="mainLayoutTable.RowCount" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="mainLayoutTable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>492, 666</value>
-  </data>
-  <data name="mainLayoutTable.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Name" xml:space="preserve">
-    <value>mainLayoutTable</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mainLayoutTable.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="mainLayoutTable.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="descriptionPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="referenceNumberGroup" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="groupBox1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="buttonLayoutPanel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="customNumbersPanel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="homographStylePanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="senseNumberStylePanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Src/xWorks/HeadWordNumbersHelper.cs
+++ b/Src/xWorks/HeadWordNumbersHelper.cs
@@ -4,6 +4,15 @@ namespace SIL.FieldWorks.XWorks
 {
 	public static class HeadWordNumbersHelper
 	{
+		/// <summary>
+		/// Splits a given string of digits into a list of Unicode characters, handling surrogate pairs if present.
+		/// The string should contain exactly 10 Unicode characters (which may be represented by more than 10 char values if surrogate pairs are used).
+		/// These unicode characters should map in order from 0 to 9.
+		/// If the string is null, empty, or does not contain exactly 10 Unicode characters, this method returns null.
+		/// Otherwise, it returns a list of the 10 Unicode characters as strings.
+		/// </summary>
+		/// <param name="digits"></param>
+		/// <returns></returns>
 		public static List<string> GetUnicodeCharacters(string digits)
 		{
 			if (!string.IsNullOrEmpty(digits))

--- a/Src/xWorks/HeadWordNumbersHelper.cs
+++ b/Src/xWorks/HeadWordNumbersHelper.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace SIL.FieldWorks.XWorks
+{
+	public static class HeadWordNumbersHelper
+	{
+		public static List<string> GetUnicodeCharacters(string digits)
+		{
+			if (!string.IsNullOrEmpty(digits))
+			{
+				// Note that some digits use surrogate pairs in UTF-16, so it's not as simple as splitting into a char array.
+				// We need to check for surrogate pairs to split everything correctly into Unicode characters.
+				var characters = new List<string>();
+				for (int i = 0; i < digits.Length; i++)
+				{
+					// The first part of a surrogate pair is the high surrogate and the second part is the low surrogate.
+					if (char.IsHighSurrogate(digits[i]) && i + 1 < digits.Length &&
+						char.IsLowSurrogate(digits[i + 1]))
+					{
+						characters.Add(digits.Substring(i, 2));
+						i++; // Skip the next char since it's part of the surrogate pair we just added.
+					}
+					else
+					{
+						characters.Add(digits[i].ToString());
+					}
+				}
+				if (characters.Count == 10)
+					return characters;
+			}
+			return null;
+		}
+	}
+}

--- a/Src/xWorks/IHeadwordNumbersView.cs
+++ b/Src/xWorks/IHeadwordNumbersView.cs
@@ -25,6 +25,5 @@ namespace SIL.FieldWorks.XWorks
 		string HomographWritingSystem { get; set; }
 		IEnumerable<CoreWritingSystemDefinition> AvailableWritingSystems { set; }
 		IEnumerable<string> CustomDigits { get; set; }
-		void SetWsFactoryForCustomDigits(ILgWritingSystemFactory factory);
 	}
 }

--- a/Src/xWorks/IHeadwordNumbersView.cs
+++ b/Src/xWorks/IHeadwordNumbersView.cs
@@ -16,7 +16,6 @@ namespace SIL.FieldWorks.XWorks
 	public interface IHeadwordNumbersView
 	{
 		event EventHandler RunStylesDialog;
-		event EventHandler CustomDigitsChanged;
 		bool HomographBefore { get; set; }
 		bool ShowHomograph { get; set; }
 		bool ShowHomographOnCrossRef { get; set; }

--- a/Src/xWorks/xWorksTests/DictionaryConfigurationModelTests.cs
+++ b/Src/xWorks/xWorksTests/DictionaryConfigurationModelTests.cs
@@ -501,7 +501,6 @@ namespace SIL.FieldWorks.XWorks
 					Label = "root",
 					HomographConfiguration = new DictionaryHomographConfiguration
 					{
-						CustomHomographNumbers = "0;1;2;3;4;5;6;7;8;9",
 						HomographNumberBefore = true,
 						HomographWritingSystem = "en",
 						ShowHwNumber = true,
@@ -1234,7 +1233,6 @@ namespace SIL.FieldWorks.XWorks
 			// If we were on NUnit 4
 			// Assert.That(model.HomographConfiguration, Is.EqualTo(clone.HomographConfiguration).UsingPropertiesComparer());
 			// But we're not, so we have to do it manually or implement otherwise unnecessary equality interfaces
-			Assert.That(model.HomographConfiguration.CustomHomographNumbers, Is.EqualTo(clone.HomographConfiguration.CustomHomographNumbers));
 			Assert.That(model.HomographConfiguration.HomographNumberBefore, Is.EqualTo(clone.HomographConfiguration.HomographNumberBefore));
 			Assert.That(model.HomographConfiguration.HomographWritingSystem, Is.EqualTo(clone.HomographConfiguration.HomographWritingSystem));
 			Assert.That(model.HomographConfiguration.ShowHwNumber, Is.EqualTo(clone.HomographConfiguration.ShowHwNumber));

--- a/Src/xWorks/xWorksTests/HeadwordNumbersControllerTests.cs
+++ b/Src/xWorks/xWorksTests/HeadwordNumbersControllerTests.cs
@@ -9,6 +9,9 @@ using SIL.LCModel;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.DomainImpl;
+using DocumentFormat.OpenXml.EMMA;
+using Paratext.Data.Linguistics.Morph;
+using SIL.WritingSystems;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -138,49 +141,34 @@ namespace SIL.FieldWorks.XWorks
 		public void Ok_Enabled_WithNoCustomNumbers()
 		{
 			// Test enabled on initial setup
-			var view = new TestHeadwordNumbersView {OkButtonEnabled = false};
+			var view = new TestHeadwordNumbersView { OkButtonEnabled = false };
 			var model = new DictionaryConfigurationModel();
 			var controller = new HeadwordNumbersController(view, model, Cache);
 			// verify ok button enabled on setup with no numbers
-			Assert.That(view.OkButtonEnabled, Is.True, "Ok not enabled by controller constructor");
-			view.OkButtonEnabled = false;
-			// verify ok button enabled when event is triggered and there are no custom numbers
-			view.TriggerCustomDigitsChanged();
-			Assert.That(view.OkButtonEnabled, Is.True, "Ok button not enabled when event is fired");
+			Assert.That(view.OkButtonEnabled, Is.True,
+				"Ok not enabled by controller constructor");
 		}
 
 		[Test]
-		public void Ok_Enabled_WithAllTenNumbers()
+		public void CustomDigits_Default_Ok_Enabled_WhenNotAllTenNumbersSet()
 		{
-			// Test enabled on initial setup
-			var view = new TestHeadwordNumbersView { OkButtonEnabled = false };
-			var model = new DictionaryConfigurationModel
+			var model = new DictionaryConfigurationModel()
 			{
-				HomographConfiguration = new DictionaryHomographConfiguration
-				{
-					CustomHomographNumbers = "a,b,c,d,e,f,g,h,i,j"
-				}
+				HomographConfiguration = new DictionaryHomographConfiguration()
 			};
-			var controller = new HeadwordNumbersController(view, model, Cache);
-			// verify ok button enabled on setup with 10 numbers
-			Assert.That(view.OkButtonEnabled, Is.True, "Ok not enabled by controller constructor");
-			view.OkButtonEnabled = false;
-			// verify ok button enabled when event is triggered and there are 10 custom numbers
-			view.TriggerCustomDigitsChanged();
-			Assert.That(view.OkButtonEnabled, Is.True, "Ok button not enabled when event is fired");
-		}
+			var view = new TestHeadwordNumbersView()
+			{
+				HomographWritingSystem = model.HomographConfiguration.HomographWritingSystem = "en"
+			};
+			var writingSystem = Cache.ServiceLocator.WritingSystemManager.Get(view.HomographWritingSystem);
+			writingSystem.NumberingSystem = NumberingSystemDefinition.CreateCustomSystem("1");
 
-		[Test]
-		public void Ok_Disabled_WhenNotAllTenNumbersSet()
-		{
-			// Test enabled on initial setup
-			var view = new TestHeadwordNumbersView();
-			var model = new DictionaryConfigurationModel();
-			var controller = new HeadwordNumbersController(view, model, Cache);
-			view.OkButtonEnabled = true;
-			view.CustomDigits = new List<string> { "1" };
-			view.TriggerCustomDigitsChanged();
-			Assert.That(view.OkButtonEnabled, Is.False, "Ok button still enabled after event is fired");
+			// If the writing system doesn't have a valid numbering system with 10 digits,
+			// the view should fall back to the default latin digits and still enable Ok.
+			var defaultNumberingSystem = NumberingSystemDefinition.CreateCustomSystem("0123456789");
+			var testController = new HeadwordNumbersController(view, model, Cache);
+			Assert.That(view.CustomDigits, Is.EqualTo(HeadWordNumbersHelper.GetUnicodeCharacters(defaultNumberingSystem.Digits)));
+			Assert.That(view.OkButtonEnabled, Is.True, "Ok button not enabled after event is fired");
 		}
 
 		[Test]
@@ -235,20 +223,21 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		[Test]
-		public void ConstructorSetsCustomHeadwordNumbersInView()
+		public void ConstructorSetsHeadwordWritingSystemNumbersInView()
 		{
-			var view = new TestHeadwordNumbersView();
-			var model = new DictionaryConfigurationModel
+			var model = new DictionaryConfigurationModel()
 			{
-				HomographConfiguration = new DictionaryHomographConfiguration
-				{
-					CustomHomographNumbers = "a;b;c;d;e;f;g;h;i;j;k"
-				}
+				HomographConfiguration = new DictionaryHomographConfiguration()
 			};
-			// ReSharper disable once UnusedVariable
-			// SUT
+			var view = new TestHeadwordNumbersView()
+			{
+				HomographWritingSystem = model.HomographConfiguration.HomographWritingSystem = "en"
+			};
+			var writingSystem = Cache.ServiceLocator.WritingSystemManager.Get(view.HomographWritingSystem);
+			writingSystem.NumberingSystem = NumberingSystemDefinition.CreateCustomSystem("abcdefghij");
+
 			var testController = new HeadwordNumbersController(view, model, Cache);
-			Assert.That(view.CustomDigits, Is.EqualTo(model.HomographConfiguration.CustomHomographNumberList));
+			Assert.That(view.CustomDigits, Is.EqualTo(HeadWordNumbersHelper.GetUnicodeCharacters(writingSystem.NumberingSystem.Digits)));
 		}
 
 		public class TestHeadwordNumbersView : IHeadwordNumbersView
@@ -267,13 +256,7 @@ namespace SIL.FieldWorks.XWorks
 #pragma warning restore 67
 			public IEnumerable<CoreWritingSystemDefinition> AvailableWritingSystems { private get; set; }
 			public IEnumerable<string> CustomDigits { get; set; }
-			public event EventHandler CustomDigitsChanged;
 			public bool OkButtonEnabled { get; set; }
-
-			internal void TriggerCustomDigitsChanged()
-			{
-				CustomDigitsChanged(this, null);
-			}
 			public void SetWsFactoryForCustomDigits(ILgWritingSystemFactory factory) { }
 		}
 	}

--- a/Src/xWorks/xWorksTests/HeadwordNumbersControllerTests.cs
+++ b/Src/xWorks/xWorksTests/HeadwordNumbersControllerTests.cs
@@ -9,8 +9,6 @@ using SIL.LCModel;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.DomainImpl;
-using DocumentFormat.OpenXml.EMMA;
-using Paratext.Data.Linguistics.Morph;
 using SIL.WritingSystems;
 
 namespace SIL.FieldWorks.XWorks


### PR DESCRIPTION
* Remove option to add custom numbers from dictionary configuration > headword numbers. Instead, get the numbering system associated with the WS selected for headword numbers and display these numbers in the headword numbers configuration.
* Ensure the WS numbering system is used for homograph/sense numbers in ConfiguredLCMGenerator. 
* In the Configure Headword Numbers dlg, use Winforms labels for number display instead of Fwtextboxes, which don't display all glyphs correctly.
* Update WS custom number handling to include the case when a drop-down preset is selected by the user, instead of typed in custom numbers.
* Handle UTF-16 surrogate pairs via GetUnicodeCharacters helper function in new HeadWordNumbersHelper class.
* Update expected behavior in tests related to headword numbers.
* Remove tests related to setting custom headword numbers, since this is no longer allowed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/855)
<!-- Reviewable:end -->
