### PR TITLE
LT-20857: Fixed a paste problem

### DIFF
--- a/Src/views/VwSelection.cpp
+++ b/Src/views/VwSelection.cpp
@@ -5417,6 +5417,72 @@ bool CheckForParaBreak(const wchar * pchw, int ich, int cch, int * pichNext)
 	return false;
 }
 
+/// <summary>
+/// Check if the selected text (the paste target) is a complete single paragraph.
+/// </summary>
+/// <returns>
+/// True: If the selection contains exactly one complete paragraph, which means that the selection starts
+///       at the beginning of a paragraph and ends at the end of the same paragraph.
+/// False: If the selection contains text from more than one paragraph or only contains part of a paragraph.
+/// </returns>
+bool VwTextSelection::SelectedTextIsSingleParagraph()
+{
+	VwParagraphBox* notUsed;
+	int targetMin;
+	int targetLim; // One past the last selected character, relative to the last paragraph.
+	GetFirstAndLast(&notUsed, &notUsed, &targetMin, &targetLim);
+
+	if (!m_pvpboxEnd &&
+		targetMin == 0 &&
+		m_pvpbox->Source()->CStrings() == 1)
+	{
+		ITsString* firstStr = NULL;
+		m_pvpbox->Source()->StringAtIndex(0, &firstStr);
+		int firstStrLen = 0;
+		CheckHr(firstStr->get_Length(&firstStrLen));
+
+		if (targetLim == firstStrLen)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+/// <summary>
+/// Check if the replacement text is a single paragraph.
+/// </summary>
+/// <param name="replacementTstr">The replacement text.</param>
+/// <returns>
+/// True: If the replacement text contains exactly one paragraph, which means that the text ends with
+/// a '\n' and contains no other '\n' characters.
+/// False: If the replacement text contains more than one '\n' or if the '\n' is not at the end.
+/// </returns>
+bool VwTextSelection::ReplacementTextIsSingleParagraph(ITsString* replacementTstr)
+{
+	int replacementCharCount;
+	SmartBstr replacementBstr;
+	CheckHr(replacementTstr->get_Length(&replacementCharCount));
+	CheckHr(replacementTstr->get_Text(&replacementBstr));
+	const wchar* replacementText = replacementBstr.Chars();
+	for (int ii = 0; ii < replacementCharCount; ii++)
+	{
+		if (replacementText[ii] == '\n')
+		{
+			// The last character is a '\n' and there are no other '\n' characters in the string.
+			if (ii == replacementCharCount - 1)
+			{
+				return true;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+	return false;
+}
+
 /*----------------------------------------------------------------------------------------------
 	Replace what is selected with a TsString.
 	If the string contains newlines, the properties associated with the Newline become
@@ -5448,6 +5514,21 @@ STDMETHODIMP VwTextSelection::ReplaceWithTsString(ITsString * ptss)
 	ITsStringPtr qtssNorm;
 	CheckHr(ptss->get_NormalizedForm(knmNFD, &qtssNorm));
 	ptss = qtssNorm;
+
+	// If the selected text (the paste target) is a complete single paragraph, and the replacement
+	// text is a complete single paragraph (has exactly one terminal paragraph marker with no interior
+	// paragraph breaks) then trim that marker so that we do character replacement instead of paragraph
+	// replacement. Paragraph replacement fails in this case: LT-20857 (and many others).
+	if (SelectedTextIsSingleParagraph() && ReplacementTextIsSingleParagraph(ptss))
+	{
+		int replacementCharCount;
+		CheckHr(ptss->get_Length(&replacementCharCount));
+
+		// Remove the trailing '\n'.
+		ITsStringPtr trimmedReplacementText;
+		MakeSubString(ptss, 0, replacementCharCount - 1, &trimmedReplacementText);
+		ptss = trimmedReplacementText;
+	}
 
 	// default: only position changed; set to 2 if para changes
 	VwSelChangeType nHowChanged = ksctSamePara;

--- a/Src/views/VwSelection.cpp
+++ b/Src/views/VwSelection.cpp
@@ -5436,7 +5436,7 @@ bool VwTextSelection::SelectedTextIsSingleParagraph()
 		targetMin == 0 &&
 		m_pvpbox->Source()->CStrings() == 1)
 	{
-		ITsString* firstStr = NULL;
+		ITsStringPtr firstStr;
 		m_pvpbox->Source()->StringAtIndex(0, &firstStr);
 		int firstStrLen = 0;
 		CheckHr(firstStr->get_Length(&firstStrLen));

--- a/Src/views/VwSelection.cpp
+++ b/Src/views/VwSelection.cpp
@@ -5463,24 +5463,24 @@ bool VwTextSelection::ReplacementTextIsSingleParagraph(ITsString* replacementTst
 	int replacementCharCount;
 	SmartBstr replacementBstr;
 	CheckHr(replacementTstr->get_Length(&replacementCharCount));
+	if (replacementCharCount <= 0)
+		return false;
+
 	CheckHr(replacementTstr->get_Text(&replacementBstr));
 	const wchar* replacementText = replacementBstr.Chars();
-	for (int ii = 0; ii < replacementCharCount; ii++)
+
+	// A single paragraph must end with exactly one trailing '\n'.
+	if (replacementText[replacementCharCount - 1] != '\n')
+		return false;
+
+	// Ensure there are no other '\n' characters before the final one.
+	for (int ii = 0; ii < replacementCharCount - 1; ii++)
 	{
 		if (replacementText[ii] == '\n')
-		{
-			// The last character is a '\n' and there are no other '\n' characters in the string.
-			if (ii == replacementCharCount - 1)
-			{
-				return true;
-			}
-			else
-			{
-				break;
-			}
-		}
+			return false;
 	}
-	return false;
+
+	return true;
 }
 
 /*----------------------------------------------------------------------------------------------

--- a/Src/views/VwSelection.h
+++ b/Src/views/VwSelection.h
@@ -541,6 +541,8 @@ public:
 		IVwViewConstructor * pvvcEdit, int fragEdit, ITsStrBldr * ptsb, bool * pfOk);
 	virtual bool RuinedByDeleting(VwBox * pbox, VwBox * pboxReplacement=0);
 	void MakeSubString(ITsString * ptss, int ichMin, int ichLim, ITsString ** pptssSub);
+	bool SelectedTextIsSingleParagraph();
+	bool ReplacementTextIsSingleParagraph(ITsString* ptss);
 
 	void SetInsertionProps(ITsTextProps * pttp)
 	{


### PR DESCRIPTION
Fixed the paste problem when the selection is a single paragraph. In the code a paragraph is indicated by a ‘\n’.

Note: This fix is specific to a single paragraph selection. It does not add support for other complex selections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/900)
<!-- Reviewable:end -->
