### PR TITLE
Fix new problem with LT-11746: Make Preview aware of publication

### DIFF
--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -51,7 +51,7 @@ namespace SIL.FieldWorks.XWorks
 			var xhtmlPath = Path.ChangeExtension(preferredPath, "xhtml");
 			try
 			{
-				SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, false, isLexEditPreviewOnly);
+				SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, isLexEditPreviewOnly: isLexEditPreviewOnly);
 			}
 			catch (IOException ioEx)
 			{
@@ -63,7 +63,7 @@ namespace SIL.FieldWorks.XWorks
 					xhtmlPath = Path.ChangeExtension(preferredPath + i, "xhtml");
 					try
 					{
-						SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, false, isLexEditPreviewOnly);
+						SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, isLexEditPreviewOnly: isLexEditPreviewOnly);
 					}
 					catch (IOException e)
 					{
@@ -88,6 +88,7 @@ namespace SIL.FieldWorks.XWorks
 			var cache = propertyTable.GetValue<LcmCache>("cache", null);
 			if (publicationDecorator == null)
 			{
+				// Used by unit tests.
 				isLexEditPreviewOnly = true;
 			}
 			// Don't display letter headers if we're showing a preview in the Edit tool or we're not sorting by headword

--- a/Src/xWorks/LcmXhtmlGenerator.cs
+++ b/Src/xWorks/LcmXhtmlGenerator.cs
@@ -45,13 +45,13 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		/// <returns>The path to the XHTML file</returns>
 		public static string SavePreviewHtmlWithStyles(int[] entryHvos, RecordClerk clerk, DictionaryPublicationDecorator publicationDecorator, DictionaryConfigurationModel configuration, XCore.PropertyTable propertyTable,
-			IThreadedProgress progress = null, int entriesPerPage = EntriesPerPage)
+			IThreadedProgress progress = null, int entriesPerPage = EntriesPerPage, bool isLexEditPreviewOnly = false)
 		{
 			var preferredPath = GetPreferredPreviewPath(configuration, propertyTable.GetValue<LcmCache>("cache"), entryHvos.Length == 1);
 			var xhtmlPath = Path.ChangeExtension(preferredPath, "xhtml");
 			try
 			{
-				SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress);
+				SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, false, isLexEditPreviewOnly);
 			}
 			catch (IOException ioEx)
 			{
@@ -63,7 +63,7 @@ namespace SIL.FieldWorks.XWorks
 					xhtmlPath = Path.ChangeExtension(preferredPath + i, "xhtml");
 					try
 					{
-						SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress);
+						SavePublishedHtmlWithStyles(entryHvos, clerk, publicationDecorator, entriesPerPage, configuration, propertyTable, xhtmlPath, progress, false, isLexEditPreviewOnly);
 					}
 					catch (IOException e)
 					{
@@ -81,13 +81,17 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		public static void SavePublishedHtmlWithStyles(int[] entryHvos, RecordClerk clerk, DictionaryPublicationDecorator publicationDecorator, int entriesPerPage,
 			DictionaryConfigurationModel configuration, XCore.PropertyTable propertyTable, string xhtmlPath, IThreadedProgress progress = null,
-			bool isXhtmlExport = false)
+			bool isXhtmlExport = false, bool isLexEditPreviewOnly = false)
 		{
 			var entryCount = entryHvos.Length;
 			var cssPath = Path.ChangeExtension(xhtmlPath, "css");
 			var cache = propertyTable.GetValue<LcmCache>("cache", null);
+			if (publicationDecorator == null)
+			{
+				isLexEditPreviewOnly = true;
+			}
 			// Don't display letter headers if we're showing a preview in the Edit tool or we're not sorting by headword
-			var wantLetterHeaders = (entryCount > 1 || !IsLexEditPreviewOnly(publicationDecorator)) && (RecordClerk.IsClerkSortingByHeadword(clerk));
+			var wantLetterHeaders = (entryCount > 1 || !isLexEditPreviewOnly) && (RecordClerk.IsClerkSortingByHeadword(clerk));
 			using (var xhtmlWriter = XmlWriter.Create(xhtmlPath))
 			using (var cssWriter = new StreamWriter(cssPath, false, Encoding.UTF8))
 			{
@@ -146,7 +150,7 @@ namespace SIL.FieldWorks.XWorks
 
 				if (progress != null)
 					progress.Message = xWorksStrings.ksGeneratingStyleInfo;
-				if (!IsLexEditPreviewOnly(publicationDecorator) && !IsExport(settings))
+				if (!isLexEditPreviewOnly && !IsExport(settings))
 				{
 					cssWriter.Write(CssGenerator.GenerateCssForSelectedEntry(settings.RightToLeft));
 					ConfiguredLcmGenerator.CopyFileSafely(settings, Path.Combine(FwDirectoryFinder.FlexFolder, ImagesFolder, CurrentEntryMarker), CurrentEntryMarker);
@@ -309,11 +313,6 @@ namespace SIL.FieldWorks.XWorks
 			var confName = XhtmlDocView.MakeFilenameSafeForHtml(Path.GetFileNameWithoutExtension(config.FilePath));
 			var fileName = isSingleEntryPreview ? confName + "-Preview" : confName;
 			return Path.Combine(basePath, fileName);
-		}
-
-		private static bool IsLexEditPreviewOnly(DictionaryPublicationDecorator decorator)
-		{
-			return decorator == null;
 		}
 
 		private static void GenerateTopOfPageButtonsIfNeeded(ConfiguredLcmGenerator.GeneratorSettings settings, int[] entryHvos, int entriesPerPage, Tuple<int, int> currentPageBounds, XmlWriter xhtmlWriter, StreamWriter cssWriter)

--- a/Src/xWorks/XhtmlRecordDocView.cs
+++ b/Src/xWorks/XhtmlRecordDocView.cs
@@ -10,6 +10,7 @@ using SIL.Utils;
 using SIL.Windows.Forms.HtmlBrowser;
 using System;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 using XCore;
@@ -25,6 +26,38 @@ namespace SIL.FieldWorks.XWorks
 	{
 		private XWebBrowser m_mainView;
 		internal string m_configObjectName;
+		private DictionaryPublicationDecorator m_pubDecorator;
+
+		public DictionaryPublicationDecorator PublicationDecorator
+		{
+			get
+			{
+				if (m_pubDecorator == null)
+				{
+					m_pubDecorator = new DictionaryPublicationDecorator(Cache, Clerk.VirtualListPublisher, Clerk.VirtualFlid);
+				}
+				var pubName = GetCurrentPublication();
+				if (xWorksStrings.AllEntriesPublication == pubName)
+				{
+					// A null publication means show everything
+					m_pubDecorator.Publication = null;
+				}
+				else
+				{
+					// look up the publication object
+
+					var pub = (from item in Cache.LangProject.LexDbOA.PublicationTypesOA.PossibilitiesOS
+							   where item.Name.UserDefaultWritingSystem.Text == pubName
+							   select item).FirstOrDefault();
+					if (pub != null && pub != m_pubDecorator.Publication)
+					{
+						// change the publication if it is different from the current one
+						m_pubDecorator.Publication = pub;
+					}
+				}
+				return m_pubDecorator;
+			}
+		}
 
 		public override void Init(Mediator mediator, PropertyTable propertyTable, XmlNode configurationParameters)
 		{
@@ -54,6 +87,13 @@ namespace SIL.FieldWorks.XWorks
 				"backColor", "Window");
 			BackColor = Color.FromName(backColorName);
 			m_configObjectName = XmlUtils.GetOptionalAttributeValue(m_configurationParameters, "configureObjectName", null);
+		}
+
+		private string GetCurrentPublication()
+		{
+			// Returns the current publication and use '$$all_entries$$' if none has yet been set
+			return m_propertyTable.GetStringProperty("SelectedPublication",
+			 xWorksStrings.AllEntriesPublication);
 		}
 
 		/// <summary>
@@ -126,7 +166,8 @@ namespace SIL.FieldWorks.XWorks
 					return;
 				}
 				var configuration = new DictionaryConfigurationModel(configurationFile, Cache);
-				var xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new [] { cmo.Hvo }, Clerk, null, configuration, m_propertyTable);
+				PublicationDecorator.Refresh();
+				var xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new [] { cmo.Hvo }, Clerk, PublicationDecorator, configuration, m_propertyTable);
 				m_mainView.Url = new Uri(xhtmlPath);
 				m_mainView.Refresh(WebBrowserRefreshOption.Completely);
 			}

--- a/Src/xWorks/XhtmlRecordDocView.cs
+++ b/Src/xWorks/XhtmlRecordDocView.cs
@@ -167,7 +167,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 				var configuration = new DictionaryConfigurationModel(configurationFile, Cache);
 				PublicationDecorator.Refresh();
-				var xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new [] { cmo.Hvo }, Clerk, PublicationDecorator, configuration, m_propertyTable);
+				var xhtmlPath = LcmXhtmlGenerator.SavePreviewHtmlWithStyles(new [] { cmo.Hvo }, Clerk, PublicationDecorator, configuration, m_propertyTable, isLexEditPreviewOnly: true);
 				m_mainView.Url = new Uri(xhtmlPath);
 				m_mainView.Refresh(WebBrowserRefreshOption.Completely);
 			}


### PR DESCRIPTION
This fixes a new problem with https://jira.sil.org/browse/LT-11746: Lexical relations shouldn't be shown if they are not in the current publication.  The solution was to pass in a DictionaryPublicationDecorator like the one in XhtmlDocView.cs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/858)
<!-- Reviewable:end -->
