### PR TITLE
LT 22373: Fix reversal numbers

### DIFF
--- a/Src/FwCoreDlgs/FwCoreDlgControls/ConfigSenseLayout.Designer.cs
+++ b/Src/FwCoreDlgs/FwCoreDlgControls/ConfigSenseLayout.Designer.cs
@@ -54,78 +54,78 @@ namespace SIL.FieldWorks.FwCoreDlgControls
 			this.m_chkSenseParagraphStyle = new System.Windows.Forms.CheckBox();
 			this.m_grpSenseNumber.SuspendLayout();
 			this.SuspendLayout();
-			//
+			// 
 			// m_cbNumberFont
-			//
+			// 
 			resources.ApplyResources(this.m_cbNumberFont, "m_cbNumberFont");
 			this.m_cbNumberFont.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.m_cbNumberFont.FormattingEnabled = true;
 			this.m_cbNumberFont.Name = "m_cbNumberFont";
-			//
+			// 
 			// m_cbNumberStyle
-			//
+			// 
 			resources.ApplyResources(this.m_cbNumberStyle, "m_cbNumberStyle");
 			this.m_cbNumberStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.m_cbNumberStyle.FormattingEnabled = true;
 			this.m_cbNumberStyle.Name = "m_cbNumberStyle";
 			this.m_cbNumberStyle.SelectedIndexChanged += new System.EventHandler(this.m_cbNumberStyle_SelectedIndexChanged);
-			//
+			// 
 			// m_tbBeforeNumber
-			//
+			// 
 			resources.ApplyResources(this.m_tbBeforeNumber, "m_tbBeforeNumber");
 			this.m_tbBeforeNumber.Name = "m_tbBeforeNumber";
-			//
+			// 
 			// m_chkSenseItalicNumber
-			//
+			// 
 			resources.ApplyResources(this.m_chkSenseItalicNumber, "m_chkSenseItalicNumber");
 			this.m_chkSenseItalicNumber.Checked = true;
 			this.m_chkSenseItalicNumber.CheckState = System.Windows.Forms.CheckState.Indeterminate;
 			this.m_chkSenseItalicNumber.Name = "m_chkSenseItalicNumber";
 			this.m_chkSenseItalicNumber.ThreeState = true;
 			this.m_chkSenseItalicNumber.UseVisualStyleBackColor = true;
-			//
+			// 
 			// m_lblNumberStyle
-			//
+			// 
 			resources.ApplyResources(this.m_lblNumberStyle, "m_lblNumberStyle");
 			this.m_lblNumberStyle.Name = "m_lblNumberStyle";
-			//
+			// 
 			// m_chkSenseBoldNumber
-			//
+			// 
 			resources.ApplyResources(this.m_chkSenseBoldNumber, "m_chkSenseBoldNumber");
 			this.m_chkSenseBoldNumber.Checked = true;
 			this.m_chkSenseBoldNumber.CheckState = System.Windows.Forms.CheckState.Indeterminate;
 			this.m_chkSenseBoldNumber.Name = "m_chkSenseBoldNumber";
 			this.m_chkSenseBoldNumber.ThreeState = true;
 			this.m_chkSenseBoldNumber.UseVisualStyleBackColor = true;
-			//
+			// 
 			// m_tbAfterNumber
-			//
+			// 
 			resources.ApplyResources(this.m_tbAfterNumber, "m_tbAfterNumber");
 			this.m_tbAfterNumber.Name = "m_tbAfterNumber";
-			//
+			// 
 			// m_lblBeforeNumber
-			//
+			// 
 			resources.ApplyResources(this.m_lblBeforeNumber, "m_lblBeforeNumber");
 			this.m_lblBeforeNumber.Name = "m_lblBeforeNumber";
-			//
+			// 
 			// m_chkNumberSingleSense
-			//
+			// 
 			resources.ApplyResources(this.m_chkNumberSingleSense, "m_chkNumberSingleSense");
 			this.m_chkNumberSingleSense.Name = "m_chkNumberSingleSense";
 			this.m_chkNumberSingleSense.UseVisualStyleBackColor = true;
-			//
+			// 
 			// m_lblNumberFont
-			//
+			// 
 			resources.ApplyResources(this.m_lblNumberFont, "m_lblNumberFont");
 			this.m_lblNumberFont.Name = "m_lblNumberFont";
-			//
+			// 
 			// m_lblAfterNumber
-			//
+			// 
 			resources.ApplyResources(this.m_lblAfterNumber, "m_lblAfterNumber");
 			this.m_lblAfterNumber.Name = "m_lblAfterNumber";
-			//
+			// 
 			// m_grpSenseNumber
-			//
+			// 
 			resources.ApplyResources(this.m_grpSenseNumber, "m_grpSenseNumber");
 			this.m_grpSenseNumber.Controls.Add(this.m_lblAfterNumber);
 			this.m_grpSenseNumber.Controls.Add(this.m_lblNumberFont);
@@ -140,29 +140,29 @@ namespace SIL.FieldWorks.FwCoreDlgControls
 			this.m_grpSenseNumber.Controls.Add(this.m_cbNumberFont);
 			this.m_grpSenseNumber.Name = "m_grpSenseNumber";
 			this.m_grpSenseNumber.TabStop = false;
-			//
+			// 
 			// m_btnMoreStyles
-			//
+			// 
 			resources.ApplyResources(this.m_btnMoreStyles, "m_btnMoreStyles");
 			this.m_btnMoreStyles.Name = "m_btnMoreStyles";
 			this.m_btnMoreStyles.UseVisualStyleBackColor = true;
-			//
+			// 
 			// m_cbSenseParaStyle
