### PR TITLE
LT-20857: Fixed a paste problem

### DIFF
--- a/Src/views/VwSelection.cpp
+++ b/Src/views/VwSelection.cpp
@@ -5584,8 +5584,18 @@ STDMETHODIMP VwTextSelection::ReplaceWithTsString(ITsString * ptss)
 						qttpPara.Clear();
 
 					if (SameObject(qttpText, qttpPara))
+					{
 						qttpPara.Clear();		// Not a special paragraph property after all.
-					vpttpPara.Push(qttpPara);
+
+						// If it is not the last character, or it is the last character
+						// and we have added others, then add it to vpttpPara.
+						// Otherwise, don't add it so the new text will be treated as if
+						// it doesn't have a newline (fix for LT-20857).
+						if (ichNext < cch || vpttpPara.Size() > 0)
+							vpttpPara.Push(qttpPara);
+					}
+					else
+						vpttpPara.Push(qttpPara);
 					Assert(cNewlines == 0);
 				}
 				else


### PR DESCRIPTION
Fixed the paste problem when the selection is a single paragraph. In the code a paragraph is indicated by a ‘\n’.

Note: This fix is specific to a single paragraph selection. It does not add support for other complex selections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/886)
<!-- Reviewable:end -->
