### PR TITLE
Fix LT-21617: Sorting does not work for Exception Features

### DIFF
--- a/Src/xWorks/RecordList.cs
+++ b/Src/xWorks/RecordList.cs
@@ -209,7 +209,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			get
 			{
-				return !(m_owningObject as ICmPossibilityList).IsSorted;
+				return (m_owningObject as ICmPossibilityList).IsSorted;
 			}
 		}
 
@@ -2942,7 +2942,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="updateAndNotify">If true: Gui and properties should be updated, and notifications sent.</param>
 		protected void SortList(ArrayList newSortedObjects, bool updateAndNotify, ProgressState progress)
 		{
-			if (m_sorter != null && !ListAlreadySorted)
+			if (m_sorter != null)
 			{
 				m_sorter.DataAccess = m_publisher;
 				if (updateAndNotify && m_sorter is IReportsSortProgress)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-21617.  RecordList.ListAlreadySorted was implemented incorrectly, and in any case IsSorted wasn't being updated when a list was reverse sorted.  ListAlreadySorted isn't called anywhere else.  It is amazing that this code worked at all.  My guess is that IsSorted was true for most possibility lists, so the old implementation of ListAlreadySorted worked.  But for some reason it wasn't true for Exception Features, and so Exception Features couldn't be sorted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/896)
<!-- Reviewable:end -->