-			//
+			// 
 			resources.ApplyResources(this.m_cbSenseParaStyle, "m_cbSenseParaStyle");
 			this.m_cbSenseParaStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.m_cbSenseParaStyle.FormattingEnabled = true;
 			this.m_cbSenseParaStyle.Name = "m_cbSenseParaStyle";
-			//
+			// 
 			// m_chkSenseParagraphStyle
-			//
+			// 
 			resources.ApplyResources(this.m_chkSenseParagraphStyle, "m_chkSenseParagraphStyle");
 			this.m_chkSenseParagraphStyle.Name = "m_chkSenseParagraphStyle";
 			this.m_chkSenseParagraphStyle.UseVisualStyleBackColor = true;
 			this.m_chkSenseParagraphStyle.CheckedChanged += new System.EventHandler(this.m_chkSenseParagraphStyle_CheckedChanged);
-			//
+			// 
 			// ConfigSenseLayout
-			//
+			// 
 			resources.ApplyResources(this, "$this");
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.Controls.Add(this.m_chkSenseParagraphStyle);

--- a/Src/FwCoreDlgs/FwCoreDlgControls/ConfigSenseLayout.resx
+++ b/Src/FwCoreDlgs/FwCoreDlgControls/ConfigSenseLayout.resx
@@ -1,579 +1,630 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-	Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-	Version 2.0
-
-	The primary goals of this format is to allow a simple XML format
-	that is mostly human readable. The generation and parsing of the
-	various data types are done through the TypeConverter classes
-	associated with the data types.
-
-	Example:
-
-	... ado.net/XML headers & schema ...
-	<resheader name="resmimetype">text/microsoft-resx</resheader>
-	<resheader name="version">2.0</resheader>
-	<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-	<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-	<data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-	<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-	<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-		<value>[base64 mime encoded serialized .NET Framework object]</value>
-	</data>
-	<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-		<value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-		<comment>This is a comment</comment>
-	</data>
-
-	There are any number of "resheader" rows that contain simple
-	name/value pairs.
-
-	Each data row contains a name, and value. The row also contains a
-	type or mimetype. Type corresponds to a .NET class that support
-	text/value conversion through the TypeConverter architecture.
-	Classes that don't support this are serialized and stored with the
-	mimetype set.
-
-	The mimetype is used for serialized objects, and tells the
-	ResXResourceReader how to depersist the object. This is currently not
-	extensible. For a given mimetype the value must be set accordingly:
-
-	Note - application/x-microsoft.net.object.binary.base64 is the format
-	that the ResXResourceWriter will generate, however the reader can
-	read any of the formats listed below.
-
-	mimetype: application/x-microsoft.net.object.binary.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.soap.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.bytearray.base64
-	value   : The object must be serialized into a byte array
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-	<xsd:element name="root" msdata:IsDataSet="true">
-	  <xsd:complexType>
-		<xsd:choice maxOccurs="unbounded">
-		  <xsd:element name="metadata">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" use="required" type="xsd:string" />
-			  <xsd:attribute name="type" type="xsd:string" />
-			  <xsd:attribute name="mimetype" type="xsd:string" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="assembly">
-			<xsd:complexType>
-			  <xsd:attribute name="alias" type="xsd:string" />
-			  <xsd:attribute name="name" type="xsd:string" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="data">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="resheader">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" />
-			</xsd:complexType>
-		  </xsd:element>
-		</xsd:choice>
-	  </xsd:complexType>
-	</xsd:element>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
-	<value>text/microsoft-resx</value>
+    <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-	<value>2.0</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="m_cbNumberFont.AccessibleName" xml:space="preserve">
-	<value>m_cbNumberFont</value>
+    <value>m_cbNumberFont</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="m_cbNumberFont.Location" type="System.Drawing.Point, System.Drawing">
-	<value>83, 79</value>
+    <value>111, 97</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="m_cbNumberFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_cbNumberFont.Size" type="System.Drawing.Size, System.Drawing">
-	<value>190, 21</value>
+    <value>252, 24</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="m_cbNumberFont.TabIndex" type="System.Int32, mscorlib">
-	<value>16</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;m_cbNumberFont.Name" xml:space="preserve">
-	<value>m_cbNumberFont</value>
+    <value>m_cbNumberFont</value>
   </data>
   <data name="&gt;&gt;m_cbNumberFont.Type" xml:space="preserve">
-	<value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_cbNumberFont.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_cbNumberFont.ZOrder" xml:space="preserve">
-	<value>10</value>
+    <value>10</value>
   </data>
   <data name="m_cbNumberStyle.AccessibleName" xml:space="preserve">
-	<value>m_cbNumberStyle</value>
+    <value>m_cbNumberStyle</value>
   </data>
   <data name="m_cbNumberStyle.Location" type="System.Drawing.Point, System.Drawing">
-	<value>83, 49</value>
+    <value>111, 60</value>
+  </data>
+  <data name="m_cbNumberStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_cbNumberStyle.Size" type="System.Drawing.Size, System.Drawing">
-	<value>121, 21</value>
+    <value>160, 24</value>
   </data>
   <data name="m_cbNumberStyle.TabIndex" type="System.Int32, mscorlib">
-	<value>12</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;m_cbNumberStyle.Name" xml:space="preserve">
-	<value>m_cbNumberStyle</value>
+    <value>m_cbNumberStyle</value>
   </data>
   <data name="&gt;&gt;m_cbNumberStyle.Type" xml:space="preserve">
-	<value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_cbNumberStyle.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_cbNumberStyle.ZOrder" xml:space="preserve">
-	<value>9</value>
+    <value>9</value>
   </data>
   <data name="m_tbBeforeNumber.AccessibleName" xml:space="preserve">
-	<value>m_tbBeforeNumber</value>
+    <value>m_tbBeforeNumber</value>
   </data>
   <data name="m_tbBeforeNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>13, 49</value>
