### PR TITLE
Report render comparison artifacts from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,6 +43,70 @@ jobs:
         shell: powershell
         run: |
           .\Build\Agent\Summarize-NativeTestResults.ps1 -Configuration Debug
+
+      - name: Collect render comparison artifacts
+        id: render_artifacts
+        if: ${{ !cancelled() && failure() }}
+        shell: pwsh
+        run: .\Build\Agent\Collect-RenderArtifacts.ps1 -SearchRoot . -OutputDirectory .\Output\RenderArtifacts
+
+      - name: Upload render comparison artifacts
+        id: upload_render_artifacts
+        if: ${{ !cancelled() && steps.render_artifacts.outputs.has_artifacts == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: render-comparison-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: Output/RenderArtifacts
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Summarize render comparison artifacts
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && (success() || steps.render_artifacts.outputs.has_artifacts == 'true') }}
+        shell: pwsh
+        continue-on-error: true
+        env:
+          ARTIFACT_URL: ${{ steps.upload_render_artifacts.outputs.artifact-url }}
+          FAILURE_COUNT: ${{ steps.render_artifacts.outputs.failure_count }}
+          HAS_ARTIFACTS: ${{ steps.render_artifacts.outputs.has_artifacts }}
+        run: .\Build\Agent\Report-RenderArtifacts.ps1 -SkipComment
+
+      - name: Build render comparison failure comment
+        id: render_failure_comment
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.render_artifacts.outputs.has_artifacts == 'true' }}
+        shell: pwsh
+        env:
+          ARTIFACT_URL: ${{ steps.upload_render_artifacts.outputs.artifact-url }}
+          FAILURE_COUNT: ${{ steps.render_artifacts.outputs.failure_count }}
+          HAS_ARTIFACTS: ${{ steps.render_artifacts.outputs.has_artifacts }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: .\Build\Agent\Build-RenderArtifactComment.ps1
+
+      - name: Update render comparison PR comment for failures
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.render_artifacts.outputs.has_artifacts == 'true' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: fieldworks-render-comparison-artifacts
+          path: ${{ steps.render_failure_comment.outputs.comment_path }}
+          skip_unchanged: true
+
+      - name: Build render comparison resolved comment
+        id: render_clean_comment
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && success() }}
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HAS_ARTIFACTS: false
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: .\Build\Agent\Build-RenderArtifactComment.ps1
+
+      - name: Update render comparison PR comment for clean run
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && success() }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: fieldworks-render-comparison-artifacts
+          only_update: true
+          path: ${{ steps.render_clean_comment.outputs.comment_path }}
+          skip_unchanged: true
 
       - name: Upload TRX test results (managed)
         if: ${{ !cancelled() }}

