### PR TITLE
LT-22525: Handle missing POS in msa and empty form hvo

### DIFF
--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ANABuilder.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ANABuilder.cs
@@ -208,7 +208,7 @@ namespace SIL.ToneParsFLEx
 				case MoStemMsaTags.kClassId:
 					var stemMsa = msa as IMoStemMsa;
 					sb.Append("RootPOS");
-					sb.Append(stemMsa.PartOfSpeechRA.Hvo);
+					sb.Append((stemMsa.PartOfSpeechRA != null) ? stemMsa.PartOfSpeechRA.Hvo : 0);
 					break;
 				case MoInflAffMsaTags.kClassId:
 					break;

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
@@ -826,7 +826,7 @@ namespace SIL.ToneParsFLEx
 			//       The LexEntry is a variant form and the (non-zero) index indicates
 			//       which set of LexEntryRefs it is for.
 			ICmObject objForm;
-			if (
+			if (String.IsNullOrEmpty(formHvo) ||
 				!cache.ServiceLocator
 					.GetInstance<ICmObjectRepository>()
 					.TryGetObject(int.Parse(formHvo), out objForm)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22525 (Crash occurs when clicking the “Parse this text” button while using the “Use TonePars with FLEx” utility).

There were two problems:

1. A stem MSA with a missing part of speech caused the crash reported in the issue.
2. After fixing that (by using an hvo of 0), processing the result could end up with an empty value for the form.

Both of these are fixed here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/903)
<!-- Reviewable:end -->
