### PR TITLE
Fix the build failure on release builds

### DIFF
--- a/Src/Generic/Test/testGeneric.cpp
+++ b/Src/Generic/Test/testGeneric.cpp
@@ -92,8 +92,10 @@ namespace unitpp
 		if (fInjectTeardownAssert || fInjectTeardownAbort)
 			RestorePreviousAssertProc();
 
+#ifdef DEBUG
 		if (fInjectTeardownAssert)
 			AssertMsg(false, "Injected teardown assert for native test infrastructure validation");
+#endif
 
 		if (fInjectTeardownAbort)
 		{

--- a/Src/views/Test/testViews.cpp
+++ b/Src/views/Test/testViews.cpp
@@ -113,8 +113,10 @@ namespace unitpp
 		if (fInjectTeardownAssert || fInjectTeardownAbort)
 			RestorePreviousAssertProc();
 
+#ifdef DEBUG
 		if (fInjectTeardownAssert)
 			AssertMsg(false, "Injected teardown assert for native test infrastructure validation");
+#endif
 
 		if (fInjectTeardownAbort)
 		{


### PR DESCRIPTION
* AssertMsg(cond, msg) is a macro that is not present on release builds leaving behind a lone ';' which is a warning

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/888)
<!-- Reviewable:end -->