--- a/Build/Agent/Build-RenderArtifactComment.ps1
+++ b/Build/Agent/Build-RenderArtifactComment.ps1
@@ -1,0 +1,330 @@
+[CmdletBinding()]
+param(
+	[string]$ArtifactUrl = $env:ARTIFACT_URL,
+	[string]$CommentPath,
+	[string]$FailureCount = $env:FAILURE_COUNT,
+	[string]$EventPath = $env:GITHUB_EVENT_PATH,
+	[string]$GitHubApiUrl = $env:GITHUB_API_URL,
+	[string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+	[string]$GitHubToken = $env:GITHUB_TOKEN,
+	[string]$HeadRef = $env:GITHUB_HEAD_REF,
+	[string]$HasArtifacts = $env:HAS_ARTIFACTS,
+	[string]$PreviousCommentBody,
+	[string]$PullRequestNumber = $env:PULL_REQUEST_NUMBER,
+	[string]$Repository = $env:GITHUB_REPOSITORY,
+	[string]$RunAttempt = $env:GITHUB_RUN_ATTEMPT,
+	[string]$RunId = $env:GITHUB_RUN_ID,
+	[string]$ServerUrl = $env:GITHUB_SERVER_URL,
+	[string]$Sha = $env:GITHUB_SHA,
+	[string]$WorkflowRef = $env:GITHUB_WORKFLOW_REF
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$StickyCommentMarker = '<!-- Sticky Pull Request Commentfieldworks-render-comparison-artifacts -->'
+$FailureRunLabelMarker = '<!-- fieldworks-render-failure-run-label: '
+$FailureRunUrlMarker = '<!-- fieldworks-render-failure-run-url: '
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($CommentPath)) {
+	$CommentPath = Join-Path (Join-Path $repoRoot 'Output\RenderArtifacts') 'render-comment.md'
+}
+
+if ([string]::IsNullOrWhiteSpace($GitHubApiUrl)) {
+	$GitHubApiUrl = 'https://api.github.com'
+}
+
+function Get-RequiredValue {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Name,
+		[AllowEmptyString()]
+		[string]$Value
+	)
+
+	if ([string]::IsNullOrWhiteSpace($Value)) {
+		throw "Required value missing: $Name"
+	}
+
+	return $Value
+}
+
+function Write-GitHubOutputValue {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Name,
+		[Parameter(Mandatory = $true)]
+		[string]$Value
+	)
+
+	if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+		return
+	}
+
+	$encoding = New-Object System.Text.UTF8Encoding($false)
+	[System.IO.File]::AppendAllText($GitHubOutputPath, "$Name=$Value$([System.Environment]::NewLine)", $encoding)
+}
+
+function Invoke-GitHubApi {
+	param(
+		[Parameter(Mandatory = $true)]
+		[ValidateSet('Get')]
+		[string]$Method,
+		[Parameter(Mandatory = $true)]
+		[string]$Uri
+	)
+
+	$headers = @{
+		Accept = 'application/vnd.github+json'
+		'X-GitHub-Api-Version' = '2022-11-28'
+	}
+	if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
+		$headers.Authorization = "Bearer $GitHubToken"
+	}
+
+	return Invoke-RestMethod -Method $Method -Uri $Uri -Headers $headers
+}
+
+function Get-PullRequestNumber {
+	if (-not [string]::IsNullOrWhiteSpace($PullRequestNumber)) {
+		return [int]$PullRequestNumber
+	}
+
+	if ([string]::IsNullOrWhiteSpace($EventPath) -or -not (Test-Path -LiteralPath $EventPath)) {
+		return $null
+	}
+
+	$eventPayload = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-Json
+	if ($null -eq $eventPayload.pull_request -or $null -eq $eventPayload.pull_request.number) {
+		return $null
+	}
+
+	return [int]$eventPayload.pull_request.number
+}
+
+function Get-PreviousCommentBody {
+	if (-not [string]::IsNullOrWhiteSpace($PreviousCommentBody)) {
+		return $PreviousCommentBody
+	}
+
+	$pullRequestNumber = Get-PullRequestNumber
+	if ($null -eq $pullRequestNumber) {
+		return $null
+	}
+
+	$repositoryName = Get-RequiredValue -Name 'Repository' -Value $Repository
+	$repositoryParts = $repositoryName.Split('/')
+	if ($repositoryParts.Count -ne 2) {
+		throw "Invalid GitHub repository value: $repositoryName"
+	}
+
+	$owner = $repositoryParts[0]
+	$repo = $repositoryParts[1]
+	$commentsUri = "$GitHubApiUrl/repos/$owner/$repo/issues/$pullRequestNumber/comments?per_page=100"
+	$comments = @(Invoke-GitHubApi -Method Get -Uri $commentsUri)
+	$latestMatchingCommentBody = $null
+	foreach ($comment in $comments) {
+		if ($comment.body -and $comment.body.Contains($StickyCommentMarker)) {
+			$latestMatchingCommentBody = [string]$comment.body
+		}
+	}
+
+	return $latestMatchingCommentBody
+}
+
+function Get-MetadataValue {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Body,
+		[Parameter(Mandatory = $true)]
+		[string]$Prefix
+	)
+
+	$pattern = [regex]::Escape($Prefix) + '(?<value>.*?) -->'
+	$match = [regex]::Match($Body, $pattern)
+	if (-not $match.Success) {
+		return $null
+	}
+
+	return $match.Groups['value'].Value.Trim()
+}
+
+function Get-PreviousFailureRunInfo {
+	param([string]$Body)
+
+	if ([string]::IsNullOrWhiteSpace($Body)) {
+		return $null
+	}
+
+	$metadataLabel = Get-MetadataValue -Body $Body -Prefix $FailureRunLabelMarker
+	$metadataUrl = Get-MetadataValue -Body $Body -Prefix $FailureRunUrlMarker
+	if (-not [string]::IsNullOrWhiteSpace($metadataLabel) -and -not [string]::IsNullOrWhiteSpace($metadataUrl)) {
+		return [pscustomobject]@{
+			Label = $metadataLabel
+			Url = $metadataUrl
+		}
+	}
+
+	$patterns = @(
+		'\[(?<label>[^\]]+ run \d+\.\d+)\]\((?<url>[^)]+/actions/runs/\d+)\) detected \d+ render snapshot failure\(s\)\.',
+		'Render snapshot failures were reported in \[(?<label>[^\]]+)\]\((?<url>[^)]+)\), but the latest run \[[^\]]+\]\([^)]+\) is clean\.'
+	)
+
+	foreach ($pattern in $patterns) {
+		$match = [regex]::Match($Body, $pattern)
+		if ($match.Success) {
+			return [pscustomobject]@{
+				Label = $match.Groups['label'].Value
+				Url = $match.Groups['url'].Value
+			}
+		}
+	}
+
+	return $null
+}
+
+function Get-WorkflowIdentifier {
+	if ([string]::IsNullOrWhiteSpace($WorkflowRef)) {
+		return 'CI.yml'
+	}
+
+	$atIndex = $WorkflowRef.IndexOf('@')
+	$workflowRefPrefix = if ($atIndex -ge 0) {
+		$WorkflowRef.Substring(0, $atIndex)
+	}
+	else {
+		$WorkflowRef
+	}
+
+	$repositoryName = Get-RequiredValue -Name 'Repository' -Value $Repository
+	$expectedPrefix = "$repositoryName/"
+	if ($workflowRefPrefix.StartsWith($expectedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+		return $workflowRefPrefix.Substring($expectedPrefix.Length)
+	}
+
+	return 'CI.yml'
+}
+
+function Get-PreviousFailureRunInfoFromWorkflowRuns {
+	if ([string]::IsNullOrWhiteSpace($HeadRef)) {
+		return $null
+	}
+
+	$repositoryName = Get-RequiredValue -Name 'Repository' -Value $Repository
+	$repositoryParts = $repositoryName.Split('/')
+	if ($repositoryParts.Count -ne 2) {
+		throw "Invalid GitHub repository value: $repositoryName"
+	}
+
+	$owner = $repositoryParts[0]
+	$repo = $repositoryParts[1]
+	$workflowIdentifier = [System.Uri]::EscapeDataString((Get-WorkflowIdentifier))
+	$encodedHeadRef = [System.Uri]::EscapeDataString($HeadRef)
+	$runsUri = "$GitHubApiUrl/repos/$owner/$repo/actions/workflows/$workflowIdentifier/runs?branch=$encodedHeadRef&event=pull_request&per_page=20"
+	$response = Invoke-GitHubApi -Method Get -Uri $runsUri
+	$runs = @($response.workflow_runs)
+	$currentRunId = if ([string]::IsNullOrWhiteSpace($RunId)) { $null } else { [string]$RunId }
+
+	foreach ($run in $runs) {
+		if ($null -eq $run) {
+			continue
+		}
+
+		$runIdValue = [string]$run.id
+		if (-not [string]::IsNullOrWhiteSpace($currentRunId) -and $runIdValue -eq $currentRunId) {
+			continue
+		}
+
+		if (-not [System.String]::Equals([string]$run.status, 'completed', [System.StringComparison]::OrdinalIgnoreCase)) {
+			continue
+		}
+
+		if (-not [System.String]::Equals([string]$run.conclusion, 'failure', [System.StringComparison]::OrdinalIgnoreCase)) {
+			continue
+		}
+
+		$runSha = [string]$run.head_sha
+		$runAttemptValue = [string]$run.run_attempt
+		if ([string]::IsNullOrWhiteSpace($runSha) -or [string]::IsNullOrWhiteSpace($runIdValue) -or [string]::IsNullOrWhiteSpace($runAttemptValue)) {
+			continue
+		}
+
+		$runShortSha = $runSha.Substring(0, [System.Math]::Min(12, $runSha.Length))
+		return [pscustomobject]@{
+			Label = "$runShortSha run $runIdValue.$runAttemptValue"
+			Url = [string]$run.html_url
+		}
+	}
+
+	return $null
+}
+
+$commentDirectory = Split-Path -Path $CommentPath -Parent
+if (-not (Test-Path -LiteralPath $commentDirectory)) {
+	New-Item -ItemType Directory -Path $commentDirectory -Force | Out-Null
+}
+
+$runLabel = "$(Get-RequiredValue -Name 'RunId' -Value $RunId).$(Get-RequiredValue -Name 'RunAttempt' -Value $RunAttempt)"
+$runUrl = "$(Get-RequiredValue -Name 'ServerUrl' -Value $ServerUrl)/$(Get-RequiredValue -Name 'Repository' -Value $Repository)/actions/runs/$RunId"
+$shortSha = (Get-RequiredValue -Name 'Sha' -Value $Sha).Substring(0, [System.Math]::Min(12, $Sha.Length))
+$renderArtifactsDetected = [System.String]::Equals([string]$HasArtifacts, 'true', [System.StringComparison]::OrdinalIgnoreCase)
+
+if ($renderArtifactsDetected) {
+	$downloadLine = if ([string]::IsNullOrWhiteSpace($ArtifactUrl)) {
+		'Artifact upload URL was not available for this run.'
+	}
+	else {
+		"- [Download render comparison artifacts]($ArtifactUrl)"
+	}
+
+	$commentLines = @(
+		"$FailureRunLabelMarker$shortSha run $runLabel -->"
+		"$FailureRunUrlMarker$runUrl -->"
+		'### Render comparison artifacts'
+		''
+		"[$shortSha run $runLabel]($runUrl) detected $(Get-RequiredValue -Name 'FailureCount' -Value $FailureCount) render snapshot failure(s)."
+		''
+		'- The artifact includes `index.html`, expected images, actual images, diff images, and metadata.'
+		$downloadLine
+		''
+		'This comment is updated in place by CI for the latest run.'
+	)
+}
+else {
+	$previousFailureRun = Get-PreviousFailureRunInfo -Body (Get-PreviousCommentBody)
+	if ($null -eq $previousFailureRun) {
+		$previousFailureRun = Get-PreviousFailureRunInfoFromWorkflowRuns
+	}
+	$commentLines = @()
+	if ($null -ne $previousFailureRun) {
+		$commentLines += "@$FailureRunLabelMarker$($previousFailureRun.Label) -->".Substring(1)
+		$commentLines += "@$FailureRunUrlMarker$($previousFailureRun.Url) -->".Substring(1)
+		$commentLines += @(
+			'### Render comparison artifacts'
+			''
+			"Render snapshot failures were reported in [$($previousFailureRun.Label)]($($previousFailureRun.Url)), but the latest run [$shortSha run $runLabel]($runUrl) is clean."
+			''
+			'This comment will be replaced if a future run produces render snapshot failures again.'
+		)
+	}
+	else {
+	$commentLines = @(
+		'### Render comparison artifacts'
+		''
+		'No render snapshot failures were captured in the latest successful CI run.'
+		''
+		"Latest run: [$shortSha run $runLabel]($runUrl)."
+	)
+	}
+}
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($CommentPath, ($commentLines -join [System.Environment]::NewLine), $utf8NoBom)
+Write-GitHubOutputValue -Name 'comment_path' -Value ([System.IO.Path]::GetFullPath($CommentPath))
+
+Write-Output ([pscustomobject]@{
+	CommentPath = [System.IO.Path]::GetFullPath($CommentPath)
+	HasArtifacts = $renderArtifactsDetected
+	FailureCount = $FailureCount
+})

--- a/Build/Agent/Collect-RenderArtifacts.ps1
+++ b/Build/Agent/Collect-RenderArtifacts.ps1
@@ -1,0 +1,258 @@
+[CmdletBinding()]
+param(
+	[string]$SearchRoot,
+	[string]$OutputDirectory,
+	[string]$GitHubOutputPath = $env:GITHUB_OUTPUT
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($SearchRoot)) {
+	$SearchRoot = $repoRoot
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+	$OutputDirectory = Join-Path (Join-Path $repoRoot 'Output') 'RenderArtifacts'
+}
+
+function Get-FullPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Path
+	)
+
+	return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Format-RelativePath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$BasePath,
+		[Parameter(Mandatory = $true)]
+		[string]$TargetPath
+	)
+
+	$baseFullPath = Get-FullPath $BasePath
+	$targetFullPath = Get-FullPath $TargetPath
+	if (-not $baseFullPath.EndsWith([System.IO.Path]::DirectorySeparatorChar.ToString(), [System.StringComparison]::Ordinal)) {
+		$baseFullPath += [System.IO.Path]::DirectorySeparatorChar
+	}
+
+	$baseUri = New-Object System.Uri($baseFullPath)
+	$targetUri = New-Object System.Uri($targetFullPath)
+	return [System.Uri]::UnescapeDataString($baseUri.MakeRelativeUri($targetUri).ToString()).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+}
+
+function Format-ArtifactPath {
+	param(
+		[string]$Path
+	)
+
+	if ([string]::IsNullOrWhiteSpace($Path)) {
+		return $null
+	}
+
+	return $Path.Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+}
+
+function Copy-RenderArtifactFile {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$SourcePath,
+		[Parameter(Mandatory = $true)]
+		[string]$DestinationPath,
+		[Parameter(Mandatory = $true)]
+		[string]$OutputRoot
+	)
+
+	if (-not (Test-Path -LiteralPath $SourcePath)) {
+		return $null
+	}
+
+	$destinationDirectory = Split-Path -Parent $DestinationPath
+	if (-not (Test-Path -LiteralPath $destinationDirectory)) {
+		New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+	}
+
+	Copy-Item -LiteralPath $SourcePath -Destination $DestinationPath -Force
+	return Format-ArtifactPath (Format-RelativePath -BasePath $OutputRoot -TargetPath $DestinationPath)
+}
+
+function Write-GitHubOutputValue {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Name,
+		[Parameter(Mandatory = $true)]
+		[string]$Value
+	)
+
+	if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+		return
+	}
+
+	$encoding = New-Object System.Text.UTF8Encoding($false)
+	[System.IO.File]::AppendAllText($GitHubOutputPath, "$Name=$Value$([System.Environment]::NewLine)", $encoding)
+}
+
+function New-MarkdownReport {
+	param(
+		[Parameter(Mandatory = $true)]
+		[object[]]$Entries,
+		[Parameter(Mandatory = $true)]
+		[string]$OutputRoot
+	)
+
+	$readmePath = Join-Path $OutputRoot 'README.md'
+	$lines = @(
+		'# Render comparison artifacts',
+		'',
+		"Render snapshot failures: $($Entries.Count)",
+		'',
+		'Open `index.html` after downloading this artifact to inspect expected, actual, and diff images.',
+		'',
+		'| Snapshot | Expected | Actual | Diff |',
+		'|---|---|---|---|'
+	)
+
+	foreach ($entry in $Entries) {
+		$expected = if ($entry.ExpectedPath) { "[expected]($($entry.ExpectedPath))" } else { 'missing' }
+		$actual = if ($entry.ActualPath) { "[actual]($($entry.ActualPath))" } else { 'missing' }
+		$diff = if ($entry.DiffPath) { "[diff]($($entry.DiffPath))" } else { 'missing' }
+		$lines += "| $($entry.SourcePath) | $expected | $actual | $diff |"
+	}
+
+	Set-Content -Path $readmePath -Value $lines -Encoding UTF8
+}
+
+function New-HtmlReport {
+	param(
+		[Parameter(Mandatory = $true)]
+		[object[]]$Entries,
+		[Parameter(Mandatory = $true)]
+		[string]$OutputRoot
+	)
+
+	$indexPath = Join-Path $OutputRoot 'index.html'
+	$builder = New-Object System.Text.StringBuilder
+	[void]$builder.AppendLine('<!doctype html>')
+	[void]$builder.AppendLine('<html lang="en">')
+	[void]$builder.AppendLine('<head>')
+	[void]$builder.AppendLine('<meta charset="utf-8">')
+	[void]$builder.AppendLine('<title>Render comparison artifacts</title>')
+	[void]$builder.AppendLine('<style>body{font-family:Segoe UI,Arial,sans-serif;margin:24px;color:#1f2328}table{border-collapse:collapse;width:100%}th,td{border:1px solid #d0d7de;padding:8px;vertical-align:top}th{background:#f6f8fa;text-align:left}img{max-width:320px;max-height:240px;border:1px solid #d0d7de;background:#fff}.path{font-family:Consolas,monospace;font-size:12px;word-break:break-all}</style>')
+	[void]$builder.AppendLine('</head>')
+	[void]$builder.AppendLine('<body>')
+	[void]$builder.AppendLine('<h1>Render comparison artifacts</h1>')
+	[void]$builder.AppendLine("<p>Render snapshot failures: $($Entries.Count)</p>")
+	[void]$builder.AppendLine('<table>')
+	[void]$builder.AppendLine('<thead><tr><th>Snapshot</th><th>Expected</th><th>Actual</th><th>Diff</th></tr></thead>')
+	[void]$builder.AppendLine('<tbody>')
+
+	foreach ($entry in $Entries) {
+		$snapshot = [System.Net.WebUtility]::HtmlEncode($entry.SourcePath)
+		[void]$builder.AppendLine('<tr>')
+		[void]$builder.AppendLine(('<td class="path">{0}</td>' -f $snapshot))
+		foreach ($artifact in @(
+			@{ PropertyName = 'ExpectedPath'; Description = 'Expected render' },
+			@{ PropertyName = 'ActualPath'; Description = 'Actual render' },
+			@{ PropertyName = 'DiffPath'; Description = 'Diff image' }
+		)) {
+			$propertyName = $artifact.PropertyName
+			$path = $entry.$propertyName
+			if ([string]::IsNullOrWhiteSpace($path)) {
+				[void]$builder.AppendLine('<td>missing</td>')
+				continue
+			}
+
+			$encodedPath = [System.Net.WebUtility]::HtmlEncode($path)
+			$encodedAltText = [System.Net.WebUtility]::HtmlEncode(('{0} for {1}' -f $artifact.Description, $entry.SourcePath))
+			[void]$builder.AppendLine(('<td><a href="{0}"><img src="{0}" alt="{1}"></a></td>' -f $encodedPath, $encodedAltText))
+		}
+		[void]$builder.AppendLine('</tr>')
+	}
+
+	[void]$builder.AppendLine('</tbody>')
+	[void]$builder.AppendLine('</table>')
+	[void]$builder.AppendLine('</body>')
+	[void]$builder.AppendLine('</html>')
+
+	Set-Content -Path $indexPath -Value $builder.ToString() -Encoding UTF8
+}
+
+$resolvedSearchRoot = Get-FullPath $SearchRoot
+$resolvedOutputDirectory = Get-FullPath $OutputDirectory
+
+if (-not (Test-Path -LiteralPath $resolvedSearchRoot)) {
+	throw "Search root not found: $resolvedSearchRoot"
+}
+
+if (Test-Path -LiteralPath $resolvedOutputDirectory) {
+	Remove-Item -LiteralPath $resolvedOutputDirectory -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $resolvedOutputDirectory -Force | Out-Null
+
+$receivedFiles = @(Get-ChildItem -Path $resolvedSearchRoot -Filter '*.received.png' -File -Recurse | Where-Object {
+	-not $_.FullName.StartsWith($resolvedOutputDirectory, [System.StringComparison]::OrdinalIgnoreCase)
+} | Sort-Object FullName)
+
+$entries = @()
+foreach ($receivedFile in $receivedFiles) {
+	$receivedPath = $receivedFile.FullName
+	$snapshotBasePath = $receivedPath.Substring(0, $receivedPath.Length - '.received.png'.Length)
+	$snapshotName = [System.IO.Path]::GetFileName($snapshotBasePath)
+	$relativeDirectory = Format-RelativePath -BasePath $resolvedSearchRoot -TargetPath (Split-Path -Parent $receivedPath)
+	$destinationDirectory = Join-Path $resolvedOutputDirectory $relativeDirectory
+
+	$expectedPath = Copy-RenderArtifactFile -SourcePath ($snapshotBasePath + '.verified.png') -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.expected.png')) -OutputRoot $resolvedOutputDirectory
+	$actualPath = Copy-RenderArtifactFile -SourcePath $receivedPath -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.actual.png')) -OutputRoot $resolvedOutputDirectory
+	$diffPath = Copy-RenderArtifactFile -SourcePath ($snapshotBasePath + '.diff.png') -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.diff.png')) -OutputRoot $resolvedOutputDirectory
+	$expectedMetadataPath = Copy-RenderArtifactFile -SourcePath ($snapshotBasePath + '.verified.json') -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.expected.json')) -OutputRoot $resolvedOutputDirectory
+	$actualMetadataPath = Copy-RenderArtifactFile -SourcePath ($snapshotBasePath + '.received.json') -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.actual.json')) -OutputRoot $resolvedOutputDirectory
+	$diffMetadataPath = Copy-RenderArtifactFile -SourcePath ($snapshotBasePath + '.diff.json') -DestinationPath (Join-Path $destinationDirectory ($snapshotName + '.diff.json')) -OutputRoot $resolvedOutputDirectory
+
+	$entries += [pscustomobject]@{
+		SnapshotName = $snapshotName
+		SourcePath = Format-ArtifactPath (Format-RelativePath -BasePath $resolvedSearchRoot -TargetPath $receivedPath)
+		ExpectedPath = $expectedPath
+		ActualPath = $actualPath
+		DiffPath = $diffPath
+		ExpectedMetadataPath = $expectedMetadataPath
+		ActualMetadataPath = $actualMetadataPath
+		DiffMetadataPath = $diffMetadataPath
+	}
+}
+
+$hasArtifacts = $entries.Count -gt 0
+Write-GitHubOutputValue -Name 'has_artifacts' -Value ($hasArtifacts.ToString().ToLowerInvariant())
+Write-GitHubOutputValue -Name 'failure_count' -Value $entries.Count.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+Write-GitHubOutputValue -Name 'artifact_path' -Value $resolvedOutputDirectory
+
+if (-not $hasArtifacts) {
+	Write-Output ([pscustomobject]@{
+		HasArtifacts = $false
+		FailureCount = 0
+		OutputDirectory = $resolvedOutputDirectory
+	})
+	return
+}
+
+$manifest = [pscustomobject]@{
+	GeneratedAtUtc = [System.DateTime]::UtcNow.ToString('O', [System.Globalization.CultureInfo]::InvariantCulture)
+	FailureCount = $entries.Count
+	Artifacts = $entries
+}
+
+$manifest | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $resolvedOutputDirectory 'manifest.json') -Encoding UTF8
+New-MarkdownReport -Entries $entries -OutputRoot $resolvedOutputDirectory
+New-HtmlReport -Entries $entries -OutputRoot $resolvedOutputDirectory
+
+Write-Output ([pscustomobject]@{
+	HasArtifacts = $true
+	FailureCount = $entries.Count
+	OutputDirectory = $resolvedOutputDirectory
+})
+
+Write-Host "::notice title=Render comparison artifacts::$($entries.Count) render comparison artifact set(s) collected."

