### PR TITLE
Reduce optional COM usage

### DIFF
--- a/Build/RegFree.targets
+++ b/Build/RegFree.targets
@@ -66,7 +66,7 @@
 		<!-- Explicitly list managed assemblies that expose COM types -->
 		<ManagedComAssemblies Include="$(OutDir)FwUtils.dll" />
 		<ManagedComAssemblies Include="$(OutDir)SimpleRootSite.dll" />
-		<ManagedComAssemblies Include="$(OutDir)ManagedLgIcuCollator.dll" />
+		<ManagedComAssemblies Include="$(OutDir)ManagedVwWindow.dll" />
 	</ItemGroup>
 	<ItemGroup>
 		<ManagedComAssemblies Remove="$(OutDir)*.resources.dll" />

--- a/Build/Src/FwBuildTasks/FwBuildTasksTests/RegFreeCreatorTests.cs
+++ b/Build/Src/FwBuildTasks/FwBuildTasksTests/RegFreeCreatorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 SIL International
+﻿// Copyright (c) 2025 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -21,6 +21,7 @@ namespace SIL.FieldWorks.Build.Tasks.FwBuildTasksTests
 	public sealed class RegFreeCreatorTests
 	{
 		private const string AsmNamespace = "urn:schemas-microsoft-com:asm.v1";
+		private const string RemovedManagedLgIcuCollatorClsid = "{e771361c-ff54-4120-9525-98a0b7a9accf}";
 
 		[Test]
 		public void ProcessManagedAssembly_PlacesClrClassAsChildOfAssembly()
@@ -65,6 +66,76 @@ namespace SIL.FieldWorks.Build.Tasks.FwBuildTasksTests
 			}
 		}
 
+		[Test]
+		public void ProcessManagedAssembly_TargetComVisibleFalseClass_DoesNotEmitClrClass()
+		{
+			var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+			Directory.CreateDirectory(tempDir);
+			var assemblyPath = Path.Combine(tempDir, "SampleComVisibleFalseClass.dll");
+
+			try
+			{
+				const string source = @"using System.Runtime.InteropServices;
+[assembly: ComVisible(true)]
+[assembly: Guid(""3D757DD4-8985-4CA6-B2C4-FA2B950C9F6D"")]
+namespace RegFreeCreatorTestAssembly
+{
+	[ComVisible(false)]
+	[Guid(""e771361c-ff54-4120-9525-98a0b7a9accf"")]
+	public class SampleComVisibleFalseClass
+	{
+	}
+}";
+				CompileAssembly(assemblyPath, source);
+
+				var doc = new XmlDocument();
+				var root = doc.CreateElement("assembly", AsmNamespace);
+				doc.AppendChild(root);
+				var logger = new TaskLoggingHelper(new TestBuildEngine(), nameof(RegFreeCreatorTests));
+				var creator = new RegFreeCreator(doc, logger);
+
+				var foundClrClass = creator.ProcessManagedAssembly(root, assemblyPath);
+				Assert.That(foundClrClass, Is.False, "Assembly with only ComVisible(false) class should not produce clrClass entries.");
+
+				var ns = new XmlNamespaceManager(doc.NameTable);
+				ns.AddNamespace("asmv1", AsmNamespace);
+				var clrClassUnderAssembly = root.SelectSingleNode("asmv1:clrClass", ns);
+				Assert.That(clrClassUnderAssembly, Is.Null, "clrClass must NOT be produced for ComVisible(false) class.");
+				var removedClrClass = root.SelectSingleNode("asmv1:clrClass[@clsid='" + RemovedManagedLgIcuCollatorClsid + "']", ns);
+				Assert.That(removedClrClass, Is.Null, "Removed ManagedLgIcuCollator CLSID must not appear in generated clrClass entries.");
+				Assert.That(root.OuterXml, Does.Not.Contain(RemovedManagedLgIcuCollatorClsid));
+			}
+			finally
+			{
+				if (Directory.Exists(tempDir))
+				{
+					Directory.Delete(tempDir, true);
+				}
+			}
+		}
+
+		[Test]
+		public void AddExcludedClsids_NormalizesClsidValues()
+		{
+			var doc = new XmlDocument();
+			var root = doc.CreateElement("assembly", AsmNamespace);
+			doc.AppendChild(root);
+			var logger = new TaskLoggingHelper(new TestBuildEngine(), nameof(RegFreeCreatorTests));
+			var creator = new RegFreeCreator(doc, logger);
+
+			creator.AddExcludedClsids(new[] { "e771361c-ff54-4120-9525-98a0b7a9accf", "{3fb0fcd2-ac55-42a8-b580-73b89a2b6215}" });
+
+			// Use reflection to verify the private field _excludedClsids was populated and normalized
+			var field = typeof(RegFreeCreator).GetField("_excludedClsids", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+			Assert.That(field, Is.Not.Null, "Should find the private _excludedClsids field.");
+
+			var excludedHashSet = (System.Collections.Generic.HashSet<string>)field.GetValue(creator);
+			Assert.That(excludedHashSet, Is.Not.Null);
+			Assert.That(excludedHashSet.Count, Is.EqualTo(2));
+			Assert.That(excludedHashSet.Contains(RemovedManagedLgIcuCollatorClsid), Is.True, "Should normalize Clsid without braces.");
+			Assert.That(excludedHashSet.Contains("{3fb0fcd2-ac55-42a8-b580-73b89a2b6215}"), Is.True, "Should preserve Clsid with braces.");
+		}
+
 		private static void CompileComVisibleAssembly(string outputPath)
 		{
 			const string source = @"using System.Runtime.InteropServices;
@@ -79,7 +150,11 @@ namespace RegFreeCreatorTestAssembly
 	{
 	}
 }";
+			CompileAssembly(outputPath, source);
+		}
 
