### PR TITLE
Fix LT-22520: Crash when closing Find dialog in Grammar Sketch

### DIFF
--- a/Src/xWorks/GeneratedHtmlViewer.cs
+++ b/Src/xWorks/GeneratedHtmlViewer.cs
@@ -228,6 +228,11 @@ namespace SIL.FieldWorks.XWorks
 
 		private void Find_Click(object sender, EventArgs e)
 		{
+			if (m_sHtmlFileName == InitialDocument)
+			{
+				// InitialDocument doesn't have the proper javascript for Find to work.
+				return;
+			}
 			findDlg = new FindDialog(m_htmlControl.Browser);
 			findDlg.FormClosing += new FormClosingEventHandler(FindDialog_FormClosing);
 			findDlg.Show(this);


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22520.  If you try to find something before a sketch has been generated, you get an error.  Ideally, we would suppress the Find menu item in this case, but I wasn't sure that I could get that right in all cases.  So now if you click on the Find menu item, nothing happens.  This isn't perfect, but at least it doesn't crash.  This is also pretty uncommon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/882)
<!-- Reviewable:end -->
