### PR TITLE
LT-22373b: Move numbering style fix to the get method

### DIFF
--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -520,10 +520,6 @@ namespace SIL.FieldWorks.XWorks
 			var senseNode = mainEntryNode.Children.Where(prop => prop.Label == senseType).FirstOrDefault();
 			if (senseNode == null) return;
 			var senseOptions = (DictionaryNodeSenseOptions)senseNode.DictionaryNodeOptions;
-			if (String.IsNullOrEmpty(senseOptions.NumberingStyle))
-			{
-				senseOptions.NumberingStyle = null;
-			}
 			cacheHc.ksSenseNumberStyle = senseOptions.NumberingStyle;
 			//SubSense Node
 			var subSenseNode = senseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
@@ -64,7 +64,13 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 
 		public string NumberingStyle
 		{
-			get{ return ((NumberingStyleComboItem)dropDownNumberingStyle.SelectedItem).FormatString; }
+			get
+			{
+				// Return null if string is empty, because returning an empty string for reversal numbers
+				// also forces sense numbers not to be displayed. Null doesn't cause the same problem.
+				var formatString = ((NumberingStyleComboItem)dropDownNumberingStyle.SelectedItem).FormatString;
+				return string.IsNullOrEmpty(formatString) ? null : formatString;
+			}
 			set
 			{
 				if (string.IsNullOrEmpty(value))


### PR DESCRIPTION
Reversal numbering style was still displaying incorrectly in the preview window of the configuration dialog. Making the change in the get method instead fixes the issue in all locations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/887)
<!-- Reviewable:end -->