+		private static void CompileAssembly(string outputPath, string source)
+		{
 			var provider = new CSharpCodeProvider();
 			var parameters = new CompilerParameters
 			{
@@ -94,7 +169,7 @@ namespace RegFreeCreatorTestAssembly
 			if (results.Errors.HasErrors)
 			{
 				var message = string.Join(Environment.NewLine, results.Errors.Cast<CompilerError>().Select(e => e.ToString()));
-				throw new InvalidOperationException($"Failed to compile COM-visible test assembly:{Environment.NewLine}{message}");
+				throw new InvalidOperationException($"Failed to compile test assembly:{Environment.NewLine}{message}");
 			}
 		}
 	}

--- a/Build/mkall.targets
+++ b/Build/mkall.targets
@@ -43,7 +43,8 @@
 		<!-- CLSIDs implemented in managed code that must be excluded from native manifests to avoid SxS duplicates -->
 		<ExcludedClsids Include="{17a2e876-2968-11e0-8046-0019dbf4566e}" /> <!-- ManagedPictureFactory -->
 		<ExcludedClsids Include="{97199458-10C7-49da-B3AE-EA922EA64859}" /> <!-- VwDrawRootBuffered -->
-		<ExcludedClsids Include="{e771361c-ff54-4120-9525-98a0b7a9accf}" /> <!-- ManagedLgIcuCollator -->
+		<ExcludedClsids Include="{3fb0fcd2-ac55-42a8-b580-73b89a2b6215}" /> <!-- ManagedVwWindow -->
+		<ExcludedClsids Include="{830BAF1F-6F84-46EF-B63E-3C1BFDF9E83E}" /> <!-- ViewInputManager -->
 	</ItemGroup>
 	<PropertyGroup>
 		<NativeMakeOutDir></NativeMakeOutDir>

--- a/Src/Common/FieldWorks/BuildInclude.targets
+++ b/Src/Common/FieldWorks/BuildInclude.targets
@@ -7,7 +7,7 @@
 		<!-- Ensure reg-free manifest includes the core managed COM servers used by FieldWorks.exe -->
 		<ManagedComAssemblies Include="$(OutDir)FwUtils.dll" />
 		<ManagedComAssemblies Include="$(OutDir)SimpleRootSite.dll" />
-		<ManagedComAssemblies Include="$(OutDir)ManagedLgIcuCollator.dll" />
+		<ManagedComAssemblies Include="$(OutDir)ManagedVwWindow.dll" />
 		<ManagedComAssemblies Include="$(OutDir)xWorks.dll" />
 		<ManagedComAssemblies Include="$(OutDir)LexTextDll.dll" />
 	</ItemGroup>

--- a/Src/Common/FwUtils/Win32Wrappers.cs
+++ b/Src/Common/FwUtils/Win32Wrappers.cs
@@ -2854,22 +2854,6 @@ namespace SIL.FieldWorks.Common.FwUtils
 #endregion
 
 #region Ole32.dll
