### PR TITLE
Fix the patching for Newtonsoft.Json

### DIFF
--- a/FLExInstaller/CustomComponents.wxi
+++ b/FLExInstaller/CustomComponents.wxi
@@ -8,8 +8,10 @@
 <Include>
 	<?ifdef MASTERBUILDDIR?>
 	<WixVariable Id="RootObjectsDir" Value="$(var.MASTERBUILDDIR)\.."/>
+	<WixVariable Id="BuildDir" Value="$(var.MASTERBUILDDIR)"/>
 	<?else?>
 	<WixVariable Id="RootObjectsDir" Value="$(var.UPDATEBUILDDIR)\.."/>
+	<WixVariable Id="BuildDir" Value="$(var.UPDATEBUILDDIR)"/>
 	<?endif?>
 
 	<DirectoryRef Id="$(var.CFDir)">
@@ -299,7 +301,6 @@
 	<?include $(var.HarvestWxiDir)\yoHarvest.wxi?>
 	<?include $(var.HarvestWxiDir)\zhHarvest.wxi?>
 	<?include $(var.HarvestWxiDir)\zlmHarvest.wxi?>
-	<?ifdef MASTERBUILDDIR?>
 	<!--
 		WiX 3 / PatchableInstaller: Newtonsoft.Json.dll is excluded from Heat (FLExInstaller/PatchableInstallerHeatExclude.xml
 		copied to BaseInstallerBuild/heat-exclude.xml; CopyFilesToInstall) and KeyPathFix.xsl. NewtonsoftJsonApp: private
@@ -309,17 +310,16 @@
 		<Component Id="NewtonsoftJsonApp" Guid="{B8A47C61-2E90-4D1A-9F4E-7C3B5A682D01}">
 			<File Id="NewtonsoftJsonFileApp"
 				Name="Newtonsoft.Json.dll"
-				Source="$(var.MASTERBUILDDIR)\Newtonsoft.Json.dll"
+				Source="!(wix.BuildDir)\Newtonsoft.Json.dll"
 				KeyPath="yes" />
 		</Component>
 		<Component Id="NewtonsoftJsonGac" Guid="*">
 			<File Id="NewtonsoftJsonFileGac"
 				Name="Newtonsoft.Json.dll"
-				Source="$(var.MASTERBUILDDIR)\Newtonsoft.Json.dll"
+				Source="!(wix.BuildDir)\Newtonsoft.Json.dll"
 				KeyPath="yes"
 				Assembly=".net" />
 		</Component>
 	</DirectoryRef>
-	<?endif?>
 	<?include Fonts.wxi?>
 </Include>

--- a/FLExInstaller/CustomFeatures.wxi
+++ b/FLExInstaller/CustomFeatures.wxi
@@ -10,11 +10,8 @@
 	<MergeRef Id="PerlEC"/>
 	<MergeRef Id="PythonEC"/>
 	<MergeRef Id="TECkit_DLLs"/>
-	<!-- Heat-excluded Newtonsoft.Json: components in CustomComponents.wxi are inside <?ifdef MASTERBUILDDIR?>; match that here so patch builds (UPDATEBUILDDIR only) do not emit dangling ComponentRefs (LGHT0094). -->
-	<?ifdef MASTERBUILDDIR?>
 	<ComponentRef Id="NewtonsoftJsonApp" />
 	<ComponentRef Id="NewtonsoftJsonGac" />
-	<?endif?>
 
 	<Feature Id='DesktopShortcut' Title='Desktop Shortcut' Description='Creates a shortcut on the desktop.' Level='1' ConfigurableDirectory='APPFOLDER' AllowAdvertise="no" InstallDefault="source" Absent='allow' TypicalDefault="install" >
 		<ComponentRef Id='ApplicationShortcutDesktop'/>


### PR DESCRIPTION
* The previous commit on this was done from an incomplete understanding of how the patch harvesting interacted with the base contents

## Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). -->

## CI-ready checklist

- [ ] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/894)
<!-- Reviewable:end -->