--- a/Build/Agent/Report-RenderArtifacts.ps1
+++ b/Build/Agent/Report-RenderArtifacts.ps1
@@ -1,0 +1,228 @@
+[CmdletBinding()]
+param(
+	[string]$ArtifactUrl = $env:ARTIFACT_URL,
+	[string]$EventPath = $env:GITHUB_EVENT_PATH,
+	[string]$FailureCount = $env:FAILURE_COUNT,
+	[string]$GitHubApiUrl = $env:GITHUB_API_URL,
+	[string]$GitHubToken = $env:GITHUB_TOKEN,
+	[string]$HasArtifacts = $env:HAS_ARTIFACTS,
+	[string]$Repository = $env:GITHUB_REPOSITORY,
+	[string]$RunAttempt = $env:GITHUB_RUN_ATTEMPT,
+	[string]$RunId = $env:GITHUB_RUN_ID,
+	[string]$ServerUrl = $env:GITHUB_SERVER_URL,
+	[string]$Sha = $env:GITHUB_SHA,
+	[string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY,
+	[switch]$SkipComment
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Marker = '<!-- fieldworks-render-comparison-artifacts -->'
+if ([string]::IsNullOrWhiteSpace($GitHubApiUrl)) {
+	$GitHubApiUrl = 'https://api.github.com'
+}
+if ([string]::IsNullOrWhiteSpace($ServerUrl)) {
+	$ServerUrl = 'https://github.com'
+}
+
+function Add-Utf8NoBomLine {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Path,
+		[Parameter(Mandatory = $true)]
+		[AllowEmptyString()]
+		[string]$Value
+	)
+
+	$encoding = New-Object System.Text.UTF8Encoding($false)
+	[System.IO.File]::AppendAllText($Path, "$Value$([System.Environment]::NewLine)", $encoding)
+}
+
+function Add-StepSummaryLine {
+	param([string]$Value = '')
+
+	if ([string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+		return
+	}
+
+	Add-Utf8NoBomLine -Path $StepSummaryPath -Value $Value
+}
+
+function Get-RequiredValue {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Name,
+		[AllowEmptyString()]
+		[string]$Value
+	)
+
+	if ([string]::IsNullOrWhiteSpace($Value)) {
+		throw "Required value missing: $Name"
+	}
+
+	return $Value
+}
+
+function Invoke-GitHubApi {
+	param(
+		[Parameter(Mandatory = $true)]
+		[ValidateSet('Get', 'Post', 'Patch')]
+		[string]$Method,
+		[Parameter(Mandatory = $true)]
+		[string]$Uri,
+		[object]$Body
+	)
+
+	$headers = @{
+		Accept = 'application/vnd.github+json'
+		Authorization = "Bearer $GitHubToken"
+		'X-GitHub-Api-Version' = '2022-11-28'
+	}
+
+	if ($PSBoundParameters.ContainsKey('Body')) {
+		$jsonBody = $Body | ConvertTo-Json -Depth 8
+		return Invoke-RestMethod -Method $Method -Uri $Uri -Headers $headers -Body $jsonBody -ContentType 'application/json'
+	}
+
+	return Invoke-RestMethod -Method $Method -Uri $Uri -Headers $headers
+}
+
+function Get-PullRequestNumber {
+	$eventPayload = Get-Content -LiteralPath (Get-RequiredValue -Name 'EventPath' -Value $EventPath) -Raw | ConvertFrom-Json
+	if ($null -eq $eventPayload.pull_request -or $null -eq $eventPayload.pull_request.number) {
+		throw 'GitHub event payload does not contain a pull request number.'
+	}
+
+	return [int]$eventPayload.pull_request.number
+}
+
+function Get-RenderComment {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$CommentsUri,
+		[Parameter(Mandatory = $true)]
+		[string]$Owner,
+		[Parameter(Mandatory = $true)]
+		[string]$Repo,
+		[Parameter(Mandatory = $true)]
+		[int]$PullRequestNumber
+	)
+
+	$comments = @(Invoke-GitHubApi -Method Get -Uri $CommentsUri)
+	foreach ($comment in $comments) {
+		if ($comment.body -and $comment.body.Contains($Marker)) {
+			return $comment
+		}
+	}
+
+	$query = @'
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      comments(first: 100) {
+        nodes {
+          databaseId
+          body
+        }
+      }
+    }
+  }
+}
+'@
+	$result = Invoke-GitHubApi -Method Post -Uri "$GitHubApiUrl/graphql" -Body @{
+		query = $query
+		variables = @{
+			owner = $Owner
+			repo = $Repo
+			number = $PullRequestNumber
+		}
+	}
+
+	$pullRequestComments = @($result.data.repository.pullRequest.comments.nodes)
+	foreach ($comment in $pullRequestComments) {
+		if ($comment.body -and $comment.body.Contains($Marker)) {
+			return [pscustomobject]@{
+				id = $comment.databaseId
+				body = $comment.body
+			}
+		}
+	}
+
+	return $null
+}
+
+$hasRenderArtifacts = [System.String]::Equals($HasArtifacts, 'true', [System.StringComparison]::OrdinalIgnoreCase)
+$repositoryName = Get-RequiredValue -Name 'Repository' -Value $Repository
+$repositoryParts = $repositoryName.Split('/')
+if ($repositoryParts.Count -ne 2) {
+	throw "Invalid GitHub repository value: $repositoryName"
+}
+
+$owner = $repositoryParts[0]
+$repo = $repositoryParts[1]
+$runLabel = "$(Get-RequiredValue -Name 'RunId' -Value $RunId).$(Get-RequiredValue -Name 'RunAttempt' -Value $RunAttempt)"
+$runUrl = "$ServerUrl/$owner/$repo/actions/runs/$RunId"
+$shortSha = (Get-RequiredValue -Name 'Sha' -Value $Sha).Substring(0, [System.Math]::Min(12, $Sha.Length))
+
+if ($hasRenderArtifacts) {
+	$artifactLink = Get-RequiredValue -Name 'ArtifactUrl' -Value $ArtifactUrl
+	$failureTotal = Get-RequiredValue -Name 'FailureCount' -Value $FailureCount
+	Add-StepSummaryLine '### Render comparison artifacts'
+	Add-StepSummaryLine
+	Add-StepSummaryLine "$failureTotal render snapshot failure(s) produced expected, actual, and diff images."
+	Add-StepSummaryLine
+	Add-StepSummaryLine "[Download render comparison artifacts]($artifactLink)"
+}
+
+if ($SkipComment) {
+	return
+}
+
+Get-RequiredValue -Name 'GitHubToken' -Value $GitHubToken | Out-Null
+$pullRequestNumber = Get-PullRequestNumber
+$commentsUri = "$GitHubApiUrl/repos/$owner/$repo/issues/$pullRequestNumber/comments?per_page=100"
+$previous = Get-RenderComment -CommentsUri $commentsUri -Owner $owner -Repo $repo -PullRequestNumber $pullRequestNumber
+
+if ($hasRenderArtifacts) {
+	$entry = "- [$shortSha run $runLabel]($runUrl) - $FailureCount render snapshot failure(s) - [download artifact]($ArtifactUrl)"
+	$previousEntries = @()
+	if ($null -ne $previous) {
+		$previousEntries = @($previous.body -split '\r?\n' | Where-Object { $_.StartsWith('- [', [System.StringComparison]::Ordinal) })
+	}
+
+	$entries = @($entry) + @($previousEntries | Where-Object { -not $_.Contains("run $runLabel") })
+	$bodyLines = @(
+		$Marker,
+		'### Render comparison artifacts',
+		'',
+		'Render snapshot failure artifacts from recent CI runs. Each artifact contains `index.html`, expected images, actual images, diff images, and metadata.',
+		''
+	) + @($entries | Select-Object -First 25) + @('')
+}
+else {
+	if ($null -eq $previous) {
+		Write-Output 'No existing render artifact comment found to mark resolved.'
+		return
+	}
+
+	$bodyLines = @(
+		$Marker,
+		'### Render comparison artifacts',
+		'',
+		'No render snapshot failures were captured in the latest successful CI run.',
+		'',
+		"Latest run: [$shortSha run $runLabel]($runUrl).",
+		''
+	)
+}
+
+$body = $bodyLines -join "`n"
+if ($null -ne $previous) {
+	Invoke-GitHubApi -Method Patch -Uri "$GitHubApiUrl/repos/$owner/$repo/issues/comments/$($previous.id)" -Body @{ body = $body } | Out-Null
+	Write-Output "Updated render artifact comment $($previous.id)."
+}
+else {
+	Invoke-GitHubApi -Method Post -Uri "$GitHubApiUrl/repos/$owner/$repo/issues/$pullRequestNumber/comments" -Body @{ body = $body } | Out-Null
+	Write-Output "Created render artifact comment on PR $pullRequestNumber."
+}

