### PR TITLE
Add debug guards around the assert verification code

### DIFF
--- a/Src/Generic/Test/TestErrorHandling.h
+++ b/Src/Generic/Test/TestErrorHandling.h
@@ -158,6 +158,7 @@ namespace TestGenericLib
 #endif
 		}
 
+#ifdef DEBUG
 		void testNativeAssertThrowsExceptionWithoutContinuing()
 		{
 #if defined(WIN32) || defined(_M_X64)
@@ -182,6 +183,7 @@ namespace TestGenericLib
 			// TODO-Linux: port
 #endif
 		}
+#endif
 
 	public:
 		TestErrorHandling();

--- a/Src/Generic/Test/testGeneric.cpp
+++ b/Src/Generic/Test/testGeneric.cpp
@@ -11,7 +11,9 @@ Last reviewed:
 -------------------------------------------------------------------------------*//*:End Ignore*/
 #include "testGenericLib.h"
 #include "RedirectHKCU.h"
+#ifdef DEBUG
 #include "DebugProcs.h"
+#endif
 #include <cstdlib>
 #include <cstring>
 #include <csignal>
@@ -19,6 +21,7 @@ Last reviewed:
 
 namespace
 {
+#ifdef DEBUG
 	Pfn_Assert g_previousAssertProc = NULL;
 
 	void RestorePreviousAssertProc()
@@ -29,6 +32,7 @@ namespace
 			g_previousAssertProc = NULL;
 		}
 	}
+#endif
 
 	void TerminateOnSigAbrt(int)
 	{
@@ -47,6 +51,7 @@ namespace
 		return fEnabled;
 	}
 
+#ifdef DEBUG
 	void WINAPI ThrowingAssertProc(const char * pszExp, const char * pszFile, int nLine, HMODULE)
 	{
 		char szMessage[1024];
@@ -61,12 +66,14 @@ namespace
 		fflush(stderr);
 		throw std::runtime_error(szMessage);
 	}
+#endif
 }
 
 namespace unitpp
 {
 	void GlobalSetup(bool verbose)
 	{
+#ifdef DEBUG
 		if (IsEnvironmentSwitchEnabled("FW_TEST_ALLOW_ASSERT_DIALOGS"))
 		{
 			ShowAssertMessageBox(1);
@@ -76,6 +83,7 @@ namespace unitpp
 			g_previousAssertProc = SetAssertProc(ThrowingAssertProc);
 			ShowAssertMessageBox(0); // Disable assertion dialogs
 		}
+#endif
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_ATTACH);
 #endif
@@ -87,15 +95,14 @@ namespace unitpp
 	{
 		signal(SIGABRT, TerminateOnSigAbrt);
 
+#ifdef DEBUG
 		const bool fInjectTeardownAssert = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ASSERT");
 		const bool fInjectTeardownAbort = IsEnvironmentSwitchEnabled("FW_TEST_INDUCE_TEARDOWN_ABORT");
 		if (fInjectTeardownAssert || fInjectTeardownAbort)
 			RestorePreviousAssertProc();
 
-#ifdef DEBUG
 		if (fInjectTeardownAssert)
 			AssertMsg(false, "Injected teardown assert for native test infrastructure validation");
-#endif
 
 		if (fInjectTeardownAbort)
 		{
@@ -103,13 +110,16 @@ namespace unitpp
 			_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 			abort();
 		}
+#endif
 
 #if defined(WIN32) || defined(WIN64)
 		ModuleEntry::DllMain(0, DLL_PROCESS_DETACH);
 #endif
 		::OleUninitialize();
 
+#ifdef DEBUG
 		RestorePreviousAssertProc();
+#endif
 	}
 }
 


### PR DESCRIPTION
* The release build doesn't need to verify this assert behavior because it won't be generating the asserts, but we still want to build and run all other tests in release mode

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/890)
<!-- Reviewable:end -->
