### PR TITLE
LT-21752: Add Send/Receive data option to backup/restore

### DIFF
--- a/Build/Manage-LocalLibraries.ps1
+++ b/Build/Manage-LocalLibraries.ps1
@@ -60,7 +60,7 @@
 
 .PARAMETER Library
 	Which library to set a version for (SetVersion mode only):
-	liblcm, libpalaso, chorus, machine, or l10nsharp.
+	lcm, palaso, chorus, machine, or l10nsharp.
 
 .PARAMETER Version
 	Sets the version in SilVersions.props (SetVersion mode). Use to revert
@@ -75,7 +75,7 @@
 	Packs libpalaso (from env var) and then chorus from the given path.
 
 .EXAMPLE
-	.\Build\Manage-LocalLibraries.ps1 -Library libpalaso -Version 17.0.0
+	.\Build\Manage-LocalLibraries.ps1 -Library palaso -Version 17.0.0
 	Sets libpalaso version to 17.0.0 in SilVersions.props (e.g. to revert).
 #>
 [CmdletBinding()]
@@ -95,7 +95,7 @@ param(
 	[switch]$L10nSharp,
 	[string]$L10nSharpPath,
 
-	[ValidateSet('liblcm', 'libpalaso', 'chorus', 'machine', 'l10nsharp')]
+	[ValidateSet('palaso', 'lcm', 'chorus', 'machine', 'l10nsharp')]
 	[string]$Library,
 
 	[string]$Version
@@ -108,7 +108,7 @@ $ErrorActionPreference = "Stop"
 # ---------------------------------------------------------------------------
 
 $LibraryConfig = @{
-	libpalaso = @{
+	palaso = @{
 		VersionProperty = 'SilLibPalasoVersion'
 		PdbRelativeDir  = 'output/Debug/net462'
 		CachePrefixes   = @(
@@ -118,7 +118,7 @@ $LibraryConfig = @{
 		)
 		EnvVar          = 'LIBPALASO_PATH'
 	}
-	liblcm = @{
+	lcm = @{
 		VersionProperty = 'SilLcmVersion'
 		PdbRelativeDir  = 'artifacts/Debug/net462'
 		CachePrefixes   = @('sil.lcmodel')
@@ -150,7 +150,7 @@ $LibraryConfig = @{
 }
 
 # Pack order: libpalaso first (other libraries may depend on it)
-$PackOrder = @('libpalaso', 'l10nsharp', 'liblcm', 'chorus', 'machine')
+$PackOrder = @('palaso', 'l10nsharp', 'lcm', 'chorus', 'machine')
 
 # ---------------------------------------------------------------------------
 # Read SilVersions.props
@@ -188,7 +188,21 @@ function Update-VersionAndClearCache {
 	$cfg = $LibraryConfig[$LibName]
 	$node = Get-VersionNode $LibName
 	$node.InnerText = $NewVersion
-	$versionProps.Save($versionPropsPath)
+
+	# Save with XmlWriter to preserve tab indentation (XmlDocument.Save() converts tabs to spaces)
+	$writerSettings = New-Object System.Xml.XmlWriterSettings
+	$writerSettings.Indent = $true
+	$writerSettings.IndentChars = "`t"
+	$writerSettings.NewLineChars = "`r`n"
+	$writerSettings.Encoding = New-Object System.Text.UTF8Encoding($false) # UTF-8 without BOM
+	$writerSettings.OmitXmlDeclaration = -not $versionProps.FirstChild.NodeType.Equals([System.Xml.XmlNodeType]::XmlDeclaration)
+	$writer = [System.Xml.XmlWriter]::Create($versionPropsPath, $writerSettings)
+	try {
+		$versionProps.WriteTo($writer)
+	} finally {
+		$writer.Close()
+	}
+
 	Write-Host "Updated SilVersions.props ($($cfg.VersionProperty) = $NewVersion)" -ForegroundColor Yellow
 
 	$packagesDir = Join-Path $repoRoot "packages"
@@ -345,8 +359,8 @@ function Invoke-PackLibrary {
 
 # Map switches and explicit paths to library names
 $switchMap = @{
-	libpalaso = @{ Enabled = [bool]$Palaso;  ExplicitPath = $PalasoPath }
-	liblcm    = @{ Enabled = [bool]$Lcm;     ExplicitPath = $LcmPath }
+	palaso = @{ Enabled = [bool]$Palaso;  ExplicitPath = $PalasoPath }
+	lcm    = @{ Enabled = [bool]$Lcm;     ExplicitPath = $LcmPath }
 	chorus    = @{ Enabled = [bool]$Chorus;   ExplicitPath = $ChorusPath }
 	machine   = @{ Enabled = [bool]$Machine;  ExplicitPath = $MachinePath }
 	l10nsharp = @{ Enabled = [bool]$L10nSharp; ExplicitPath = $L10nSharpPath }
@@ -436,5 +450,5 @@ elseif ($Library -and $Version) {
 	Write-Host "Run .\build.ps1 to restore and build with the new version." -ForegroundColor Cyan
 }
 else {
-	throw "Nothing to do. Use -Palaso/-Lcm/-Chorus/-Machine/-L10nSharp switches to pack, or -Library and -Version to set a version.`nExamples:`n  .\Build\Manage-LocalLibraries.ps1 -Palaso -PalasoPath C:\Repos\libpalaso`n  .\Build\Manage-LocalLibraries.ps1 -Palaso -Chorus`n  .\Build\Manage-LocalLibraries.ps1 -Machine -MachinePath C:\Repos\machine`n  .\Build\Manage-LocalLibraries.ps1 -Library l10nsharp -Version 10.0.0`n  .\Build\Manage-LocalLibraries.ps1 -Library libpalaso -Version 17.0.0"
+	throw "Nothing to do. Use -Palaso/-Lcm/-Chorus/-Machine/-L10nSharp switches to pack, or -Library and -Version to set a version.`nExamples:`n  .\Build\Manage-LocalLibraries.ps1 -Palaso -PalasoPath C:\Repos\libpalaso`n  .\Build\Manage-LocalLibraries.ps1 -Palaso -Chorus`n  .\Build\Manage-LocalLibraries.ps1 -Machine -MachinePath C:\Repos\machine`n  .\Build\Manage-LocalLibraries.ps1 -Library l10nsharp -Version 10.0.0`n  .\Build\Manage-LocalLibraries.ps1 -Library palaso -Version 17.0.0"
 }

--- a/Build/SilVersions.props
+++ b/Build/SilVersions.props
@@ -1,5 +1,5 @@
 <Project>
-  <!--
+	<!--
 		=============================================================
 		SIL ECOSYSTEM VERSION PROPERTIES
 		Single source of truth for all SIL dependency versions.
@@ -12,7 +12,7 @@
 		=============================================================
 	-->
 	<PropertyGroup Label="SIL Ecosystem Versions">
-		<SilLcmVersion>11.0.0-beta0161</SilLcmVersion>
+		<SilLcmVersion>11.0.0-beta0166</SilLcmVersion>
 		<SilLibPalasoVersion>18.0.0-beta0013</SilLibPalasoVersion>
 		<SilLibPalasoL10nsVersion>18.0.0-beta0012</SilLibPalasoL10nsVersion>
 		<SilChorusVersion>6.0.0-beta0065</SilChorusVersion>

--- a/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.Designer.cs
+++ b/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.Designer.cs
@@ -36,6 +36,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			this.components = new System.ComponentModel.Container();
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BackupProjectDlg));
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.m_sendReceiveData = new System.Windows.Forms.CheckBox();
 			this.m_spellCheckAdditions = new System.Windows.Forms.CheckBox();
 			this.m_supportingFiles = new System.Windows.Forms.CheckBox();
 			this.m_linkedFiles = new System.Windows.Forms.CheckBox();
@@ -55,6 +56,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			//
 			// groupBox1
 			//
+			this.groupBox1.Controls.Add(this.m_sendReceiveData);
 			this.groupBox1.Controls.Add(this.m_spellCheckAdditions);
 			this.groupBox1.Controls.Add(this.m_supportingFiles);
 			this.groupBox1.Controls.Add(this.m_linkedFiles);
@@ -70,6 +72,13 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			this.m_spellCheckAdditions.Name = "m_spellCheckAdditions";
 			this.helpProvider.SetShowHelp(this.m_spellCheckAdditions, ((bool)(resources.GetObject("m_spellCheckAdditions.ShowHelp"))));
 			this.m_spellCheckAdditions.UseVisualStyleBackColor = true;
+			//
+			// m_sendReceiveData
+			//
+			resources.ApplyResources(this.m_sendReceiveData, "m_sendReceiveData");
+			this.m_sendReceiveData.ForeColor = System.Drawing.SystemColors.ControlText;
+			this.m_sendReceiveData.Name = "m_sendReceiveData";
+			this.m_sendReceiveData.UseVisualStyleBackColor = true;
 			//
 			// m_supportingFiles
 			//
@@ -187,5 +196,6 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 		private System.Windows.Forms.ToolTip toolTip;
 		private System.Windows.Forms.HelpProvider helpProvider;
 		private System.Windows.Forms.CheckBox m_spellCheckAdditions;
+		private System.Windows.Forms.CheckBox m_sendReceiveData;
 	}
 }

--- a/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.cs
+++ b/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.cs
@@ -62,6 +62,15 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 				m_supportingFiles.Enabled = false;
 			}
 
+			if (m_presenter.SendReceiveDataExists)
+			{
+				m_sendReceiveData.Checked = true;
+			}
+			else
+			{
+				m_sendReceiveData.Enabled = false;
+			}
+
 			DestinationFolder = FwDirectoryFinder.DefaultBackupDirectory;
 			if (File.Exists(m_presenter.PersistanceFilePath))
 			{
@@ -238,6 +247,15 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 		{
 			get { return m_spellCheckAdditions.Checked; }
 			set { m_spellCheckAdditions.Checked = value; }
+		}
+
+		///<summary>
+		/// Whether or not user wants Send/Receive repository data in the backup.
+		///</summary>
+		public bool IncludeSendReceiveData
+		{
+			get { return m_sendReceiveData.Checked; }
+			set { m_sendReceiveData.Checked = value; }
 		}
 
 		/// <summary>

--- a/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.resx
+++ b/Src/FwCoreDlgs/BackupRestore/BackupProjectDlg.resx
@@ -154,6 +154,33 @@
 	<value>groupBox1</value>
   </data>
   <data name="&gt;&gt;m_spellCheckAdditions.ZOrder" xml:space="preserve">
+	<value>1</value>
+  </data>
+  <data name="m_sendReceiveData.AutoSize" type="System.Boolean, mscorlib">
+	<value>True</value>
+  </data>
+  <data name="m_sendReceiveData.Location" type="System.Drawing.Point, System.Drawing">
+	<value>15, 113</value>
+  </data>
+  <data name="m_sendReceiveData.Size" type="System.Drawing.Size, System.Drawing">
+	<value>200, 17</value>
+  </data>
+  <data name="m_sendReceiveData.TabIndex" type="System.Int32, mscorlib">
+	<value>5</value>
+  </data>
+  <data name="m_sendReceiveData.Text" xml:space="preserve">
+	<value>Send/Receive data (repository history)</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Name" xml:space="preserve">
+	<value>m_sendReceiveData</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Type" xml:space="preserve">
+	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Parent" xml:space="preserve">
+	<value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.ZOrder" xml:space="preserve">
 	<value>0</value>
   </data>
   <data name="m_supportingFiles.AutoSize" type="System.Boolean, mscorlib">
@@ -241,7 +268,7 @@
 	<value>12, 12</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-	<value>555, 148</value>
+	<value>555, 171</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
 	<value>1</value>
@@ -265,7 +292,7 @@
 	<value>True</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-	<value>9, 174</value>
+	<value>9, 197</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
 	<value>54, 13</value>
@@ -289,7 +316,7 @@
 	<value>7</value>
   </data>
   <data name="m_comment.Location" type="System.Drawing.Point, System.Drawing">
-	<value>12, 194</value>
+	<value>12, 217</value>
   </data>
   <data name="m_comment.Size" type="System.Drawing.Size, System.Drawing">
 	<value>555, 20</value>
@@ -313,7 +340,7 @@
 	<value>True</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-	<value>12, 229</value>
+	<value>12, 252</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
 	<value>46, 13</value>
@@ -337,7 +364,7 @@
 	<value>5</value>
   </data>
   <data name="m_destinationFolder.Location" type="System.Drawing.Point, System.Drawing">
-	<value>12, 251</value>
+	<value>12, 274</value>
   </data>
   <data name="m_destinationFolder.Size" type="System.Drawing.Size, System.Drawing">
 	<value>476, 20</value>
@@ -358,7 +385,7 @@
 	<value>4</value>
   </data>
   <data name="m_browse.Location" type="System.Drawing.Point, System.Drawing">
-	<value>494, 248</value>
+	<value>494, 271</value>
   </data>
   <data name="m_browse.Size" type="System.Drawing.Size, System.Drawing">
 	<value>73, 23</value>
@@ -385,7 +412,7 @@
 	<value>Bottom, Right</value>
   </data>
   <data name="m_backUp.Location" type="System.Drawing.Point, System.Drawing">
-	<value>328, 290</value>
+	<value>328, 313</value>
   </data>
   <data name="m_backUp.Size" type="System.Drawing.Size, System.Drawing">
 	<value>75, 23</value>
@@ -412,7 +439,7 @@
 	<value>Bottom, Right</value>
   </data>
   <data name="m_cancel.Location" type="System.Drawing.Point, System.Drawing">
-	<value>409, 290</value>
+	<value>409, 313</value>
   </data>
   <data name="m_cancel.Size" type="System.Drawing.Size, System.Drawing">
 	<value>75, 23</value>
@@ -439,7 +466,7 @@
 	<value>Bottom, Right</value>
   </data>
   <data name="m_help.Location" type="System.Drawing.Point, System.Drawing">
-	<value>491, 290</value>
+	<value>491, 313</value>
   </data>
   <data name="m_help.Size" type="System.Drawing.Size, System.Drawing">
 	<value>75, 23</value>
@@ -475,7 +502,7 @@
 	<value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-	<value>581, 326</value>
+	<value>581, 349</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
 	<value>Back up this Project</value>

--- a/Src/FwCoreDlgs/BackupRestore/BackupProjectPresenter.cs
+++ b/Src/FwCoreDlgs/BackupRestore/BackupProjectPresenter.cs
@@ -53,6 +53,21 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 		}
 
 		///<summary>
+		/// Returns true if the project has Send/Receive repository data (.hg or OtherRepositories).
+		///</summary>
+		internal bool SendReceiveDataExists
+		{
+			get
+			{
+				var projectFolder = m_cache.ProjectId.ProjectFolder;
+				return Directory.Exists(Path.Combine(projectFolder, ".hg")) ||
+					(Directory.Exists(LcmFileHelper.GetOtherRepositoriesDir(projectFolder)) &&
+					Directory.EnumerateDirectories(LcmFileHelper.GetOtherRepositoriesDir(projectFolder))
+						.Any(dir => Directory.Exists(Path.Combine(dir, ".hg"))));
+			}
+		}
+
+		///<summary>
 		/// If the SupportingFiles folder contains any files return true. Otherwise resturn false.
 		///</summary>
 		internal bool SupportingFilesFolderContainsFiles

--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.Designer.cs
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.Designer.cs
@@ -63,6 +63,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			this.m_linkedFiles = new CheckBox();
 			this.m_supportingFiles = new CheckBox();
 			this.m_gbAlsoRestore = new GroupBox();
+			this.m_sendReceiveData = new CheckBox();
 			this.m_spellCheckAdditions = new CheckBox();
 			this.m_btnOk = new Button();
 			this.m_lblOtherBackupIncludes = new Label();
@@ -178,12 +179,19 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			// m_gbAlsoRestore
 			//
 			resources.ApplyResources(this.m_gbAlsoRestore, "m_gbAlsoRestore");
+			this.m_gbAlsoRestore.Controls.Add(this.m_sendReceiveData);
 			this.m_gbAlsoRestore.Controls.Add(this.m_spellCheckAdditions);
 			this.m_gbAlsoRestore.Controls.Add(this.m_supportingFiles);
 			this.m_gbAlsoRestore.Controls.Add(this.m_linkedFiles);
 			this.m_gbAlsoRestore.Controls.Add(this.m_configurationSettings);
 			this.m_gbAlsoRestore.Name = "m_gbAlsoRestore";
 			this.m_gbAlsoRestore.TabStop = false;
+			//
+			// m_sendReceiveData
+			//
+			resources.ApplyResources(this.m_sendReceiveData, "m_sendReceiveData");
+			this.m_sendReceiveData.Name = "m_sendReceiveData";
+			this.m_sendReceiveData.UseVisualStyleBackColor = true;
 			//
 			// m_spellCheckAdditions
 			//
@@ -397,6 +405,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 		private Label m_lblOtherBackupIncludes;
 		private GroupBox m_gbBackupProperties;
 		private CheckBox m_spellCheckAdditions;
+		private CheckBox m_sendReceiveData;
 		private GroupBox m_gbRestoreAs;
 		private RadioButton m_rdoUseOriginalName;
 		private RadioButton m_rdoRestoreToName;

--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
@@ -222,6 +222,15 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			set { m_spellCheckAdditions.Checked = value; }
 		}
 
+		///<summary>
+		/// Whether or not user wants Send/Receive repository data restored.
+		///</summary>
+		public bool SendReceiveData
+		{
+			get { return m_sendReceiveData.Checked; }
+			set { m_sendReceiveData.Checked = value; }
+		}
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Sets the backup file settings and updates the dialog controls accordingly
@@ -363,6 +372,8 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			m_supportingFiles.Enabled = settings.IncludeSupportingFiles;
 			m_spellCheckAdditions.Checked = settings.IncludeSpellCheckAdditions;
 			m_spellCheckAdditions.Enabled = settings.IncludeSpellCheckAdditions;
+			m_sendReceiveData.Checked = settings.IncludeSendReceiveData;
+			m_sendReceiveData.Enabled = false;
 			if (m_rdoDefaultFolder.Checked)
 				m_lblDefaultBackupIncludes.Text = m_presenter.IncludesFiles(settings);
 			else
@@ -591,6 +602,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			m_settings.IncludeLinkedFiles = LinkedFiles;
 			m_settings.IncludeSupportingFiles = SupportingFiles;
 			m_settings.IncludeSpellCheckAdditions = SpellCheckAdditions;
+			m_settings.IncludeSendReceiveData = SendReceiveData;
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.resx
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.resx
@@ -550,6 +550,36 @@
 	<value>m_gbAlsoRestore</value>
   </data>
   <data name="&gt;&gt;m_spellCheckAdditions.ZOrder" xml:space="preserve">
+	<value>1</value>
+  </data>
+  <data name="m_sendReceiveData.AutoSize" type="System.Boolean, mscorlib">
+	<value>True</value>
+  </data>
+  <data name="m_sendReceiveData.Enabled" type="System.Boolean, mscorlib">
+	<value>False</value>
+  </data>
+  <data name="m_sendReceiveData.Location" type="System.Drawing.Point, System.Drawing">
+	<value>8, 111</value>
+  </data>
+  <data name="m_sendReceiveData.Size" type="System.Drawing.Size, System.Drawing">
+	<value>250, 17</value>
+  </data>
+  <data name="m_sendReceiveData.TabIndex" type="System.Int32, mscorlib">
+	<value>4</value>
+  </data>
+  <data name="m_sendReceiveData.Text" xml:space="preserve">
+	<value>Send/&amp;Receive data (repository history)</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Name" xml:space="preserve">
+	<value>m_sendReceiveData</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Type" xml:space="preserve">
+	<value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.Parent" xml:space="preserve">
+	<value>m_gbAlsoRestore</value>
+  </data>
+  <data name="&gt;&gt;m_sendReceiveData.ZOrder" xml:space="preserve">
 	<value>0</value>
   </data>
   <data name="m_gbAlsoRestore.Enabled" type="System.Boolean, mscorlib">
@@ -559,7 +589,7 @@
 	<value>15, 258</value>
   </data>
   <data name="m_gbAlsoRestore.Size" type="System.Drawing.Size, System.Drawing">
-	<value>521, 135</value>
+	<value>521, 158</value>
   </data>
   <data name="m_gbAlsoRestore.TabIndex" type="System.Int32, mscorlib">
 	<value>6</value>
@@ -1153,7 +1183,7 @@
 	<value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-	<value>550, 447</value>
+	<value>550, 470</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
 	<value>566, 485</value>

--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectPresenter.cs
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectPresenter.cs
@@ -93,6 +93,8 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 				itemsBackedUp.Add(FwCoreDlgs.ksSupportingFilesRestoreDlg);
 			if (settings.IncludeSpellCheckAdditions)
 				itemsBackedUp.Add(FwCoreDlgs.ksSpellingFilesRestoreDlg);
+			if (settings.IncludeSendReceiveData)
+				itemsBackedUp.Add(FwCoreDlgs.ksSendReceiveDataRestoreDlg);
 
 			int numberOfFileSetsBackedUp = itemsBackedUp.Count;
 			if (numberOfFileSetsBackedUp == 0)
@@ -139,8 +141,8 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			if (!m_restoreProjectView.Settings.ProjectExists)
 				return true;
 
-			// If the user is using Send/Receive, it is NOT OK to restore
-			if (m_restoreProjectView.Settings.UsingSendReceive)
+			// If the user is using Send/Receive and the backup doesn't include S/R data, it is NOT OK to restore
+			if (m_restoreProjectView.Settings.UsingSendReceive && !m_restoreProjectView.Settings.IncludeSendReceiveData)
 			{
 				MessageBox.Show(FwCoreDlgs.ksBackupCantRestoreWhenUsingSRMsg, FwCoreDlgs.ksBackupCantRestoreWhenUsingSRCaption,
 					MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Src/FwCoreDlgs/FwCoreDlgs.Designer.cs
+++ b/Src/FwCoreDlgs/FwCoreDlgs.Designer.cs
@@ -1229,7 +1229,16 @@ namespace SIL.FieldWorks.FwCoreDlgs {
                 return ResourceManager.GetString("ksSpellingFilesRestoreDlg", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Send/Receive data.
+        /// </summary>
+        public static string ksSendReceiveDataRestoreDlg {
+            get {
+                return ResourceManager.GetString("ksSendReceiveDataRestoreDlg", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to {0} Stem.
         /// </summary>

--- a/Src/FwCoreDlgs/FwCoreDlgs.resx
+++ b/Src/FwCoreDlgs/FwCoreDlgs.resx
@@ -830,6 +830,9 @@ Enter a shorter name.</value>
   <data name="ksSpellingFilesRestoreDlg" xml:space="preserve">
     <value>Spelling dictionary</value>
   </data>
+  <data name="ksSendReceiveDataRestoreDlg" xml:space="preserve">
+    <value>Send/Receive data</value>
+  </data>
   <data name="ksIncludesAndRestoreDlg" xml:space="preserve">
     <value> and {0}.</value>
   </data>

--- a/Src/FwCoreDlgs/FwCoreDlgsTests/RestoreProjectPresenterTests.cs
+++ b/Src/FwCoreDlgs/FwCoreDlgsTests/RestoreProjectPresenterTests.cs
@@ -4,27 +4,65 @@
 //
 // File: RestoreProjectPresenterTests.cs
 // Responsibility: FW Team
-// DISABLED: BackupProjectSettings API has been refactored - tests use obsolete constructor and properties
 
+using System.IO;
 using NUnit.Framework;
+using SIL.FieldWorks.FwCoreDlgs.BackupRestore;
+using SIL.LCModel;
+using SIL.LCModel.DomainServices.BackupRestore;
+using SIL.LCModel.Utils;
 
 namespace SIL.FieldWorks.FwCoreDlgs
 {
-	/// <summary>
-	/// Historical tests for RestoreProjectPresenter.
-	/// The original tests used backup/restore APIs that have since been refactored.
-	/// </summary>
 	[TestFixture]
-	[Ignore("Obsolete: backup/restore presenter tests need rewrite after API refactor.")]
 	public class RestoreProjectPresenterTests
 	{
-		[Test]
-		public void ObsoletePresenterApi_Disabled()
+		private BackupFileSettings CreateBackupFileSettingsWithFlags(
+			bool config = false, bool linked = false, bool supporting = false,
+			bool spellCheck = false, bool sendReceive = false)
 		{
-			Assert.Ignore(
-				"Obsolete: legacy presenter tests are archived behind RUN_LW_LEGACY_TESTS " +
-				"and need to be rewritten against the current backup/restore APIs."
-			);
+			var backupSettings = new BackupFileSettings(
+				Path.ChangeExtension("dummy", LcmFileHelper.ksFwBackupFileExtension), false);
+			ReflectionHelper.SetField(backupSettings, "m_projectName", "dummy");
+			ReflectionHelper.SetField(backupSettings, "m_configurationSettings", config);
+			ReflectionHelper.SetField(backupSettings, "m_linkedFiles", linked);
+			ReflectionHelper.SetField(backupSettings, "m_supportingFiles", supporting);
+			ReflectionHelper.SetField(backupSettings, "m_spellCheckAdditions", spellCheck);
+			ReflectionHelper.SetField(backupSettings, "m_sendReceiveData", sendReceive);
+			return backupSettings;
+		}
+
+		[Test]
+		public void IncludesFiles_WithSendReceiveData_ShowsInLabel()
+		{
+			var presenter = new RestoreProjectPresenter(null);
+			var settings = CreateBackupFileSettingsWithFlags(sendReceive: true);
+			string result = presenter.IncludesFiles(settings);
+			Assert.That(result, Is.EqualTo("Send/Receive data"));
+		}
+
+		[Test]
+		public void IncludesFiles_WithoutSendReceiveData_OmitsFromLabel()
+		{
+			var presenter = new RestoreProjectPresenter(null);
+			var settings = CreateBackupFileSettingsWithFlags(config: true, sendReceive: false);
+			string result = presenter.IncludesFiles(settings);
+			Assert.That(result, Does.Not.Contain("Send/Receive data"));
+		}
+
+		[Test]
+		public void IncludesFiles_AllFlags_CorrectCombination()
+		{
+			var presenter = new RestoreProjectPresenter(null);
+			var settings = CreateBackupFileSettingsWithFlags(
+				config: true, linked: true, supporting: true,
+				spellCheck: true, sendReceive: true);
+			string result = presenter.IncludesFiles(settings);
+			Assert.That(result, Does.Contain("Configuration settings"));
+			Assert.That(result, Does.Contain("Linked files"));
+			Assert.That(result, Does.Contain("Supporting Files"));
+			Assert.That(result, Does.Contain("Spelling dictionary"));
+			Assert.That(result, Does.Contain("Send/Receive data"));
 		}
 	}
 }
@@ -73,7 +111,7 @@ namespace SIL.FieldWorks.FwCoreDlgs
 		[Test]
 		public void VerifyStringForBackupPropertiesLabel()
 		{
-			var restoreProjectPresenter = new RestoreProjectPresenter(null, string.Empty);
+			var restoreProjectPresenter = new RestoreProjectPresenter(null);
 			BackupFileSettings backupSettings = new BackupFileSettings(
 				Path.ChangeExtension("dummy", LcmFileHelper.ksFwBackupFileExtension), false);
 			// This is needed to thwart BackupFileSettings's normal logic to populate the flags
@@ -114,7 +152,7 @@ namespace SIL.FieldWorks.FwCoreDlgs
 		public void DefaultBackupFile_NoBackupFilesAvailable()
 		{
 			m_fileOs.ExistingDirectories.Add(FwDirectoryFinder.DefaultBackupDirectory);
-			RestoreProjectPresenter presenter = new RestoreProjectPresenter(null, string.Empty);
+			RestoreProjectPresenter presenter = new RestoreProjectPresenter(null);
 			Assert.That(presenter.DefaultProjectName, Is.EqualTo(String.Empty));
 		}
 
@@ -134,7 +172,7 @@ namespace SIL.FieldWorks.FwCoreDlgs
 			backupSettings.BackupTime = backupSettings.BackupTime.AddHours(-3);
 			string backupFileName2 = backupSettings.ZipFileName;
 			m_fileOs.AddExistingFile(backupFileName2);
-			RestoreProjectPresenter presenter = new RestoreProjectPresenter(null, string.Empty);
+			RestoreProjectPresenter presenter = new RestoreProjectPresenter(null);
 			Assert.That(presenter.DefaultProjectName, Is.EqualTo(backupSettings.ProjectName));
 		}
 


### PR DESCRIPTION
## Summary

- Adds a new "Send/Receive data" checkbox to the Backup and Restore dialogs, allowing users to include `.hg` (Mercurial) directories and `OtherRepositories/` folders in backups
- The backup checkbox is checked by default when S/R data exists in the project; the restore checkbox is informational-only (disabled) reflecting what the backup contains
- Updates `RestoreProjectPresenter.IsOkayToRestoreProject()` to allow restoring over S/R projects when the backup includes S/R data
- Fixes `Manage-LocalLibraries.ps1`: uses `XmlWriter` with tab-indented settings instead of `XmlDocument.Save()` to preserve `SilVersions.props` formatting; makes `-Library` ValidateSet names (`lcm`, `palaso`) consistent with pack-mode switch names (`-Lcm`, `-Palaso`)

## Companion PR

The liblcm side of this feature (interface, settings, serialization, backup/restore service changes, and tests) has already been merged: the `IBackupInfo.IncludeSendReceiveData` property, `BackupFileSettings` serialization, `ProjectBackupService` file gathering, `ProjectRestoreService` extraction, and `RestoreProjectSettings` command-line option.

## Test plan

- [x] New unit tests in `RestoreProjectPresenterTests.cs` (3 tests for `IncludesFiles` with S/R flag variations)
- [x] Verify backup dialog shows S/R checkbox, enabled and checked when `.hg` exists in project
- [x] Verify backup zip contains `.hg/` and `OtherRepositories/` entries when checked
- [x] Verify restore dialog shows S/R checkbox as disabled/informational, reflecting backup contents
- [x] Verify restoring over an S/R project is allowed when backup includes S/R data
- [x] Verify `Manage-LocalLibraries.ps1 -Library lcm -Version X` works (previously required `-Library liblcm`)
- [x] Verify `SilVersions.props` retains tab indentation after running `Manage-LocalLibraries.ps1`

> **Note:** `Build/SilVersions.props` contains a temporary local version (`11.0.0-chore-updateperm0157`) used during integration testing. This should be reverted to the upstream version before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/907)
<!-- Reviewable:end -->