+    <value>17, 60</value>
+  </data>
+  <data name="m_tbBeforeNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_tbBeforeNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>65, 20</value>
+    <value>85, 22</value>
   </data>
   <data name="m_tbBeforeNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>11</value>
+    <value>11</value>
   </data>
   <data name="m_tbBeforeNumber.WordWrap" type="System.Boolean, mscorlib">
-	<value>False</value>
+    <value>False</value>
   </data>
   <data name="&gt;&gt;m_tbBeforeNumber.Name" xml:space="preserve">
-	<value>m_tbBeforeNumber</value>
+    <value>m_tbBeforeNumber</value>
   </data>
   <data name="&gt;&gt;m_tbBeforeNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_tbBeforeNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_tbBeforeNumber.ZOrder" xml:space="preserve">
-	<value>8</value>
+    <value>8</value>
   </data>
   <data name="m_chkSenseItalicNumber.AccessibleName" xml:space="preserve">
-	<value>m_chkSenseItalicNumber</value>
+    <value>m_chkSenseItalicNumber</value>
   </data>
   <data name="m_chkSenseItalicNumber.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="m_chkSenseItalicNumber.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_chkSenseItalicNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>282, 53</value>
+    <value>376, 65</value>
+  </data>
+  <data name="m_chkSenseItalicNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkSenseItalicNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>48, 17</value>
+    <value>56, 20</value>
   </data>
   <data name="m_chkSenseItalicNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>15</value>
+    <value>15</value>
   </data>
   <data name="m_chkSenseItalicNumber.Text" xml:space="preserve">
-	<value>Italic</value>
+    <value>Italic</value>
   </data>
   <data name="&gt;&gt;m_chkSenseItalicNumber.Name" xml:space="preserve">
-	<value>m_chkSenseItalicNumber</value>
+    <value>m_chkSenseItalicNumber</value>
   </data>
   <data name="&gt;&gt;m_chkSenseItalicNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_chkSenseItalicNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_chkSenseItalicNumber.ZOrder" xml:space="preserve">
-	<value>7</value>
+    <value>7</value>
   </data>
   <data name="m_lblNumberStyle.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_lblNumberStyle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_lblNumberStyle.Location" type="System.Drawing.Point, System.Drawing">
-	<value>83, 27</value>
+    <value>111, 33</value>
+  </data>
+  <data name="m_lblNumberStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="m_lblNumberStyle.Size" type="System.Drawing.Size, System.Drawing">
-	<value>73, 13</value>
+    <value>91, 16</value>
   </data>
   <data name="m_lblNumberStyle.TabIndex" type="System.Int32, mscorlib">
-	<value>27</value>
+    <value>27</value>
   </data>
   <data name="m_lblNumberStyle.Text" xml:space="preserve">
-	<value>Number Style:</value>
+    <value>Number Style:</value>
   </data>
   <data name="&gt;&gt;m_lblNumberStyle.Name" xml:space="preserve">
-	<value>m_lblNumberStyle</value>
+    <value>m_lblNumberStyle</value>
   </data>
   <data name="&gt;&gt;m_lblNumberStyle.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_lblNumberStyle.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_lblNumberStyle.ZOrder" xml:space="preserve">
-	<value>6</value>
+    <value>6</value>
   </data>
   <data name="m_chkSenseBoldNumber.AccessibleName" xml:space="preserve">
-	<value>m_chkSenseBoldNumber</value>
+    <value>m_chkSenseBoldNumber</value>
   </data>
   <data name="m_chkSenseBoldNumber.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_chkSenseBoldNumber.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_chkSenseBoldNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>283, 31</value>
+    <value>377, 38</value>
+  </data>
+  <data name="m_chkSenseBoldNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkSenseBoldNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>47, 17</value>
+    <value>57, 20</value>
   </data>
   <data name="m_chkSenseBoldNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>14</value>
+    <value>14</value>
   </data>
   <data name="m_chkSenseBoldNumber.Text" xml:space="preserve">
-	<value>Bold</value>
+    <value>Bold</value>
   </data>
   <data name="&gt;&gt;m_chkSenseBoldNumber.Name" xml:space="preserve">
-	<value>m_chkSenseBoldNumber</value>
+    <value>m_chkSenseBoldNumber</value>
   </data>
   <data name="&gt;&gt;m_chkSenseBoldNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_chkSenseBoldNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_chkSenseBoldNumber.ZOrder" xml:space="preserve">
-	<value>5</value>
+    <value>5</value>
   </data>
   <data name="m_tbAfterNumber.AccessibleName" xml:space="preserve">
-	<value>m_tbAfterNumber</value>
+    <value>m_tbAfterNumber</value>
   </data>
   <data name="m_tbAfterNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>208, 49</value>
+    <value>277, 60</value>
+  </data>
+  <data name="m_tbAfterNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_tbAfterNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>65, 20</value>
+    <value>85, 22</value>
   </data>
   <data name="m_tbAfterNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>13</value>
+    <value>13</value>
   </data>
   <data name="m_tbAfterNumber.WordWrap" type="System.Boolean, mscorlib">
-	<value>False</value>
+    <value>False</value>
   </data>
   <data name="&gt;&gt;m_tbAfterNumber.Name" xml:space="preserve">
-	<value>m_tbAfterNumber</value>
+    <value>m_tbAfterNumber</value>
   </data>
   <data name="&gt;&gt;m_tbAfterNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_tbAfterNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_tbAfterNumber.ZOrder" xml:space="preserve">
-	<value>4</value>
+    <value>4</value>
   </data>
   <data name="m_lblBeforeNumber.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_lblBeforeNumber.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_lblBeforeNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>13, 27</value>
