### PR TITLE
LT-22373c: Fix NumberingStyle get in DictionaryNodeOptions

### DIFF
--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -520,18 +520,18 @@ namespace SIL.FieldWorks.XWorks
 			var senseNode = mainEntryNode.Children.Where(prop => prop.Label == senseType).FirstOrDefault();
 			if (senseNode == null) return;
 			var senseOptions = (DictionaryNodeSenseOptions)senseNode.DictionaryNodeOptions;
-			cacheHc.ksSenseNumberStyle = senseOptions.NumberingStyle;
+			cacheHc.ksSenseNumberStyle = senseOptions.NonEmptyNumberingStyle;
 			//SubSense Node
 			var subSenseNode = senseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
 			if (subSenseNode == null) return;
 			var subSenseOptions = (DictionaryNodeSenseOptions)subSenseNode.DictionaryNodeOptions;
-			cacheHc.ksSubSenseNumberStyle = subSenseOptions.NumberingStyle;
+			cacheHc.ksSubSenseNumberStyle = subSenseOptions.NonEmptyNumberingStyle;
 			cacheHc.ksParentSenseNumberStyle = subSenseOptions.ParentSenseNumberingStyle;
 			//SubSubSense Node
 			var subSubSenseNode = subSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
 			if (subSubSenseNode == null) return;
 			var subSubSenseOptions = (DictionaryNodeSenseOptions)subSubSenseNode.DictionaryNodeOptions;
-			cacheHc.ksSubSubSenseNumberStyle = subSubSenseOptions.NumberingStyle;
+			cacheHc.ksSubSubSenseNumberStyle = subSubSenseOptions.NonEmptyNumberingStyle;
 			cacheHc.ksParentSubSenseNumberStyle = subSubSenseOptions.ParentSenseNumberingStyle;
 		}
 

--- a/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
+++ b/Src/xWorks/DictionaryDetailsView/SenseOptionsView.cs
@@ -66,8 +66,12 @@ namespace SIL.FieldWorks.XWorks.DictionaryDetailsView
 		{
 			get
 			{
-				// Return null if string is empty, because returning an empty string for reversal numbers
-				// also forces sense numbers not to be displayed. Null doesn't cause the same problem.
+				// Handles NumberingStyle for the dictionary/reversal configuration dialog preview display.
+				// Both empty string and null mean there is no numbering style to use.
+				// Numbering style will be null if no numbering style has ever been selected.
+				// Numbering style will be an empty string if a numbering style was selected at some point and then turned back off.
+				// Returning an empty string for reversal numbering style forces sense numbers to be turned off too, but null doesn't cause this problem.
+				// Return null if numbering style is empty.
 				var formatString = ((NumberingStyleComboItem)dropDownNumberingStyle.SelectedItem).FormatString;
 				return string.IsNullOrEmpty(formatString) ? null : formatString;
 			}

--- a/Src/xWorks/DictionaryNodeOptions.cs
+++ b/Src/xWorks/DictionaryNodeOptions.cs
@@ -56,7 +56,22 @@ namespace SIL.FieldWorks.XWorks
 
 		// Example values: ""->none; %O->1.2.3; %d->1, 2, 3
 		[XmlAttribute(AttributeName = "numberingStyle")]
-		public string NumberingStyle { get; set; }
+		private string _numberingStyle;
+
+		public string NumberingStyle
+		{
+			get
+			{
+				// Handles NumberingStyle for the dictionary and reversal displays.
+				// Both empty string and null mean there is no numbering style to use.
+				// Numbering style will be null if no numbering style has ever been selected.
+				// Numbering style will be an empty string if a numbering style was selected at some point and then turned back off.
+				// Returning an empty string for reversal numbering style forces sense numbers to be turned off too, but null doesn't cause this problem.
+				// Return null if numbering style is empty.
+				return string.IsNullOrEmpty(_numberingStyle)? null : _numberingStyle;
+			}
+			set { _numberingStyle = value; }
+		}
 
 		// Example values: ""->none; %j->Joined; %.->Separated by dot
 		[XmlAttribute(AttributeName = "parentSenseNumberingStyle")]

--- a/Src/xWorks/DictionaryNodeOptions.cs
+++ b/Src/xWorks/DictionaryNodeOptions.cs
@@ -56,21 +56,28 @@ namespace SIL.FieldWorks.XWorks
 
 		// Example values: ""->none; %O->1.2.3; %d->1, 2, 3
 		[XmlAttribute(AttributeName = "numberingStyle")]
-		private string _numberingStyle;
+		private string m_NumberingStyle;
 
-		public string NumberingStyle
+		/// <summary>
+		/// Numbering style for senses. If null or empty, no style is used.
+		///
+		/// NumberingStyle is null if no numbering style has ever been selected.
+		/// NumberingStyle is an empty string if a numbering style is selected but then removed.
+		/// </summary>
+		public string NumberingStyle { get; set; }
+
+		/// <summary>
+		/// Returns the numbering style, or null if no numbering style should be used.
+		///
+		/// <see cref="NumberingStyle"/> may contain either null or an empty string to indicate
+		/// that numbering is disabled. An empty string used for reversals' NumberingStyle also
+		/// forces sense numbers to be disabled. This property normalizes both values to null
+		/// to retain the expected behavior for senses.
+		/// </summary>
+		public string NonEmptyNumberingStyle
 		{
-			get
-			{
-				// Handles NumberingStyle for the dictionary and reversal displays.
-				// Both empty string and null mean there is no numbering style to use.
-				// Numbering style will be null if no numbering style has ever been selected.
-				// Numbering style will be an empty string if a numbering style was selected at some point and then turned back off.
-				// Returning an empty string for reversal numbering style forces sense numbers to be turned off too, but null doesn't cause this problem.
-				// Return null if numbering style is empty.
-				return string.IsNullOrEmpty(_numberingStyle)? null : _numberingStyle;
-			}
-			set { _numberingStyle = value; }
+			get => string.IsNullOrEmpty(m_NumberingStyle) ? null : m_NumberingStyle;
+			set => m_NumberingStyle = value;
 		}
 
 		// Example values: ""->none; %j->Joined; %.->Separated by dot

--- a/Src/xWorks/DictionaryNodeOptions.cs
+++ b/Src/xWorks/DictionaryNodeOptions.cs
@@ -64,7 +64,11 @@ namespace SIL.FieldWorks.XWorks
 		/// NumberingStyle is null if no numbering style has ever been selected.
 		/// NumberingStyle is an empty string if a numbering style is selected but then removed.
 		/// </summary>
-		public string NumberingStyle { get; set; }
+		public string NumberingStyle
+		{
+			get => m_NumberingStyle;
+			set => m_NumberingStyle = value;
+		}
 
 		/// <summary>
 		/// Returns the numbering style, or null if no numbering style should be used.


### PR DESCRIPTION
Previously updated the NumberingStyle get method in SenseOptionsView, so that it returns null when no numbering style is selected. This avoids an issue where sense numbering style gets treated as empty when reversal number style is an empty string.
But this only applies to the dictionary configuration dialog preview.

Updating the NumberingStyle get method in DictionaryNodeOptions to fix the issue for the dictionary and reversal displays.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/899)
<!-- Reviewable:end -->
