### PR TITLE
Clean-up artifact comment bug on 0 comments

### DIFF
--- a/Build/Agent/Build-RenderArtifactComment.ps1
+++ b/Build/Agent/Build-RenderArtifactComment.ps1
@@ -122,7 +122,7 @@ function Get-PreviousCommentBody {
 	$owner = $repositoryParts[0]
 	$repo = $repositoryParts[1]
 	$commentsUri = "$GitHubApiUrl/repos/$owner/$repo/issues/$pullRequestNumber/comments?per_page=100"
-	$comments = @(Invoke-GitHubApi -Method Get -Uri $commentsUri)
+	$comments = @(Invoke-GitHubApi -Method Get -Uri $commentsUri) | Where-Object { $null -ne $_ }
 	$latestMatchingCommentBody = $null
 	foreach ($comment in $comments) {
 		if ($comment.body -and $comment.body.Contains($StickyCommentMarker)) {


### PR DESCRIPTION
The script for making sure that comments are cleared if problems are resolved didn't handle the absence of previous problems

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/897)
<!-- Reviewable:end -->