-		/// <summary>
-		/// Carries out the clipboard shutdown sequence. It also releases the <c>IDataObject</c>
-		/// pointer that was previously placed on the clipboard.
-		/// </summary>
-		/// <returns><c>true</c> if the clipboard has been flushed.</returns>
-		[DllImport("ole32.dll")]
-		public static extern int OleFlushClipboard();
-
-		/// <summary>
-		/// Determines whether the data object pointer previously placed on the clipboard is
-		/// still on the clipboard.
-		/// </summary>
-		/// <param name="pDataObject">[in] Pointer to the data object previously copied or cut.</param>
-		/// <returns><c>true</c> if object still on the clipboard.</returns>
-		[DllImport("ole32.dll")]
-		public static extern bool OleIsCurrentClipboard([MarshalAs(UnmanagedType.IUnknown)]object pDataObject);
 #endregion
 
 #region Shell32.dll

--- a/Src/Generic/ModuleEntry.cpp
+++ b/Src/Generic/ModuleEntry.cpp
@@ -57,7 +57,6 @@ bool ModuleEntry::s_fPerUserRegistration = false;
 #endif // WIN32
 
 #ifdef EXE_MODULE
-IDataObjectPtr ModuleEntry::s_qdobjClipboard;	// data stored in clipboard by this app.
 bool ModuleEntry::s_fIsExe = true;
 
 #else // EXE_MODULE
@@ -83,11 +82,6 @@ ModuleEntry::~ModuleEntry()
 /***********************************************************************************************
 	The code in this section only gets included for EXE servers.
 /**********************************************************************************************/
-
-void ModuleEntry::SetClipboard(IDataObject * pdobjClipboard)
-{
-	s_qdobjClipboard = pdobjClipboard;
-}
 
 /*----------------------------------------------------------------------------------------------
 	For an exe, we post a WM_QUIT message to the main thread when the module reference
@@ -154,7 +148,6 @@ bool ModuleEntry::Startup(HINSTANCE hinst, LPSTR pszCmdLine)
 
 	// Initialize COM
 	HRESULT hr = OleInitialize(NULL);
-	s_qdobjClipboard.Clear();
 
 	if (FAILED(hr))
 	{
@@ -230,17 +223,6 @@ void ModuleEntry::ShutDown()
 		}
 	}
 
-	// Uninitialize COM, first shutting down the clipboard.
-	if (s_qdobjClipboard.Ptr())
-	{
-		hr = OleIsCurrentClipboard(s_qdobjClipboard.Ptr());
-		WarnHr(hr);
-		if (hr == S_OK)
-		{
-			WarnHr(OleFlushClipboard());
-		}
-		s_qdobjClipboard.Clear();
-	}
 	OleUninitialize();
 }
 
@@ -266,7 +248,6 @@ int ModuleEntry::WinMain(HINSTANCE hinst, HINSTANCE hinstPrev, LPSTR pszCmdLine,
 
 	// Initialize COM
 	HRESULT hr = OleInitialize(NULL);
-	s_qdobjClipboard.Clear();
 
 	if (FAILED(hr))
 	{
@@ -324,17 +305,6 @@ int ModuleEntry::WinMain(HINSTANCE hinst, HINSTANCE hinstPrev, LPSTR pszCmdLine,
 		WarnHr(hr);
 	}
 
-	// Uninitialize COM, first shutting down the clipboard.
-	if (s_qdobjClipboard.Ptr())
-	{
-		hr = OleIsCurrentClipboard(s_qdobjClipboard.Ptr());
-		WarnHr(hr);
-		if (hr == S_OK)
-		{
-			WarnHr(OleFlushClipboard());
-		}
-		s_qdobjClipboard.Clear();
-	}
 	OleUninitialize();
 
 	return nRet;
@@ -346,13 +316,6 @@ int ModuleEntry::WinMain(HINSTANCE hinst, HINSTANCE hinstPrev, LPSTR pszCmdLine,
 /***********************************************************************************************
 	The code in this section only gets included for DLLs.
 /**********************************************************************************************/