+    <value>17, 33</value>
+  </data>
+  <data name="m_lblBeforeNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="m_lblBeforeNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>41, 13</value>
+    <value>50, 16</value>
   </data>
   <data name="m_lblBeforeNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>26</value>
+    <value>26</value>
   </data>
   <data name="m_lblBeforeNumber.Text" xml:space="preserve">
-	<value>Before:</value>
+    <value>Before:</value>
   </data>
   <data name="&gt;&gt;m_lblBeforeNumber.Name" xml:space="preserve">
-	<value>m_lblBeforeNumber</value>
+    <value>m_lblBeforeNumber</value>
   </data>
   <data name="&gt;&gt;m_lblBeforeNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_lblBeforeNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_lblBeforeNumber.ZOrder" xml:space="preserve">
-	<value>3</value>
+    <value>3</value>
   </data>
   <data name="m_chkNumberSingleSense.AccessibleName" xml:space="preserve">
-	<value>m_chkNumberSingleSense</value>
+    <value>m_chkNumberSingleSense</value>
   </data>
   <data name="m_chkNumberSingleSense.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_chkNumberSingleSense.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_chkNumberSingleSense.Location" type="System.Drawing.Point, System.Drawing">
-	<value>13, 119</value>
+    <value>17, 147</value>
+  </data>
+  <data name="m_chkNumberSingleSense.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkNumberSingleSense.Size" type="System.Drawing.Size, System.Drawing">
-	<value>160, 17</value>
+    <value>200, 20</value>
   </data>
   <data name="m_chkNumberSingleSense.TabIndex" type="System.Int32, mscorlib">
-	<value>17</value>
+    <value>17</value>
   </data>
   <data name="m_chkNumberSingleSense.Text" xml:space="preserve">
-	<value>Number even a single sense</value>
+    <value>Number even a single sense</value>
   </data>
   <data name="&gt;&gt;m_chkNumberSingleSense.Name" xml:space="preserve">
-	<value>m_chkNumberSingleSense</value>
+    <value>m_chkNumberSingleSense</value>
   </data>
   <data name="&gt;&gt;m_chkNumberSingleSense.Type" xml:space="preserve">
-	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_chkNumberSingleSense.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_chkNumberSingleSense.ZOrder" xml:space="preserve">
-	<value>2</value>
+    <value>2</value>
   </data>
   <data name="m_lblNumberFont.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-	<value>MiddleRight</value>
+    <value>MiddleRight</value>
   </data>
   <data name="m_lblNumberFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_lblNumberFont.Location" type="System.Drawing.Point, System.Drawing">
-	<value>13, 79</value>
+    <value>17, 97</value>
+  </data>
+  <data name="m_lblNumberFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="m_lblNumberFont.Size" type="System.Drawing.Size, System.Drawing">
-	<value>68, 13</value>
+    <value>91, 16</value>
   </data>
   <data name="m_lblNumberFont.TabIndex" type="System.Int32, mscorlib">
-	<value>30</value>
+    <value>30</value>
   </data>
   <data name="m_lblNumberFont.Text" xml:space="preserve">
-	<value>Font:</value>
+    <value>Font:</value>
   </data>
   <data name="m_lblNumberFont.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-	<value>MiddleRight</value>
+    <value>MiddleRight</value>
   </data>
   <data name="&gt;&gt;m_lblNumberFont.Name" xml:space="preserve">
-	<value>m_lblNumberFont</value>
+    <value>m_lblNumberFont</value>
   </data>
   <data name="&gt;&gt;m_lblNumberFont.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_lblNumberFont.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_lblNumberFont.ZOrder" xml:space="preserve">
-	<value>1</value>
+    <value>1</value>
   </data>
   <data name="m_lblAfterNumber.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_lblAfterNumber.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_lblAfterNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>208, 27</value>
+    <value>277, 33</value>
+  </data>
+  <data name="m_lblAfterNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="m_lblAfterNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>32, 13</value>
+    <value>37, 16</value>
   </data>
   <data name="m_lblAfterNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>28</value>
+    <value>28</value>
   </data>
   <data name="m_lblAfterNumber.Text" xml:space="preserve">
-	<value>After:</value>
+    <value>After:</value>
   </data>
   <data name="&gt;&gt;m_lblAfterNumber.Name" xml:space="preserve">
-	<value>m_lblAfterNumber</value>
+    <value>m_lblAfterNumber</value>
   </data>
   <data name="&gt;&gt;m_lblAfterNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_lblAfterNumber.Parent" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_lblAfterNumber.ZOrder" xml:space="preserve">
-	<value>0</value>
+    <value>0</value>
   </data>
   <data name="m_grpSenseNumber.AccessibleName" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="m_grpSenseNumber.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <data name="m_grpSenseNumber.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_grpSenseNumber.Location" type="System.Drawing.Point, System.Drawing">
-	<value>0, 0</value>
+    <value>0, 0</value>
+  </data>
+  <data name="m_grpSenseNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="m_grpSenseNumber.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_grpSenseNumber.Size" type="System.Drawing.Size, System.Drawing">
-	<value>342, 155</value>
+    <value>570, 239</value>
   </data>
   <data name="m_grpSenseNumber.TabIndex" type="System.Int32, mscorlib">
-	<value>32</value>
+    <value>32</value>
   </data>
   <data name="m_grpSenseNumber.Text" xml:space="preserve">
-	<value>Sense Number Configuration</value>
+    <value>Sense Number Configuration</value>
   </data>
   <data name="&gt;&gt;m_grpSenseNumber.Name" xml:space="preserve">
-	<value>m_grpSenseNumber</value>
+    <value>m_grpSenseNumber</value>
   </data>
   <data name="&gt;&gt;m_grpSenseNumber.Type" xml:space="preserve">
