### PR TITLE
Fix LT-22508: text not enabled; text deletion issues

### DIFF
--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -268,7 +268,7 @@ namespace SIL.FieldWorks.IText
 			else
 				createAndInsertMethodObj = new NonUndoableCreateAndInsertStText(Cache, this);
 			var newText = m_list.DoCreateAndInsert(createAndInsertMethodObj);
-
+			InterestingTextsDecorator.ClearInterestingTextsList(m_propertyTable);
 			// Check to if a genre was assigned to this text
 			// (when selected from the text list: ie a genre w/o a text was sellected)
 			string property = GetCorrespondingPropertyName("DelayedGenreAssignment");

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -269,6 +269,7 @@ namespace SIL.FieldWorks.IText
 			else
 				createAndInsertMethodObj = new NonUndoableCreateAndInsertStText(Cache, this);
 			var newText = m_list.DoCreateAndInsert(createAndInsertMethodObj);
+
 			// Check to if a genre was assigned to this text
 			// (when selected from the text list: ie a genre w/o a text was sellected)
 			string property = GetCorrespondingPropertyName("DelayedGenreAssignment");

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -27,7 +27,7 @@ namespace SIL.FieldWorks.IText
 			get { return m_wsPrevText; }
 			set { m_wsPrevText = value; }
 		}
-		private int m_langProjectTextFlid = 0;
+		private int m_langProjectTextsFlid = 0;
 
 		/// <summary>
 		/// Get the list of currently selected Scripture section ids.
@@ -304,11 +304,11 @@ namespace SIL.FieldWorks.IText
 		public override void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
 		{
 			base.PropChanged(hvo, tag, ivMin, cvIns, cvDel);
-			if (m_langProjectTextFlid == 0)
+			if (m_langProjectTextsFlid == 0)
 			{
-				m_langProjectTextFlid = Cache.MetaDataCacheAccessor.GetFieldId("LangProject", "Texts", true);
+				m_langProjectTextsFlid = Cache.MetaDataCacheAccessor.GetFieldId("LangProject", "Texts", true);
 			}
-			if (tag == m_langProjectTextFlid && (cvIns > 0 || cvDel > 0))
+			if (tag == m_langProjectTextsFlid && (cvIns > 0 || cvDel > 0))
 			{
 				InterestingTextsDecorator.ClearInterestingTextsList(m_propertyTable);
 			}

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -27,6 +27,7 @@ namespace SIL.FieldWorks.IText
 			get { return m_wsPrevText; }
 			set { m_wsPrevText = value; }
 		}
+		private int m_langProjectTextFlid = 0;
 
 		/// <summary>
 		/// Get the list of currently selected Scripture section ids.
@@ -268,7 +269,6 @@ namespace SIL.FieldWorks.IText
 			else
 				createAndInsertMethodObj = new NonUndoableCreateAndInsertStText(Cache, this);
 			var newText = m_list.DoCreateAndInsert(createAndInsertMethodObj);
-			InterestingTextsDecorator.ClearInterestingTextsList(m_propertyTable);
 			// Check to if a genre was assigned to this text
 			// (when selected from the text list: ie a genre w/o a text was sellected)
 			string property = GetCorrespondingPropertyName("DelayedGenreAssignment");
@@ -298,6 +298,19 @@ namespace SIL.FieldWorks.IText
 			// waiting for 'Activate' to return!
 			//link.Activate();
 			return true;
+		}
+
+		public override void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
+		{
+			base.PropChanged(hvo, tag, ivMin, cvIns, cvDel);
+			if (m_langProjectTextFlid == 0)
+			{
+				m_langProjectTextFlid = Cache.MetaDataCacheAccessor.GetFieldId("LangProject", "Texts", true);
+			}
+			if (tag == m_langProjectTextFlid && (cvIns > 0 || cvDel > 0))
+			{
+				InterestingTextsDecorator.ClearInterestingTextsList(m_propertyTable);
+			}
 		}
 
 		internal abstract class CreateAndInsertStText : RecordList.ICreateAndInsert<IStText>

--- a/Src/xWorks/InterestingTextsDecorator.cs
+++ b/Src/xWorks/InterestingTextsDecorator.cs
@@ -1,16 +1,16 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using SIL.LCModel;
+using SIL.LCModel.Application;
+using SIL.LCModel.Core.Cellar;
+using SIL.LCModel.Core.KernelInterfaces;
+using SIL.LCModel.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
-using SIL.LCModel.Core.Cellar;
-using SIL.LCModel.Core.KernelInterfaces;
-using SIL.LCModel;
-using SIL.LCModel.Application;
-using SIL.LCModel.Infrastructure;
 using XCore;
 
 namespace SIL.FieldWorks.XWorks
@@ -102,6 +102,11 @@ namespace SIL.FieldWorks.XWorks
 				services.GetInstance<ISilDataAccessManaged>().AddNotification(interestingTextList);
 			}
 			return interestingTextList;
+		}
+
+		static public void ClearInterestingTextsList(PropertyTable propertyTable)
+		{
+			propertyTable.SetProperty(InterestingTextKey, null, false);
 		}
 
 		void m_interestingTexts_InterestingTextsChanged(object sender, InterestingTextsChangedArgs e)

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -295,8 +295,8 @@ namespace SIL.FieldWorks.XWorks
 
 		/// <summary>
 		/// We watch for changes to DateModified and update the status bar if we are controlling it.
-		/// </summary>
-		public void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
+		///  </summary>
+		public virtual void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
 		{
 			if (hvo != CurrentObjectHvo)
 				return;


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22508.  I don't think that this was a regression.  The latest change to InterestingTextsDecorator was April 7th.  I tried a version from March 31st and the bug was still there.  The penultimate change was in 2017.

I added a PropChanged to clear the cache of InterestingTextsList when needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/866)
<!-- Reviewable:end -->
