### PR TITLE
Fix normalization in ToneParsInvokerTests

### DIFF
--- a/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
+++ b/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
@@ -184,8 +184,8 @@ namespace SIL.DisambiguateInFLExDBTests
 		private string NormalizeContent(string input)
 		{
 			string tp = "tonepars64";
-			string normalized = NormalizeViaIndex(input, "AppData", "");
-			normalized = NormalizeViaIndex(normalized, "TestData", "");
+			string normalized = NormalizeViaIndex(input, "AppData", "AppData");
+			normalized = NormalizeViaIndex(normalized, "TestData", "TestData");
 			normalized = NormalizeViaIndex(normalized, tp, tp);
 			return normalized;
 		}
@@ -201,7 +201,7 @@ namespace SIL.DisambiguateInFLExDBTests
 				{
 					iColon--; // skip the drive letter, too
 					string appdataPath = input.Substring(iColon, iAppData - iColon);
-					input = input.Replace(appdataPath, change);
+					input = input.Replace(appdataPath + match, change);
 				}
 			}
 			return input;


### PR DESCRIPTION
NormalizeContent didn't work on the file names for my machine, applying a transform where it shouldn't.  I tightened up the pattern to avoid the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/881)
<!-- Reviewable:end -->
