### PR TITLE
LT-22519: ensure variant form title uses the variant version

### DIFF
--- a/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
+++ b/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
@@ -67,6 +67,7 @@ namespace SIL.VariantGenerator
 				InitializePublishEntryInControls();
 				SetBackColor();
 				this.Text = VariantGeneratorDll_Strings.ksTitle;
+				formTitle = VariantGeneratorDll_Strings.ksTitle;
 			}
 			// Create an instance of a ListView column sorter and assign it
 			// to the ListView control.


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22519 (Dialog label changes incorrectly from "Variant Generator" to "Allomorph Generator" after clicking Save Changes).

The VariantGenForm subclasses AlloGenFormBase which has a protected variable called formTitle.  This gets initialized to "Allomorph Generator".  The fix is to ensure it gets set to "Variant Generator" in the VariantGenForm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/898)
<!-- Reviewable:end -->