--- a/Build/Agent/Test-BuildRenderArtifactComment.ps1
+++ b/Build/Agent/Test-BuildRenderArtifactComment.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Build-RenderArtifactComment.ps1'
+$workspace = Join-Path ([System.IO.Path]::GetTempPath()) ('BuildRenderArtifactCommentTest-' + [guid]::NewGuid().ToString('N'))
+
+function Assert-True {
+	param(
+		[Parameter(Mandatory = $true)]
+		[bool]$Condition,
+		[Parameter(Mandatory = $true)]
+		[string]$Message
+	)
+
+	if (-not $Condition) {
+		throw $Message
+	}
+}
+
+try {
+	$artifactsDirectory = Join-Path $workspace 'with-artifacts'
+	$noArtifactsDirectory = Join-Path $workspace 'without-artifacts'
+	New-Item -ItemType Directory -Path $artifactsDirectory -Force | Out-Null
+	New-Item -ItemType Directory -Path $noArtifactsDirectory -Force | Out-Null
+
+	$withArtifactsCommentPath = Join-Path $artifactsDirectory 'render-comment.md'
+	$withArtifactsOutputPath = Join-Path $artifactsDirectory 'github-output.txt'
+	$withArtifactsParameters = @{
+		ArtifactUrl = 'https://example.test/artifact'
+		CommentPath = $withArtifactsCommentPath
+		FailureCount = '2'
+		GitHubOutputPath = $withArtifactsOutputPath
+		HasArtifacts = 'true'
+		Repository = 'sillsdev/FieldWorks'
+		RunAttempt = '1'
+		RunId = '123456'
+		ServerUrl = 'https://github.com'
+		Sha = '0123456789abcdef0123456789abcdef01234567'
+	}
+	$withArtifactsResult = & $scriptPath @withArtifactsParameters
+
+	Assert-True (Test-Path -LiteralPath $withArtifactsCommentPath) 'Expected helper to write the artifact comment markdown file.'
+	Assert-True (Test-Path -LiteralPath $withArtifactsOutputPath) 'Expected helper to write the GitHub output file for the artifact case.'
+	Assert-True ($withArtifactsResult.HasArtifacts -eq $true) 'Expected helper to report artifact presence.'
+
+	$withArtifactsComment = Get-Content -LiteralPath $withArtifactsCommentPath -Raw
+	Assert-True ($withArtifactsComment.Contains('detected 2 render snapshot failure(s).')) 'Expected artifact comment to include the failure count.'
+	Assert-True ($withArtifactsComment.Contains('[Download render comparison artifacts](https://example.test/artifact)')) 'Expected artifact comment to include the artifact link.'
+
+	$withArtifactsOutput = Get-Content -LiteralPath $withArtifactsOutputPath -Raw
+	Assert-True ($withArtifactsOutput.Contains('comment_path=')) 'Expected artifact case to publish comment_path to GitHub output.'
+
+	$withoutArtifactsCommentPath = Join-Path $noArtifactsDirectory 'render-comment.md'
+	$withoutArtifactsOutputPath = Join-Path $noArtifactsDirectory 'github-output.txt'
+	$previousFailureComment = @'
+### Render comparison artifacts
+
+[0123456789ab run 123456.1](https://github.com/sillsdev/FieldWorks/actions/runs/123456) detected 2 render snapshot failure(s).
+
+- The artifact includes `index.html`, expected images, actual images, diff images, and metadata.
+- [Download render comparison artifacts](https://example.test/artifact)
+
+This comment is updated in place by CI for the latest run.
+<!-- Sticky Pull Request Commentfieldworks-render-comparison-artifacts -->
+'@
+	$withoutArtifactsParameters = @{
+		CommentPath = $withoutArtifactsCommentPath
+		GitHubOutputPath = $withoutArtifactsOutputPath
+		HasArtifacts = 'false'
+		PreviousCommentBody = $previousFailureComment
+		Repository = 'sillsdev/FieldWorks'
+		RunAttempt = '2'
+		RunId = '123457'
+		ServerUrl = 'https://github.com'
+		Sha = 'fedcba9876543210fedcba9876543210fedcba98'
+	}
+	$withoutArtifactsResult = & $scriptPath @withoutArtifactsParameters
+
+	Assert-True (Test-Path -LiteralPath $withoutArtifactsCommentPath) 'Expected helper to write the clean-run comment markdown file.'
+	Assert-True (Test-Path -LiteralPath $withoutArtifactsOutputPath) 'Expected helper to write the GitHub output file for the clean-run case.'
+	Assert-True ($withoutArtifactsResult.HasArtifacts -eq $false) 'Expected helper to report no artifacts for a clean run.'
+
+	$withoutArtifactsComment = Get-Content -LiteralPath $withoutArtifactsCommentPath -Raw
+	Assert-True ($withoutArtifactsComment.Contains('Render snapshot failures were reported in [0123456789ab run 123456.1](https://github.com/sillsdev/FieldWorks/actions/runs/123456), but the latest run [fedcba987654 run 123457.2](https://github.com/sillsdev/FieldWorks/actions/runs/123457) is clean.')) 'Expected clean-run comment to reference the prior failing run and the latest clean run.'
+}
+finally {
+	if (Test-Path -LiteralPath $workspace) {
+		Remove-Item -LiteralPath $workspace -Recurse -Force
+	}
+}
+
+Write-Output '[OK] Build-RenderArtifactComment smoke test passed.'

--- a/Build/Agent/Test-CollectRenderArtifacts.ps1
+++ b/Build/Agent/Test-CollectRenderArtifacts.ps1
@@ -1,0 +1,72 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Collect-RenderArtifacts.ps1'
+$workspace = Join-Path ([System.IO.Path]::GetTempPath()) ('CollectRenderArtifactsTest-' + [guid]::NewGuid().ToString('N'))
+$searchRoot = Join-Path $workspace 'repo'
+$outputDirectory = Join-Path $workspace 'render-artifacts'
+$githubOutputPath = Join-Path $workspace 'github-output.txt'
+
+function Assert-True {
+	param(
+		[Parameter(Mandatory = $true)]
+		[bool]$Condition,
+		[Parameter(Mandatory = $true)]
+		[string]$Message
+	)
+
+	if (-not $Condition) {
+		throw $Message
+	}
+}
+
+try {
+	New-Item -ItemType Directory -Path $searchRoot -Force | Out-Null
+
+	$baselineDirectory = Join-Path $searchRoot 'Src/Common/RootSite/RootSiteTests/Baselines'
+	New-Item -ItemType Directory -Path $baselineDirectory -Force | Out-Null
+
+	foreach ($name in @('alpha', 'beta')) {
+		Set-Content -Path (Join-Path $baselineDirectory "$name.verified.png") -Value "expected-$name"
+		Set-Content -Path (Join-Path $baselineDirectory "$name.received.png") -Value "actual-$name"
+		Set-Content -Path (Join-Path $baselineDirectory "$name.diff.png") -Value "diff-$name"
+		Set-Content -Path (Join-Path $baselineDirectory "$name.diff.json") -Value "{`"SnapshotName`":`"$name`"}"
+	}
+
+	$result = & $scriptPath -SearchRoot $searchRoot -OutputDirectory $outputDirectory -GitHubOutputPath $githubOutputPath
+
+	Assert-True ($result.HasArtifacts -eq $true) 'Expected render artifacts to be detected.'
+	Assert-True ($result.FailureCount -eq 2) 'Expected two render failures to be reported.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'index.html')) 'Expected an HTML report.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'README.md')) 'Expected a Markdown report.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'manifest.json')) 'Expected a manifest file.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'Src/Common/RootSite/RootSiteTests/Baselines/alpha.expected.png')) 'Expected alpha baseline image to be copied.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'Src/Common/RootSite/RootSiteTests/Baselines/alpha.actual.png')) 'Expected alpha received image to be copied.'
+	Assert-True (Test-Path (Join-Path $outputDirectory 'Src/Common/RootSite/RootSiteTests/Baselines/alpha.diff.png')) 'Expected alpha diff image to be copied.'
+
+	$githubOutputBytes = [System.IO.File]::ReadAllBytes($githubOutputPath)
+	$hasUtf8Bom = $githubOutputBytes.Length -ge 3 -and $githubOutputBytes[0] -eq 0xEF -and $githubOutputBytes[1] -eq 0xBB -and $githubOutputBytes[2] -eq 0xBF
+	Assert-True (-not $hasUtf8Bom) 'Expected GitHub output file to be written without a UTF-8 BOM.'
+
+	$githubOutput = [System.IO.File]::ReadAllText($githubOutputPath)
+	Assert-True ($githubOutput.Contains('has_artifacts=true')) 'Expected has_artifacts GitHub output.'
+	Assert-True ($githubOutput.Contains('failure_count=2')) 'Expected failure_count GitHub output.'
+
+	$readme = Get-Content -LiteralPath (Join-Path $outputDirectory 'README.md') -Raw
+	Assert-True ($readme.Contains('[expected](')) 'Expected Markdown report to use expected link labels.'
+	Assert-True ($readme.Contains('[actual](')) 'Expected Markdown report to use actual link labels.'
+	Assert-True ($readme.Contains('[diff](')) 'Expected Markdown report to use diff link labels.'
+
+	$html = Get-Content -LiteralPath (Join-Path $outputDirectory 'index.html') -Raw
+	Assert-True ($html.Contains('alt="Expected render for Src/Common/RootSite/RootSiteTests/Baselines/alpha.received.png"')) 'Expected descriptive alt text for expected render image.'
+}
+finally {
+	if (Test-Path -LiteralPath $workspace) {
+		Remove-Item -LiteralPath $workspace -Recurse -Force
+	}
+}
+
+Write-Output '[OK] Collect-RenderArtifacts smoke test passed.'


### PR DESCRIPTION
Adds CI support for render snapshot failure artifacts.

- Collects render verifier `.received.png`, `.verified.png`, `.diff.png`, and metadata into `Output/RenderArtifacts`
- Uploads a run artifact with `index.html`, `README.md`, and `manifest.json`
- Adds a workflow summary link to the artifact
- Updates a single PR comment with artifact links for failing render runs, and marks it resolved after a successful run

Local verification:
- `./Build/Agent/Test-CollectRenderArtifacts.ps1`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/876)
<!-- Reviewable:end -->