-	<value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_grpSenseNumber.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;m_grpSenseNumber.ZOrder" xml:space="preserve">
-	<value>3</value>
+    <value>3</value>
   </data>
   <data name="m_btnMoreStyles.AccessibleName" xml:space="preserve">
-	<value>m_btnMoreStyles</value>
+    <value>m_btnMoreStyles</value>
   </data>
   <data name="m_btnMoreStyles.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="m_btnMoreStyles.Location" type="System.Drawing.Point, System.Drawing">
-	<value>179, 184</value>
+    <value>239, 226</value>
+  </data>
+  <data name="m_btnMoreStyles.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_btnMoreStyles.Size" type="System.Drawing.Size, System.Drawing">
-	<value>75, 23</value>
+    <value>100, 28</value>
   </data>
   <data name="m_btnMoreStyles.TabIndex" type="System.Int32, mscorlib">
-	<value>38</value>
+    <value>38</value>
   </data>
   <data name="m_btnMoreStyles.Text" xml:space="preserve">
-	<value>Styles...</value>
+    <value>Styles...</value>
   </data>
   <data name="&gt;&gt;m_btnMoreStyles.Name" xml:space="preserve">
-	<value>m_btnMoreStyles</value>
+    <value>m_btnMoreStyles</value>
   </data>
   <data name="&gt;&gt;m_btnMoreStyles.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_btnMoreStyles.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;m_btnMoreStyles.ZOrder" xml:space="preserve">
-	<value>1</value>
+    <value>1</value>
   </data>
   <data name="m_cbSenseParaStyle.AccessibleName" xml:space="preserve">
-	<value>m_cbSenseParaStyle</value>
+    <value>m_cbSenseParaStyle</value>
   </data>
   <data name="m_cbSenseParaStyle.Location" type="System.Drawing.Point, System.Drawing">
-	<value>33, 184</value>
+    <value>44, 226</value>
+  </data>
+  <data name="m_cbSenseParaStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_cbSenseParaStyle.Size" type="System.Drawing.Size, System.Drawing">
-	<value>140, 21</value>
+    <value>185, 24</value>
   </data>
   <data name="m_cbSenseParaStyle.TabIndex" type="System.Int32, mscorlib">
-	<value>36</value>
+    <value>36</value>
   </data>
   <data name="&gt;&gt;m_cbSenseParaStyle.Name" xml:space="preserve">
-	<value>m_cbSenseParaStyle</value>
+    <value>m_cbSenseParaStyle</value>
   </data>
   <data name="&gt;&gt;m_cbSenseParaStyle.Type" xml:space="preserve">
-	<value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_cbSenseParaStyle.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;m_cbSenseParaStyle.ZOrder" xml:space="preserve">
-	<value>2</value>
+    <value>2</value>
   </data>
   <data name="m_chkSenseParagraphStyle.AccessibleName" xml:space="preserve">
-	<value>m_chkSenseParagraphStyle</value>
+    <value>m_chkSenseParagraphStyle</value>
   </data>
   <data name="m_chkSenseParagraphStyle.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="m_chkSenseParagraphStyle.Location" type="System.Drawing.Point, System.Drawing">
-	<value>13, 161</value>
+    <value>17, 198</value>
+  </data>
+  <data name="m_chkSenseParagraphStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="m_chkSenseParagraphStyle.Size" type="System.Drawing.Size, System.Drawing">
-	<value>189, 17</value>
+    <value>238, 20</value>
   </data>
   <data name="m_chkSenseParagraphStyle.TabIndex" type="System.Int32, mscorlib">
-	<value>39</value>
+    <value>39</value>
   </data>
   <data name="m_chkSenseParagraphStyle.Text" xml:space="preserve">
-	<value>Display each sense in a paragraph</value>
+    <value>Display each sense in a paragraph</value>
   </data>
   <data name="&gt;&gt;m_chkSenseParagraphStyle.Name" xml:space="preserve">
-	<value>m_chkSenseParagraphStyle</value>
+    <value>m_chkSenseParagraphStyle</value>
   </data>
   <data name="&gt;&gt;m_chkSenseParagraphStyle.Type" xml:space="preserve">
-	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;m_chkSenseParagraphStyle.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;m_chkSenseParagraphStyle.ZOrder" xml:space="preserve">
-	<value>0</value>
+    <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-	<value>True</value>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-	<value>6, 13</value>
+    <value>8, 16</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-	<value>342, 222</value>
+    <value>456, 273</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-	<value>ConfigSenseLayout</value>
+    <value>ConfigSenseLayout</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-	<value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2432,7 +2432,9 @@ namespace SIL.FieldWorks.XWorks
 
 			var senseOptions = nodeList.Last().DictionaryNodeOptions as DictionaryNodeSenseOptions;
 
-			var formattedSenseNumber = GetSenseNumber(senseOptions.NumberingStyle, sense, decorator, ref info);
+			var rootNode = DictionaryConfigurationDlg.GetTopLevelNode(nodeList.Last());
+			bool isReversalEntry = rootNode.Label == "Reversal Entry";
+			var formattedSenseNumber = GetSenseNumber(senseOptions.NumberingStyle, sense, decorator, ref info, isReversalEntry);
 			info.HomographConfig = settings.Cache.ServiceLocator.GetInstance<HomographConfiguration>();
 			var senseNumberWs = string.IsNullOrEmpty(info.HomographConfig.WritingSystem) ? "en" : info.HomographConfig.WritingSystem;
 			if (string.IsNullOrEmpty(formattedSenseNumber))