-
-/*----------------------------------------------------------------------------------------------
-	For a DLL, we don't have a global place to record this, so ignore it.
-----------------------------------------------------------------------------------------------*/
-void ModuleEntry::SetClipboard(IDataObject * pdobjClipboard)
-{
-}
 
 /*----------------------------------------------------------------------------------------------
 	For a DLL, we just decrement the count. (But DON'T put this inline in the header! It

--- a/Src/Generic/ModuleEntry.h
+++ b/Src/Generic/ModuleEntry.h
@@ -166,8 +166,6 @@ public:
 	}
 
 #ifdef EXE_MODULE
-	// Data placed on the clipboard by this program.
-	static IDataObjectPtr s_qdobjClipboard;
 #ifdef USING_MFC
 
 	static bool Startup(HINSTANCE hinst, LPSTR pszCmdLine);
@@ -203,8 +201,6 @@ public:
 	static HMODULE GetModuleHandle(void)
 		{ return s_hmod; }
 	static LPCTSTR GetModulePathName(void);
-
-	static void SetClipboard(IDataObject * pdobjClipboard);
 
 	// These methods increment and decrement the reference count for the module. A module
 	// will not be unloaded from memory as long as something is still referencing it.

--- a/Src/ManagedLgIcuCollator/LgIcuCollator.cs
+++ b/Src/ManagedLgIcuCollator/LgIcuCollator.cs
@@ -17,9 +17,7 @@ namespace SIL.FieldWorks.Language
 	/// Direct port of the C++ class LgIcuCollator
 	/// </summary>
 	[Serializable]
-	[ComVisible(true)]
-	[ClassInterface(ClassInterfaceType.None)]
-	[Guid("e771361c-ff54-4120-9525-98a0b7a9accf")]
+	[ComVisible(false)]
 	public class ManagedLgIcuCollator : ILgCollatingEngine, IDisposable
 	{
 		#region Member variables


### PR DESCRIPTION
## Scope

This PR reduces optional COM usage and centralizes Encoding Converters access without changing the required FieldWorks native COM boundaries.

Included in this PR:
- Remove `ManagedLgIcuCollator` COM visibility and its class-specific reg-free manifest/build plumbing.
- Remove dormant native OLE clipboard ownership cleanup and unused managed OLE clipboard P/Invokes while leaving managed clipboard and TSF `IDataObject` behavior unchanged.
- Isolate debug-only `DebugProcs` COM activation behind an injectable transport seam; COM remains the debug fallback rather than leaking through general managed code.
- Add `IEncodingConvertersProvider` / `EncodingConvertersProvider` and migrate product-level direct `new EncConverters()` construction behind that FieldWorks-owned provider.
- Add/update focused tests and OpenSpec docs for the COM-reduction plan.

Explicitly out of scope:
- No RootBox, Views/FwKernel, Graphite, TSF, MSAA, `IPicture`, `IStream`, or `UnknownProp` ABI rewrite.
- No global COM registration or registry workaround.
- No replacement of the `encoding-converters-core` runtime; this PR creates the provider boundary only.
- No removal of Linux-era `ViewInputManager` / `ManagedVwWindow` shims; that work was split to branch `retire-linux-era-view-shims`.

## Validation

- `./build.ps1`
- `./build.ps1 -BuildTests` / broader managed validation during implementation
- `./test.ps1 -TestProject ManagedLgIcuCollatorTests`
- `./test.ps1 -TestProject FiltersTests`
- `./test.ps1 -TestProject LexEdDllTests`
- `./test.ps1 -TestProject FwBuildTasksTests -TestFilter "FullyQualifiedName~RegFreeCreator"`
- `./test.ps1 -TestProject SimpleRootSiteTests -TestFilter "FullyQualifiedName~EditingHelperTests"`
- `./test.ps1 -SkipManaged -TestProject TestGeneric`
- `./test.ps1 -TestProject FwUtilsTests -TestFilter "FullyQualifiedName~DebugProcs"`
- `./test.ps1 -TestProject ParatextImportTests`
- `./test.ps1 -TestProject FwCoreDlgsTests`
- `./test.ps1 -TestProject Sfm2XmlTests`
- `./test.ps1 -TestProject LexTextControlsTests`
- `./test.ps1 -TestProject XMLViewsTests`
- `./test.ps1 -TestProject ITextDllTests`
- VS Code task `CI: Whitespace check`
- VS Code task `CI: Commit messages`

## Follow-up / Merge Notes

- Branch now has one commit on top of `origin/main`: `61579e344 Reduce optional COM usage`.
- Linux-era Views shim retirement is intentionally separate in branch `retire-linux-era-view-shims`.
- Manual clipboard smoke and external CLSID compatibility sign-off should be confirmed before merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/904)
<!-- Reviewable:end -->