@@ -2441,26 +2443,31 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		private static string GetSenseNumber(string numberingStyle, ILexSense sense,
-			DictionaryPublicationDecorator publicationDecorator, ref SenseInfo info)
+			DictionaryPublicationDecorator publicationDecorator, ref SenseInfo info, bool isReversalEntry = false)
 		{
 			string nextNumber;
 			var senseCount = info.SenseCounter;
-			// Try to get the outline number if there is a publication decorator
-			if (publicationDecorator != null && sense != null)
+
+			// GetOutlineNumber assumes sense is not a reversal. Only try to get outline number if that assumption is correct.
+			if(!isReversalEntry)
 			{
-				var senseCollectionFlid = 0;
-				var mdc = (IFwMetaDataCacheManaged)sense.Cache.MetaDataCacheAccessor;
-				// get flid for the senses field of the owner
-				if (sense.Owner is ILexSense)
-					senseCollectionFlid = mdc.GetFieldId("LexSense", "Senses", false);
-				else if (sense.Owner is ILexEntry)
-					senseCollectionFlid = mdc.GetFieldId("LexEntry", "Senses", false);
-				if (senseCollectionFlid > 0)
+				// Try to get the outline number if there is a publication decorator
+				if (publicationDecorator != null && sense != null)
 				{
-					var senseNumber = sense.Cache.GetOutlineNumber(sense, senseCollectionFlid, false, true, publicationDecorator);
-					if (!string.IsNullOrEmpty(senseNumber))
+					var senseCollectionFlid = 0;
+					var mdc = (IFwMetaDataCacheManaged)sense.Cache.MetaDataCacheAccessor;
+					// get flid for the senses field of the owner
+					if (sense.Owner is ILexSense)
+						senseCollectionFlid = mdc.GetFieldId("LexSense", "Senses", false);
+					else if (sense.Owner is ILexEntry)
+						senseCollectionFlid = mdc.GetFieldId("LexEntry", "Senses", false);
+					if (senseCollectionFlid > 0)
 					{
-						senseCount = int.Parse(senseNumber.Split('.').Last());
+						var senseNumber = sense.Cache.GetOutlineNumber(sense, senseCollectionFlid, false, true, publicationDecorator);
+						if (!string.IsNullOrEmpty(senseNumber))
+						{
+							senseCount = int.Parse(senseNumber.Split('.').Last());
+						}
 					}
 				}
 			}

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -2432,8 +2432,9 @@ namespace SIL.FieldWorks.XWorks
 
 			var senseOptions = nodeList.Last().DictionaryNodeOptions as DictionaryNodeSenseOptions;
 
-			var rootNode = DictionaryConfigurationDlg.GetTopLevelNode(nodeList.Last());
+			var rootNode = nodeList.First();
 			bool isReversalEntry = rootNode.Label == "Reversal Entry";
+
 			var formattedSenseNumber = GetSenseNumber(senseOptions.NumberingStyle, sense, decorator, ref info, isReversalEntry);
 			info.HomographConfig = settings.Cache.ServiceLocator.GetInstance<HomographConfiguration>();
 			var senseNumberWs = string.IsNullOrEmpty(info.HomographConfig.WritingSystem) ? "en" : info.HomographConfig.WritingSystem;

--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -520,6 +520,10 @@ namespace SIL.FieldWorks.XWorks
 			var senseNode = mainEntryNode.Children.Where(prop => prop.Label == senseType).FirstOrDefault();
 			if (senseNode == null) return;
 			var senseOptions = (DictionaryNodeSenseOptions)senseNode.DictionaryNodeOptions;
+			if (String.IsNullOrEmpty(senseOptions.NumberingStyle))
+			{
+				senseOptions.NumberingStyle = null;
+			}
 			cacheHc.ksSenseNumberStyle = senseOptions.NumberingStyle;
 			//SubSense Node
 			var subSenseNode = senseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();

--- a/Src/xWorks/DictionaryConfigurationDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationDlg.cs
@@ -245,7 +245,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// Returns the top-level ancestor of the given node
 		/// </summary>
-		public static ConfigurableDictionaryNode GetTopLevelNode(ConfigurableDictionaryNode childNode)
+		private static ConfigurableDictionaryNode GetTopLevelNode(ConfigurableDictionaryNode childNode)
 		{
 			while (childNode.Parent != null)
 				childNode = childNode.Parent;

--- a/Src/xWorks/DictionaryConfigurationDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationDlg.cs
@@ -245,7 +245,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// Returns the top-level ancestor of the given node
 		/// </summary>
-		private static ConfigurableDictionaryNode GetTopLevelNode(ConfigurableDictionaryNode childNode)
+		public static ConfigurableDictionaryNode GetTopLevelNode(ConfigurableDictionaryNode childNode)
 		{
 			while (childNode.Parent != null)
 				childNode = childNode.Parent;

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -98,8 +98,9 @@ namespace SIL.FieldWorks.XWorks
 				}
 				else if (Options is DictionaryNodeSenseOptions)
 				{
+					bool isReversal = model != null && model.IsReversal;
 					optionsView = LoadSenseOptions((DictionaryNodeSenseOptions)Options, node.Parent != null && node.FieldDescription == node.Parent.FieldDescription,
-						node.Parent != null && node.Parent.Label == "MainEntrySubsenses", model.IsReversal);
+						node.Parent != null && node.Parent.Label == "MainEntrySubsenses", isReversal);
 				}
 				else if (Options is DictionaryNodeListOptions)
 				{

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -75,6 +75,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			m_configModel = model;
 			m_node = node;
+			bool isReversal = DictionaryConfigurationDlg.GetTopLevelNode(node).Label == "Reversal Entry";
 
 			View.SuspendLayout();
 
@@ -99,7 +100,7 @@ namespace SIL.FieldWorks.XWorks
 				else if (Options is DictionaryNodeSenseOptions)
 				{
 					optionsView = LoadSenseOptions((DictionaryNodeSenseOptions)Options, node.Parent != null && node.FieldDescription == node.Parent.FieldDescription,
-						node.Parent != null && node.Parent.Label == "MainEntrySubsenses");
+						node.Parent != null && node.Parent.Label == "MainEntrySubsenses", isReversal);
 				}
 				else if (Options is DictionaryNodeListOptions)
 				{
@@ -387,12 +388,12 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>Initialize options for DictionaryNodeSenseOptions</summary>
-		private UserControl LoadSenseOptions(DictionaryNodeSenseOptions senseOptions, bool isSubsense, bool isSubSubsense)
+		private UserControl LoadSenseOptions(DictionaryNodeSenseOptions senseOptions, bool isSubsense, bool isSubSubsense, bool isReversal = false)
 		{
 			// initialize SenseOptionsView
 			//For senses disallow the 1 1.2 1.2.3 option, that is now handled in subsenses
 			var disallowedNumberingStyles = "%O";
-			var senseOptionsView = new SenseOptionsView(isSubsense)
+			var senseOptionsView = new SenseOptionsView(isSubsense, isReversal)
 			{
 				BeforeText = senseOptions.BeforeNumber,
 				// load list of available NumberingStyles before setting NumberingStyle's value

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -75,7 +75,6 @@ namespace SIL.FieldWorks.XWorks
 		{
 			m_configModel = model;
 			m_node = node;
-			bool isReversal = DictionaryConfigurationDlg.GetTopLevelNode(node).Label == "Reversal Entry";
 
 			View.SuspendLayout();
 
@@ -100,7 +99,7 @@ namespace SIL.FieldWorks.XWorks
 				else if (Options is DictionaryNodeSenseOptions)
 				{
 					optionsView = LoadSenseOptions((DictionaryNodeSenseOptions)Options, node.Parent != null && node.FieldDescription == node.Parent.FieldDescription,
-						node.Parent != null && node.Parent.Label == "MainEntrySubsenses", isReversal);
+						node.Parent != null && node.Parent.Label == "MainEntrySubsenses", model.IsReversal);
 				}
 				else if (Options is DictionaryNodeListOptions)
 				{

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.Designer.cs
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.Designer.cs
@@ -194,7 +194,7 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 			resources.ApplyResources(this.dropDownParentSenseNumberStyle, "dropDownParentSenseNumberStyle");
 			this.dropDownParentSenseNumberStyle.Name = "dropDownParentSenseNumberStyle";
 			// 
-			// senseOrderingAndFormattingOptionsVerticalFlow
+			// senseStructureVerticalFlow
 			// 
 			resources.ApplyResources(this.senseStructureVerticalFlow, "senseStructureVerticalFlow");
 			this.senseStructureVerticalFlow.Controls.Add(this.checkBoxShowGrammarFirst);
@@ -208,8 +208,6 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.Controls.Add(this.groupBoxSenseNumber);
 			this.Controls.Add(this.senseStructureVerticalFlow);
-			this.MaximumSize = new System.Drawing.Size(0, 193);
-			this.MinimumSize = new System.Drawing.Size(305, 220);
 			this.Name = "SenseOptionsView";
 			this.groupBoxSenseNumber.ResumeLayout(false);
 			this.groupBoxSenseNumber.PerformLayout();

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014-2016 SIL International
+// Copyright (c) 2014-2016 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -15,7 +15,7 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 	public partial class SenseOptionsView : UserControl, IDictionarySenseOptionsView
 	{
 
-		public SenseOptionsView(bool isSubsense)
+		public SenseOptionsView(bool isSubsense, bool isReversal = false)
 		{
 			InitializeComponent();
 
@@ -24,7 +24,8 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 
 			textBoxBefore.TextChanged += SpecialCharacterHandling.RevealInvisibleCharacters;
 			textBoxAfter.TextChanged += SpecialCharacterHandling.RevealInvisibleCharacters;
-
+			if (isReversal)
+				groupBoxSenseNumber.Text = xWorksStrings.ksReversalNumberConfig;
 			if (!isSubsense)
 				return;
 			groupBoxSenseNumber.Text = xWorksStrings.ksSubsenseNumberConfig;

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.resx
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.resx
@@ -457,13 +457,13 @@
     <value>NoControl</value>
   </data>
   <data name="checkBoxNumberSingleSense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 153</value>
+    <value>13, 145</value>
   </data>
   <data name="checkBoxNumberSingleSense.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
   <data name="checkBoxNumberSingleSense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>313, 31</value>
+    <value>313, 25</value>
   </data>
   <data name="checkBoxNumberSingleSense.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.resx
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -127,10 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="checkBoxSenseInPara.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 26</value>
+    <value>4, 32</value>
+  </data>
+  <data name="checkBoxSenseInPara.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="checkBoxSenseInPara.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 17</value>
+    <value>238, 20</value>
   </data>
   <data name="checkBoxSenseInPara.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -157,10 +160,13 @@
     <value>True</value>
   </data>
   <data name="checkBoxShowGrammarFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="checkBoxShowGrammarFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="checkBoxShowGrammarFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>299, 17</value>
+    <value>371, 20</value>
   </data>
   <data name="checkBoxShowGrammarFirst.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -190,13 +196,16 @@
     <value>NoControl</value>
   </data>
   <data name="checkBoxFirstSenseInline.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 49</value>
+    <value>4, 60</value>
+  </data>
+  <data name="checkBoxFirstSenseInline.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="checkBoxFirstSenseInline.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>20, 0, 0, 0</value>
+    <value>27, 0, 0, 0</value>
   </data>
   <data name="checkBoxFirstSenseInline.Size" type="System.Drawing.Size, System.Drawing">
-    <value>171, 17</value>
+    <value>212, 20</value>
   </data>
   <data name="checkBoxFirstSenseInline.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -226,10 +235,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 16</value>
+    <value>8, 20</value>
+  </data>
+  <data name="labelStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="labelStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>101, 16</value>
   </data>
   <data name="labelStyle.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -259,10 +271,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelAfter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 56</value>
+    <value>281, 69</value>
+  </data>
+  <data name="labelAfter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="labelAfter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>37, 16</value>
   </data>
   <data name="labelAfter.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -292,10 +307,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelNumberingStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 56</value>
+    <value>112, 69</value>
+  </data>
+  <data name="labelNumberingStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="labelNumberingStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 13</value>
+    <value>109, 16</value>
   </data>
   <data name="labelNumberingStyle.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -325,10 +343,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelBefore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 56</value>
+    <value>8, 69</value>
+  </data>
+  <data name="labelBefore.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="labelBefore.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>50, 16</value>
   </data>
   <data name="labelBefore.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -352,10 +373,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="dropDownNumberingStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 72</value>
+    <value>116, 89</value>
+  </data>
+  <data name="dropDownNumberingStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="dropDownNumberingStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>160, 24</value>
   </data>
   <data name="dropDownNumberingStyle.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -376,10 +400,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="textBoxAfter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>214, 72</value>
+    <value>285, 89</value>
+  </data>
+  <data name="textBoxAfter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="textBoxAfter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
+    <value>95, 22</value>
   </data>
   <data name="textBoxAfter.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -400,10 +427,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="textBoxBefore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 72</value>
+    <value>12, 89</value>
+  </data>
+  <data name="textBoxBefore.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="textBoxBefore.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
+    <value>95, 22</value>
   </data>
   <data name="textBoxBefore.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -427,10 +457,13 @@
     <value>NoControl</value>
   </data>
   <data name="checkBoxNumberSingleSense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 122</value>
+    <value>13, 153</value>
+  </data>
+  <data name="checkBoxNumberSingleSense.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="checkBoxNumberSingleSense.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 17</value>
+    <value>313, 31</value>
   </data>
   <data name="checkBoxNumberSingleSense.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -454,10 +487,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="dropDownStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 32</value>
+    <value>12, 39</value>
+  </data>
+  <data name="dropDownStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="dropDownStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 21</value>
+    <value>260, 24</value>
   </data>
   <data name="dropDownStyle.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -478,10 +514,13 @@
     <value>NoControl</value>
   </data>
   <data name="buttonStyles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 32</value>
+    <value>281, 39</value>
+  </data>
+  <data name="buttonStyles.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="buttonStyles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
+    <value>100, 26</value>
   </data>
   <data name="buttonStyles.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -511,10 +550,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelParentSenseNumberStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 102</value>
+    <value>8, 126</value>
+  </data>
+  <data name="labelParentSenseNumberStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="labelParentSenseNumberStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 13</value>
+    <value>169, 16</value>
   </data>
   <data name="labelParentSenseNumberStyle.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -535,10 +577,13 @@
     <value>0</value>
   </data>
   <data name="dropDownParentSenseNumberStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>165, 99</value>
+    <value>220, 122</value>
+  </data>
+  <data name="dropDownParentSenseNumberStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="dropDownParentSenseNumberStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>160, 24</value>
   </data>
   <data name="dropDownParentSenseNumberStyle.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -556,10 +601,16 @@
     <value>1</value>
   </data>
   <data name="groupBoxSenseNumber.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="groupBoxSenseNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="groupBoxSenseNumber.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="groupBoxSenseNumber.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 145</value>
+    <value>400, 178</value>
   </data>
   <data name="groupBoxSenseNumber.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -589,10 +640,13 @@
     <value>TopDown</value>
   </data>
   <data name="senseStructureVerticalFlow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 151</value>
+    <value>4, 186</value>
+  </data>
+  <data name="senseStructureVerticalFlow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="senseStructureVerticalFlow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>305, 69</value>
+    <value>379, 84</value>
   </data>
   <data name="senseStructureVerticalFlow.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -613,13 +667,22 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>8, 16</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="$this.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 238</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>407, 271</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>311, 220</value>
+    <value>408, 271</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SenseOptionsView</value>

--- a/Src/xWorks/xWorksStrings.Designer.cs
+++ b/Src/xWorks/xWorksStrings.Designer.cs
@@ -2099,6 +2099,15 @@ namespace SIL.FieldWorks.XWorks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reversal Number Configuration.
+        /// </summary>
+        internal static string ksReversalNumberConfig {
+            get {
+                return ResourceManager.GetString("ksReversalNumberConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The entry you have selected is not shown, {0}..
         /// </summary>
         internal static string ksSelectedEntryNotInDict {

--- a/Src/xWorks/xWorksStrings.resx
+++ b/Src/xWorks/xWorksStrings.resx
@@ -1104,6 +1104,9 @@ See USFM documentation for help.</value>
   <data name="SomethingWentWrongTryingToPrintDict" xml:space="preserve">
     <value>Something went wrong trying to print. An operation may have timed out. You may be able to export your dictionary from the File menu and print it using your browser.</value>
   </data>
+  <data name="ksReversalNumberConfig" xml:space="preserve">
+    <value>Reversal Number Configuration</value>
+  </data>
   <data name="ksSubsenseNumberConfig" xml:space="preserve">
     <value>Subsense Number Configuration</value>
   </data>


### PR DESCRIPTION
* Fix width of "Number even a single sense" message to prevent
the final e being cut off.
* Fix position of "number even a single sense" box to prevent
box border being cut off.
* Fix title of the configuration to say "Reversal Number
Configuration" instead of "Sense Number Configuration"
when configuring referenced senses in the reversal.
* Fix reversal number handling in GetSenseNumber
* Fix disappearing sense nums if reversals are toggled on/off

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/875)
<!-- Reviewable:end -->
