### PR TITLE
chore: improve build, test, and installer reliability

### DIFF
--- a/.github/instructions/dotnet-framework.instructions.md
+++ b/.github/instructions/dotnet-framework.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: 'Guidance for working with .NET Framework projects. Includes project structure, C# language version, NuGet management, and best practices.'
 applyTo: '**/*.csproj, **/*.cs'
 ---
@@ -18,7 +18,7 @@ applyTo: '**/*.csproj, **/*.cs'
   - Example: `<Compile Include="Path\To\NewFile.cs" />`
 
 - **No Implicit Imports**: Unlike SDK-style projects, .NET Framework projects do not automatically import common namespaces or assemblies
- 
+
 - **Build Configuration**: Contains explicit `<PropertyGroup>` sections for Debug/Release configurations
 
 - **Output Paths**: Explicit `<OutputPath>` and `<IntermediateOutputPath>` definitions

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -1,4 +1,4 @@
-name: Patch Installer
+﻿name: Patch Installer
 
 # Builds the FieldWorks Patch Installer on the specified `base_release`
 # If `make_release` is true, uploads installers to https://flex-updates.s3.amazonaws.com/?prefix=jobs/FieldWorks-Win-all-Release-Patch.
@@ -151,7 +151,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: | 
+          dotnet-version: |
             3.1.x
             5.0.x
 
@@ -166,7 +166,7 @@ jobs:
           choco install wixtoolset --version 3.11.2 --allow-downgrade --force
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         if: github.event_name != 'pull_request'
-        
+
       - name: Import Base Build Artifacts
         shell: pwsh
         run: |
@@ -211,7 +211,7 @@ jobs:
           )
           $valueName = "Switch.System.DisableTempFileCollectionDirectoryFeature"
           $expectedValue = "true"
-          
+
           foreach ($path in $regPaths) {
               Write-Host "Adding or updating registry value in $path..."
               if (-not (Test-Path $path)) {
@@ -238,11 +238,11 @@ jobs:
           $results = Select-String -Path "build.log" -Pattern "^\s*[1-9][0-9]* Error\(s\)"
           if ($results) {
               foreach ($result in $results) {
-                  Write-Host "Found errors in build.log $($result.LineNumber): $($result.Line)" -ForegroundColor red 
+                  Write-Host "Found errors in build.log $($result.LineNumber): $($result.Line)" -ForegroundColor red
               }
               exit 1
           } else {
-              Write-Host "No errors found" -ForegroundColor green 
+              Write-Host "No errors found" -ForegroundColor green
               exit 0
           }
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "chat.promptFilesRecommendations": {
     "speckit.constitution": true,
     "speckit.specify": true,
@@ -95,11 +95,7 @@
   // Tasks not listed require manual confirmation.
   // ============================================================================
   "chat.tools.tasks.allowedTasks": [
-    // Build tasks (safe - only produce artifacts)
-    "Build",
-    "Build Release",
-
-    // Test tasks (safe - no external changes)
+    // Test tasks remain auto-approved so Linux hosts surface the not-supported message.
     "Test",
     "Test (no build)",
 
@@ -125,6 +121,9 @@
   ]
   // ============================================================================
   // TASKS REQUIRING MANUAL APPROVAL (not in allowedTasks):
+  // - Build                        (Windows only)
+  // - Build Release                (Windows only)
+  // - Build Tests                  (Windows only)
   // - Test (with filter)           (has user input prompt)
   // - Test (specific project)      (has user input prompt)
   // - Agent: Propose updates       (modifies files)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AI Agent Playbook for FieldWorks
+﻿# AI Agent Playbook for FieldWorks
 
 Minimal, high-signal guidance for coding agents in this repository.
 
@@ -8,10 +8,6 @@ Minimal, high-signal guidance for coding agents in this repository.
 - Build with `.\build.ps1`.
 - Test with `.\test.ps1`.
 - Do not bypass repository scripts for normal build/test work.
-- Before committing or pushing, run the existing VS Code task `CI: Full local check`.
-- After any rebase, merge, cherry-pick, or manual conflict resolution, run `CI: Whitespace check` before committing.
-- If `CI: Whitespace check` rewrites files, review and restage those files, then rerun the task until it passes cleanly.
-- When commit history changes, run `CI: Commit messages` before pushing.
 
 ## Critical constraints
 
@@ -24,6 +20,10 @@ Minimal, high-signal guidance for coding agents in this repository.
 - Use `.github/instructions/*.instructions.md` for prescriptive rules.
 - Apply `.github/instructions/navigation.instructions.md` for structural navigation and hidden-dependency handling.
 - Use `Src/AGENTS.md`, `.github/AGENTS.md`, `FLExInstaller/AGENTS.md`, and `openspec/AGENTS.md` for area-specific guidance.
+
+## External Dependencies (LibLcm)
+
+FieldWorks is built upon the `liblcm` (Language & Culture Model) repository, which provides the main data model and FDO (FieldWorks Data Objects) layers used by FieldWorks. The liblcm library is the core FieldWorks model for language and culture data and includes interfaces like `IScrFootnoteFactory` that FieldWorks consumes. If you cannot find a core data model definition within this workspace, ask for access to the `liblcm` repository to reference the source.
 
 ## Serena navigation
 
@@ -40,6 +40,5 @@ Minimal, high-signal guidance for coding agents in this repository.
 ## Validation checklist
 
 1. Run the relevant build/test scripts for touched areas.
-2. Run `CI: Full local check` before commit/push; use `CI: Whitespace check` immediately after conflict resolution.
-3. Keep edits scoped and avoid unrelated refactors.
-4. Update docs only when behavior/contracts/process changed.
+2. Keep edits scoped and avoid unrelated refactors.
+3. Update docs only when behavior/contracts/process changed.

--- a/Build/Agent/FwBuildHelpers.psm1
+++ b/Build/Agent/FwBuildHelpers.psm1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 	Shared helper functions for FieldWorks build and test scripts.
 
@@ -486,26 +486,45 @@ function Get-NewestWriteTimeUtc {
 
     $latest = [datetime]::MinValue
     foreach ($path in $Paths) {
-        if (-not (Test-Path $path)) {
+		if (-not (Test-Path -LiteralPath $path)) {
             continue
         }
 
-        $items = Get-ChildItem -Path $path -Recurse -File -ErrorAction SilentlyContinue
-        if ($IncludePatterns.Count -gt 0) {
-            $items = $items | Where-Object {
-                $fileName = $_.Name
-                foreach ($pattern in $IncludePatterns) {
-                    if ($fileName -like $pattern) {
-                        return $true
-                    }
-                }
-                return $false
-            }
+		$item = Get-Item -LiteralPath $path -ErrorAction SilentlyContinue
+		if ($item -is [System.IO.FileInfo]) {
+			$matches = $IncludePatterns.Count -eq 0
+			foreach ($pattern in $IncludePatterns) {
+				if ($item.Name -like $pattern) {
+					$matches = $true
+					break
+				}
+			}
+
+			if ($matches -and $item.LastWriteTimeUtc -gt $latest) {
+				$latest = $item.LastWriteTimeUtc
+			}
+			continue
         }
 
-        foreach ($item in $items) {
-            if ($item.LastWriteTimeUtc -gt $latest) {
-                $latest = $item.LastWriteTimeUtc
+		if (-not ($item -is [System.IO.DirectoryInfo])) {
+			continue
+		}
+
+		$patterns = $IncludePatterns
+		if ($patterns.Count -eq 0) {
+			$patterns = @('*')
+		}
+
+		foreach ($pattern in $patterns) {
+			try {
+				foreach ($sourceFile in $item.EnumerateFiles($pattern, [System.IO.SearchOption]::AllDirectories)) {
+					if ($sourceFile.LastWriteTimeUtc -gt $latest) {
+						$latest = $sourceFile.LastWriteTimeUtc
+					}
+				}
+			}
+			catch {
+				Write-Verbose "Skipping freshness scan for '$path' with pattern '$pattern': $_"
             }
         }
     }
@@ -558,9 +577,13 @@ function Test-ViewsNativeArtifactsStale {
         (Join-Path $RepoRoot 'Src\views'),
         (Join-Path $RepoRoot 'Src\Kernel'),
         (Join-Path $RepoRoot 'Src\Generic'),
-        (Join-Path $RepoRoot 'Include')
+		(Join-Path $RepoRoot 'Include'),
+		(Join-Path $RepoRoot 'Bld'),
+		(Join-Path $RepoRoot 'Build'),
+		(Join-Path $RepoRoot 'Directory.Build.props'),
+		(Join-Path $RepoRoot 'Directory.Build.targets')
     )
-    $sourcePatterns = @('*.cpp', '*.c', '*.cc', '*.h', '*.hpp', '*.ixx', '*.idl', '*.rc', '*.mak', '*.def', '*.bat')
+	$sourcePatterns = @('*.cpp', '*.c', '*.cc', '*.h', '*.hpp', '*.hxx', '*.inl', '*.ixx', '*.idl', '*.rc', '*.rc2', '*.rh', '*.mak', '*.def', '*.bat', '*.cmd', '*.vcxproj', '*.vcxproj.filters', '*.props', '*.targets')
     $artifactPaths = @(
         (Join-Path $RepoRoot "Output\$Configuration\Views.dll"),
         (Join-Path $RepoRoot "Output\$Configuration\views.lib"),

--- a/Build/Agent/FwBuildHelpers.psm1
+++ b/Build/Agent/FwBuildHelpers.psm1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 	Shared helper functions for FieldWorks build and test scripts.
 
@@ -474,6 +474,110 @@ function Test-GitTrackedFile {
 	}
 }
 
+function Get-NewestWriteTimeUtc {
+    <#!
+    .SYNOPSIS
+        Returns the newest LastWriteTimeUtc among matching files under one or more roots.
+    #>
+    param(
+        [Parameter(Mandatory)][string[]]$Paths,
+        [string[]]$IncludePatterns = @()
+    )
+
+    $latest = [datetime]::MinValue
+    foreach ($path in $Paths) {
+        if (-not (Test-Path $path)) {
+            continue
+        }
+
+        $items = Get-ChildItem -Path $path -Recurse -File -ErrorAction SilentlyContinue
+        if ($IncludePatterns.Count -gt 0) {
+            $items = $items | Where-Object {
+                $fileName = $_.Name
+                foreach ($pattern in $IncludePatterns) {
+                    if ($fileName -like $pattern) {
+                        return $true
+                    }
+                }
+                return $false
+            }
+        }
+
+        foreach ($item in $items) {
+            if ($item.LastWriteTimeUtc -gt $latest) {
+                $latest = $item.LastWriteTimeUtc
+            }
+        }
+    }
+
+    return $latest
+}
+
+function Get-OldestWriteTimeUtc {
+    <#!
+    .SYNOPSIS
+        Returns the oldest LastWriteTimeUtc across a set of required artifact files.
+        Returns $null if any required artifact is missing.
+    #>
+    param(
+        [Parameter(Mandatory)][string[]]$Paths
+    )
+
+    $oldest = [datetime]::MaxValue
+    $foundAny = $false
+    foreach ($path in $Paths) {
+        if (-not (Test-Path $path)) {
+            return $null
+        }
+
+        $item = Get-Item -LiteralPath $path -ErrorAction Stop
+        $foundAny = $true
+        if ($item.LastWriteTimeUtc -lt $oldest) {
+            $oldest = $item.LastWriteTimeUtc
+        }
+    }
+
+    if (-not $foundAny) {
+        return $null
+    }
+
+    return $oldest
+}
+
+function Test-ViewsNativeArtifactsStale {
+    <#!
+    .SYNOPSIS
+        Returns $true when the Views/FwKernel native artifacts are missing or older than relevant native inputs.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$Configuration
+    )
+
+    $sourceRoots = @(
+        (Join-Path $RepoRoot 'Src\views'),
+        (Join-Path $RepoRoot 'Src\Kernel'),
+        (Join-Path $RepoRoot 'Src\Generic'),
+        (Join-Path $RepoRoot 'Include')
+    )
+    $sourcePatterns = @('*.cpp', '*.c', '*.cc', '*.h', '*.hpp', '*.ixx', '*.idl', '*.rc', '*.mak', '*.def', '*.bat')
+    $artifactPaths = @(
+        (Join-Path $RepoRoot "Output\$Configuration\Views.dll"),
+        (Join-Path $RepoRoot "Output\$Configuration\views.lib"),
+        (Join-Path $RepoRoot "Output\$Configuration\Common\FwKernelTlb.h"),
+        (Join-Path $RepoRoot "Obj\$Configuration\Views\autopch\VwRootBox.obj")
+    )
+
+    $latestSource = Get-NewestWriteTimeUtc -Paths $sourceRoots -IncludePatterns $sourcePatterns
+    $oldestArtifact = Get-OldestWriteTimeUtc -Paths $artifactPaths
+
+    if ($oldestArtifact -eq $null) {
+        return $true
+    }
+
+    return $latestSource -gt $oldestArtifact
+}
+
 # =============================================================================
 # Module Exports
 # =============================================================================
@@ -493,5 +597,8 @@ Export-ModuleMember -Function @(
 	'Exit-WorktreeLock',
 	'Remove-StaleObjFolders',
 	'Test-IsFileLockError',
-	'Invoke-WithFileLockRetry'
+	'Invoke-WithFileLockRetry',
+	'Get-NewestWriteTimeUtc',
+	'Get-OldestWriteTimeUtc',
+	'Test-ViewsNativeArtifactsStale'
 )

--- a/Build/Agent/README.md
+++ b/Build/Agent/README.md
@@ -1,4 +1,4 @@
-# Build/Agent Scripts
+﻿# Build/Agent Scripts
 
 PowerShell scripts for build, test, and CI orchestration.
 
@@ -11,6 +11,7 @@ PowerShell scripts for build, test, and CI orchestration.
 
 | Script | Purpose |
 |--------|---------|
+| `Run-AllRenders.ps1` | Runs the DetailControls and RootSite render suites sequentially from one command without adding a meta test project. |
 | `Summarize-NativeTestResults.ps1` | Parses native Unit++ logs and appends a pass/fail summary table to GitHub step summary. |
 
 ## GitHub Actions usage

--- a/Build/Agent/Verify-FwDependencies.ps1
+++ b/Build/Agent/Verify-FwDependencies.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 	Verifies that all FieldWorks build dependencies are available.
 
@@ -71,6 +71,8 @@ function Test-Dependency {
 		[string]$Required = "Required"
 	)
 
+	$isRequired = ($Required -eq "Required")
+
 	try {
 		$result = & $Check
 		if ($result) {
@@ -80,18 +82,18 @@ function Test-Dependency {
 					Write-Host "       $result" -ForegroundColor DarkGray
 				}
 			}
-			return @{ Name = $Name; Found = $true; IsRequired = ($Required -eq "Required"); Info = $result }
+			return @{ Name = $Name; Found = $true; IsRequired = $isRequired; Info = $result }
 		}
 		else {
 			throw "Check returned null/false"
 		}
 	}
 	catch {
-		$color = if ($Required -eq "Required") { "Red" } else { "Yellow" }
-		$status = if ($Required -eq "Required") { "[FAIL]" } else { "[WARN]" }
+		$color = if ($isRequired) { "Red" } else { "Yellow" }
+		$status = if ($isRequired) { "[FAIL]" } else { "[WARN]" }
 		Write-Host "$status $Name" -ForegroundColor $color
 		Write-Host "       $_" -ForegroundColor DarkGray
-		return @{ Name = $Name; Found = $false; IsRequired = ($Required -eq "Required"); Error = $_.ToString() }
+		return @{ Name = $Name; Found = $false; IsRequired = $isRequired; Error = $_.ToString() }
 	}
 }
 
@@ -304,9 +306,9 @@ if ($Detailed) {
 	Write-Host "=== Summary ===" -ForegroundColor Cyan
 }
 
-$required = $results | Where-Object { $_.IsRequired -ne $false }
-$missing = $required | Where-Object { -not $_.Found }
-$optional = $results | Where-Object { $_.IsRequired -eq $false }
+$required = @($results | Where-Object { $_.IsRequired -ne $false })
+$missing = @($required | Where-Object { -not $_.Found })
+$optional = @($results | Where-Object { $_.IsRequired -eq $false })
 
 $totalRequired = ($required | Measure-Object).Count
 $foundRequired = ($required | Where-Object { $_.Found } | Measure-Object).Count

--- a/Build/Agent/fix-whitespace.ps1
+++ b/Build/Agent/fix-whitespace.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 $ErrorActionPreference = 'Stop'
 
 # Import shared git helpers
@@ -10,39 +10,10 @@ function Get-BaseRef {
 	return (Get-DefaultBranchRef)
 }
 
-function Test-HasUtf8Bom {
-	param([Parameter(Mandatory)][string]$Path)
-
-	# Read only the first three bytes to check for a UTF-8 BOM to avoid loading the entire file.
-	$buffer = [byte[]]::new(3)
-	$stream = [System.IO.File]::OpenRead($Path)
-	try {
-		$bytesRead = $stream.Read($buffer, 0, 3)
-	}
-	finally {
-		$stream.Dispose()
-	}
-
-	if ($bytesRead -lt 3) { return $false }
-	return $buffer[0] -eq 0xEF -and $buffer[1] -eq 0xBB -and $buffer[2] -eq 0xBF
-}
-
-function Write-Utf8Text {
-	param(
-		[Parameter(Mandatory)][string]$Path,
-		[Parameter(Mandatory)][string]$Content,
-		[Parameter(Mandatory)][bool]$EmitBom
-	)
-
-	$encoding = New-Object System.Text.UTF8Encoding($EmitBom)
-	[System.IO.File]::WriteAllText($Path, $Content, $encoding)
-}
-
 function Format-FileWhitespace {
 	param([Parameter(Mandatory)][string]$Path)
 	if (-not (Test-Path -LiteralPath $Path)) { return }
 	try {
-		$hasUtf8Bom = Test-HasUtf8Bom -Path $Path
 		$raw = Get-Content -LiteralPath $Path -Raw -Encoding utf8
 	}
  catch {
@@ -62,7 +33,7 @@ function Format-FileWhitespace {
 	# Join back and ensure exactly one trailing newline
 	$new = ($lines -join "`n") + "`n"
 	if ($new -ne $orig) {
-		Write-Utf8Text -Path $Path -Content $new -EmitBom $hasUtf8Bom
+		Set-Content -LiteralPath $Path -Value $new -Encoding utf8 -NoNewline
 		Write-Host "Fixed whitespace: $Path"
 	}
 }
@@ -85,6 +56,5 @@ $files = $fixFiles | Where-Object { $_ -and (Test-Path $_) }
 
 foreach ($f in $files) { Format-FileWhitespace -Path $f }
 
-Write-Host "Whitespace fix completed. Review and stage the updated files before committing."
-Write-Host "If check-whitespace reported an older commit in origin/main..HEAD, rewrite history with amend, squash, or rebase so that offending commit is no longer part of the branch."
+Write-Host "Whitespace fix completed. Review changes, commit, and rebase as needed."
 exit 0

--- a/Build/Agent/fix-whitespace.ps1
+++ b/Build/Agent/fix-whitespace.ps1
@@ -10,11 +10,49 @@ function Get-BaseRef {
 	return (Get-DefaultBranchRef)
 }
 
+function Read-Utf8TextWithoutBom {
+	param([Parameter(Mandatory)][string]$Path)
+
+	$bytes = [System.IO.File]::ReadAllBytes($Path)
+	$offset = 0
+	$hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+	if ($hasBom) {
+		$offset = 3
+	}
+
+	$encoding = New-Object System.Text.UTF8Encoding($false, $true)
+	return @{
+		Text = $encoding.GetString($bytes, $offset, $bytes.Length - $offset)
+		HadBom = $hasBom
+	}
+}
+
+function Test-ForceUtf8WithoutBom {
+	param([Parameter(Mandatory)][string]$Path)
+
+	# Preserve the existing BOM state for ordinary UTF-8 text files to avoid
+	# noisy encoding-only churn. Force BOM-less writes only for entrypoint scripts
+	# where a UTF-8 BOM can break execution or produce confusing shell output.
+	return @('.cmd', '.bat') -contains [System.IO.Path]::GetExtension($Path).ToLowerInvariant()
+}
+
+function Write-Utf8Text {
+	param(
+		[Parameter(Mandatory)][string]$Path,
+		[Parameter(Mandatory)][string]$Content,
+		[Parameter(Mandatory)][bool]$EmitBom
+	)
+
+	$encoding = New-Object System.Text.UTF8Encoding($EmitBom)
+	[System.IO.File]::WriteAllText($Path, $Content, $encoding)
+}
+
 function Format-FileWhitespace {
 	param([Parameter(Mandatory)][string]$Path)
 	if (-not (Test-Path -LiteralPath $Path)) { return }
 	try {
-		$raw = Get-Content -LiteralPath $Path -Raw -Encoding utf8
+		$readResult = Read-Utf8TextWithoutBom -Path $Path
+		$raw = $readResult.Text
 	}
  catch {
 		Write-Host "Skipping non-UTF8 or binary file: $Path"
@@ -32,8 +70,10 @@ function Format-FileWhitespace {
 	while ($lines.Count -gt 0 -and [string]::IsNullOrWhiteSpace($lines[$lines.Count - 1])) { $lines.RemoveAt($lines.Count - 1) }
 	# Join back and ensure exactly one trailing newline
 	$new = ($lines -join "`n") + "`n"
-	if ($new -ne $orig) {
-		Set-Content -LiteralPath $Path -Value $new -Encoding utf8 -NoNewline
+	$forceUtf8WithoutBom = Test-ForceUtf8WithoutBom -Path $Path
+	$emitBom = $readResult.HadBom -and -not $forceUtf8WithoutBom
+	if ($new -ne $orig -or ($forceUtf8WithoutBom -and $readResult.HadBom)) {
+		Write-Utf8Text -Path $Path -Content $new -EmitBom $emitBom
 		Write-Host "Fixed whitespace: $Path"
 	}
 }

--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
 	<!-- ########################################################################################################## -->
 	<!-- ### Configuration properties - Review and edit these values as needed.                                 ### -->
@@ -280,6 +280,10 @@
 			<!-- REVIEW (Hasso) 2018.04: not sure if this is files or a folder -->
 			<MergeModules Include="$(OutputDirForConfig)\Python\**\*" />
 			<!-- REVIEW (Hasso) 2018.04: not sure if this is files or a folder -->
+			<MergeModules Include="$(OutputDirForConfig)\ScrChecks.dll" />
+			<!-- this will be taken from DistFiles\Editorial Checks -->
+			<MergeModules Include="$(OutputDirForConfig)\ScrChecks.pdb" />
+			<!-- this will be taken from DistFiles\Editorial Checks -->
 			<MergeModules Include="$(OutputDirForConfig)\SilEncConverters40.dll" />
 			<MergeModules Include="$(OutputDirForConfig)\SilEncConverters40.tlb" />
 			<MergeModules Include="$(OutputDirForConfig)\Temp\**\*" />

--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -279,9 +279,9 @@
 			<MergeModules Include="$(OutputDirForConfig)\Python*" />
 			<!-- REVIEW (Hasso) 2018.04: not sure if this is files or a folder -->
 			<MergeModules Include="$(OutputDirForConfig)\Python\**\*" />
-			<!-- REVIEW (Hasso) 2018.04: not sure if this is files or a folder -->
+			<!-- Keep the output-root copy out of BinFiles so the DistFiles\Editorial Checks copy is harvested instead. -->
 			<MergeModules Include="$(OutputDirForConfig)\ScrChecks.dll" />
-			<!-- this will be taken from DistFiles\Editorial Checks -->
+			<!-- Keep the output-root copy out of BinFiles so the DistFiles\Editorial Checks copy is harvested instead. -->
 			<MergeModules Include="$(OutputDirForConfig)\ScrChecks.pdb" />
 			<!-- this will be taken from DistFiles\Editorial Checks -->
 			<MergeModules Include="$(OutputDirForConfig)\SilEncConverters40.dll" />

--- a/Build/Src/NativeBuild/NativeBuild.csproj
+++ b/Build/Src/NativeBuild/NativeBuild.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project
   DefaultTargets="Build"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
@@ -45,7 +45,10 @@
   </PropertyGroup>
   <!-- Reference to sil.lcmodel.core package for contentFiles. -->
   <ItemGroup>
-    <PackageReference Include="SIL.LCModel.Core" Version="$(SilLcmVersion)" GeneratePathProperty="true">
+    <PackageReference
+      Include="SIL.LCModel.Core"
+      Version="$(SilLcmVersion)"
+      GeneratePathProperty="true">
       <IncludeAssets>none</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Build/scripts/Invoke-CppTest.ps1
+++ b/Build/scripts/Invoke-CppTest.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 	Build and/or run native C++ test executables.
 
@@ -302,11 +302,9 @@ function Ensure-UnitPlusPlusLibrary {
 
 function Ensure-TestViewsPrerequisites {
 	if ($TestProject -ne 'TestViews') { return }
-	$fwKernelHeader = Join-Path $WorktreePath "Output\$Configuration\Common\FwKernelTlb.h"
-	$viewsObj = Join-Path $WorktreePath "Obj\$Configuration\Views\autopch\VwRootBox.obj"
-	if ((Test-Path $fwKernelHeader) -and (Test-Path $viewsObj)) { return }
+	if (-not (Test-ViewsNativeArtifactsStale -RepoRoot $WorktreePath -Configuration $Configuration)) { return }
 
-	Write-Host "[INFO] Missing native artifacts or generated headers required for TestViews." -ForegroundColor Yellow
+	Write-Host "[INFO] Refreshing native artifacts and generated headers required for TestViews." -ForegroundColor Yellow
 	Build-NativeArtifacts
 	Build-ViewsInterfacesArtifacts
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-
+﻿
 <Project>
 	<Import Project="$(MSBuildThisFileDirectory)Build\FieldWorks.Toolchain.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)Build\FieldWorks.Toolchain.props')" />
@@ -84,10 +84,24 @@
 	<PropertyGroup Label="Shared Paths for Traversal Build">
 		<!-- Root directory paths -->
 		<FwRoot>$(MSBuildThisFileDirectory)</FwRoot>
+		<!--
+			Verify NuGet package auto-discovers SolutionDir/SolutionName by searching up 2 parent
+			directories. Test projects nested 3+ levels deep (e.g. Src/Common/RootSite/RootSiteTests)
+			can't find FieldWorks.sln at the repo root. Set these explicitly to suppress the warning.
+		-->
+		<SolutionDir Condition="'$(SolutionDir)' == '' Or '$(SolutionDir)' == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
+		<SolutionName Condition="'$(SolutionName)' == '' Or '$(SolutionName)' == '*Undefined*'">FieldWorks</SolutionName>
 		<FwDistFiles>$(FwRoot)DistFiles\</FwDistFiles>
 		<FwOutput>$(FwRoot)Output\</FwOutput>
 		<FwOutputBase>$(FwOutput)$(Configuration)\</FwOutputBase>
 		<FwObj>$(FwRoot)Obj\</FwObj>
+		<!--
+			WPF temp-file crash recovery:
+			Interrupted builds leave stale *_wpftmp.csproj files in source directories.
+			SDK auto-globbing picks them up, causing NETSDK1022 or MSB3030 on the next build.
+			DefaultItemExcludes prevents the SDK from ever auto-including these files.
+		-->
+		<DefaultItemExcludes>$(DefaultItemExcludes);*_wpftmp*</DefaultItemExcludes>
 		<!--
 			Unified Intermediate Output Policy:
 			All SDK-style projects use the root Obj/ folder (gitignored) instead of per-project obj/ folders.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿
+
 <Project>
 	<Import Project="$(MSBuildThisFileDirectory)Build\FieldWorks.Toolchain.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)Build\FieldWorks.Toolchain.props')" />
@@ -97,11 +97,11 @@
 		<FwObj>$(FwRoot)Obj\</FwObj>
 		<!--
 			WPF temp-file crash recovery:
-			Interrupted builds leave stale *_wpftmp.csproj files in source directories.
+			Interrupted builds leave stale *_wpftmp project files in source directories.
 			SDK auto-globbing picks them up, causing NETSDK1022 or MSB3030 on the next build.
 			DefaultItemExcludes prevents the SDK from ever auto-including these files.
 		-->
-		<DefaultItemExcludes>$(DefaultItemExcludes);*_wpftmp*</DefaultItemExcludes>
+		<DefaultItemExcludes>$(DefaultItemExcludes);*_wpftmp*.csproj;*_wpftmp*.props;*_wpftmp*.targets</DefaultItemExcludes>
 		<!--
 			Unified Intermediate Output Policy:
 			All SDK-style projects use the root Obj/ folder (gitignored) instead of per-project obj/ folders.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 	<PropertyGroup>
 		<_TransformRoot Condition="'$(_TransformRoot)'==''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</_TransformRoot>
 		<_TransformOutputBase Condition="'$(_TransformOutputBase)'=='' and '$(dir-outputBase)'!=''">$(dir-outputBase)</_TransformOutputBase>
@@ -24,5 +24,21 @@
 			Targets="BuildWindowsXslAssemblies"
 			Properties="Configuration=$(Configuration);Platform=$(Platform);BuildingTransforms=true;dir-outputBase=$(_TransformOutputBase)"
 			Condition="Exists('$(_InstallerBuildProj)')" />
+	</Target>
+	<!--
+		WPF temp-file crash recovery:
+		If a build is interrupted between GenerateTemporaryTargetAssembly and
+		CleanupTemporaryTargetAssembly, stale *_wpftmp* files remain in the source
+		directory and break the next build. This target deletes them before Pass 2 runs.
+	-->
+	<Target Name="_CleanStaleWpfTempProjects"
+		BeforeTargets="MarkupCompilePass2ForMainAssembly"
+		Condition="'$(UseWPF)' == 'true' and '$(_IsWpfTempProject)' != 'true'">
+		<ItemGroup>
+			<_StaleWpfTemp Include="$(MSBuildProjectDirectory)\*_wpftmp*" />
+		</ItemGroup>
+		<Delete Files="@(_StaleWpfTemp)" Condition="'@(_StaleWpfTemp)' != ''" />
+		<Message Text="Cleaned stale WPF temp files: @(_StaleWpfTemp)"
+			Condition="'@(_StaleWpfTemp)' != ''" Importance="normal" />
 	</Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 	<PropertyGroup>
 		<_TransformRoot Condition="'$(_TransformRoot)'==''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</_TransformRoot>
 		<_TransformOutputBase Condition="'$(_TransformOutputBase)'=='' and '$(dir-outputBase)'!=''">$(dir-outputBase)</_TransformOutputBase>
@@ -28,14 +28,16 @@
 	<!--
 		WPF temp-file crash recovery:
 		If a build is interrupted between GenerateTemporaryTargetAssembly and
-		CleanupTemporaryTargetAssembly, stale *_wpftmp* files remain in the source
+		CleanupTemporaryTargetAssembly, stale *_wpftmp project files remain in the source
 		directory and break the next build. This target deletes them before Pass 2 runs.
 	-->
 	<Target Name="_CleanStaleWpfTempProjects"
 		BeforeTargets="MarkupCompilePass2ForMainAssembly"
 		Condition="'$(UseWPF)' == 'true' and '$(_IsWpfTempProject)' != 'true'">
 		<ItemGroup>
-			<_StaleWpfTemp Include="$(MSBuildProjectDirectory)\*_wpftmp*" />
+			<_StaleWpfTemp Include="$(MSBuildProjectDirectory)\*_wpftmp*.csproj" />
+			<_StaleWpfTemp Include="$(MSBuildProjectDirectory)\*_wpftmp*.props" />
+			<_StaleWpfTemp Include="$(MSBuildProjectDirectory)\*_wpftmp*.targets" />
 		</ItemGroup>
 		<Delete Files="@(_StaleWpfTemp)" Condition="'@(_StaleWpfTemp)' != ''" />
 		<Message Text="Cleaned stale WPF temp files: @(_StaleWpfTemp)"

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to FieldWorks Development
+﻿# Contributing to FieldWorks Development
 
 Thank you for your interest in contributing to FieldWorks (FLEx)!
 
@@ -14,7 +14,8 @@ There are several ways you can contribute to the development of FieldWorks:
 
 The following steps are required for setting up a FieldWorks development environment on Windows.
 
-> **Note**: FieldWorks is Windows-only. Linux builds are no longer supported.
+> **Note**: FieldWorks build, test, installer, and setup workflows are Windows-only.
+> Linux and macOS are supported for editing, code search, documentation, specs, and agent work only.
 
 ### 1. Install Required Software
 
@@ -108,6 +109,8 @@ Build FieldWorks using the PowerShell build script:
 ```
 
 For more build options, see [.github/instructions/build.instructions.md](../.github/instructions/build.instructions.md).
+
+On Linux or macOS, do not run `build.ps1` or `test.ps1`; those entry points intentionally fail fast with a not-supported message.
 
 ### Run tests from the command line
 

--- a/FLExInstaller/Directory.Packages.props
+++ b/FLExInstaller/Directory.Packages.props
@@ -1,10 +1,15 @@
-<Project>
+﻿<Project>
 	<PropertyGroup>
 		<!--
 			Installer projects use WiX-specific packages (WixToolset.Dtf.*) that are
-			not shared with the main FieldWorks codebase. Opt out of CPM to avoid
-			needing unnecessary entries in the root Directory.Packages.props.
+			not shared with the main FieldWorks codebase. Keep those versions scoped
+			to FLExInstaller, but centralize them here.
 		-->
-		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
+
+	<ItemGroup Label="Installer Packages">
+		<PackageVersion Include="WixToolset.Dtf.CustomAction" Version="6.0.0" />
+		<PackageVersion Include="WixToolset.Dtf.WindowsInstaller" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomActions.csproj
+++ b/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomActions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <AssemblyName>CustomActions</AssemblyName>
@@ -10,8 +10,8 @@
     <Content Include="CustomAction.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="6.0.0" />
-    <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="6.0.0" />
+    <PackageReference Include="WixToolset.Dtf.CustomAction" />
+    <PackageReference Include="WixToolset.Dtf.WindowsInstaller" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-## Getting Started
+﻿## Getting Started
 
 New to FieldWorks development? Start here:
 
@@ -8,6 +8,14 @@ New to FieldWorks development? Start here:
 - **[Core Developer Setup](Docs/core-developer-setup.md)** - Additional setup for team members
 
 > **Note**: We are migrating documentation from the [FwDocumentation wiki](https://github.com/sillsdev/FwDocumentation/wiki) into this repository. Some wiki content may be more recent until migration is complete.
+
+## Linux and macOS
+
+This repository can be opened on Linux or macOS for editing, code search, documentation, specs, and agent-assisted review.
+
+Builds, tests, installer work, and developer-environment setup are Windows-only and are intentionally disabled on non-Windows hosts.
+
+If you need runnable output, use a Windows machine and run `./build.ps1` or `./test.ps1` there.
 
 ## Developer Machine Setup
 

--- a/SDK_MIGRATION.md
+++ b/SDK_MIGRATION.md
@@ -1,4 +1,4 @@
-# FieldWorks SDK Migration — Postmortem & Blame Index
+﻿# FieldWorks SDK Migration — Postmortem & Blame Index
 
 **Migration Period**: November 7-21, 2025
 **Base Commit**: `8e508dab484fafafb641298ed9071f03070f7c8b`
@@ -262,7 +262,7 @@ With CPM ensuring all projects resolve to the same package version, most manual 
 - Initializes VS Developer environment
 - Supports `/m` parallel builds
 - **Stale DLL detection**: Runs `Remove-StaleDlls.ps1` pre-build to catch version-mismatched binaries
-- **Diagnostics config**: Optionally copies dev trace config for Debug builds (`-TraceCrashes` or `UseDevTraceConfig`)
+- **Diagnostics config**: Optionally copies dev trace config for Debug builds (`-EnableTracing` or `UseDevTraceConfig`)
 - **Installer support**: `-BuildInstaller` flag triggers full installer build pipeline
 
 **Note**: `build.sh` is not supported in this repo (FieldWorks is Windows-first). Use `.\build.ps1`.

--- a/Src/AppForTests.config
+++ b/Src/AppForTests.config
@@ -1,26 +1,29 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<system.diagnostics>
-<trace autoflush="false" indentsize="4">
-<listeners>
-<clear/>
-<add name="FwTraceListener" type="SIL.LCModel.Utils.EnvVarTraceListener, SIL.LCModel.Utils, Version=11.0.0.0, Culture=neutral"
- initializeData="assertuienabled='false' assertexceptionenabled='true' logfilename='%temp%/asserts.log'"/>
-</listeners>
-</trace>
-</system.diagnostics>
-<runtime>
-<generatePublisherEvidence enabled="false" />
-<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-<!-- Binding redirects are auto-generated at build time
- (AutoGenerateBindingRedirects=true in Directory.Build.props).
- Do NOT add manual redirects here; they will drift from CPM versions. -->
-<!-- Chorus 6.0.0 references L10NSharp 9.0.0; redirect to 10.0.0.
-     Remove when Chorus is updated to reference L10NSharp 10. -->
-<dependentAssembly>
-<assemblyIdentity name="L10NSharp" publicKeyToken="fd0b3e309a5b7c28" culture="neutral" />
-<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-</dependentAssembly>
-</assemblyBinding>
-</runtime>
+	<system.diagnostics>
+		<trace autoflush="false" indentsize="4">
+			<listeners>
+				<clear />
+				<add
+					name="FwTraceListener"
+					type="SIL.LCModel.Utils.EnvVarTraceListener, SIL.LCModel.Utils"
+					initializeData="assertuienabled='false' assertexceptionenabled='true' logfilename='%temp%/asserts.log'"
+				/>
+			</listeners>
+		</trace>
+	</system.diagnostics>
+	<runtime>
+		<generatePublisherEvidence enabled="false" />
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<!-- Binding redirects are auto-generated at build time
+			 (AutoGenerateBindingRedirects=true in Directory.Build.props).
+			 Do NOT add manual redirects here; they will drift from CPM versions. -->
+			<!-- Chorus 6.0.0 references L10NSharp 9.0.0; redirect to 10.0.0.
+			     Remove when Chorus is updated to reference L10NSharp 10. -->
+			<dependentAssembly>
+				<assemblyIdentity name="L10NSharp" publicKeyToken="fd0b3e309a5b7c28" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 </configuration>

--- a/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
+++ b/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
@@ -187,6 +187,7 @@ namespace SIL.DisambiguateInFLExDBTests
 			string normalized = NormalizeViaIndex(input, "AppData", "AppData");
 			normalized = NormalizeViaIndex(normalized, "TestData", "TestData");
 			normalized = NormalizeViaIndex(normalized, tp, tp);
+			// Strip machine-specific absolute Windows path prefixes so the comparison stays stable across temp and repo roots.
 			return Regex.Replace(normalized, @"[A-Za-z]:\\(?:[^\\\r\n""]+\\)*", "");
 		}
 

--- a/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
+++ b/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SIL International
+﻿// Copyright (c) 2019 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -187,7 +187,7 @@ namespace SIL.DisambiguateInFLExDBTests
 			string normalized = NormalizeViaIndex(input, "AppData", "AppData");
 			normalized = NormalizeViaIndex(normalized, "TestData", "TestData");
 			normalized = NormalizeViaIndex(normalized, tp, tp);
-			return normalized;
+			return Regex.Replace(normalized, @"[A-Za-z]:\\(?:[^\\\r\n""]+\\)*", "");
 		}
 
 		private static string NormalizeViaIndex(string input, string match, string change)

--- a/Test.runsettings
+++ b/Test.runsettings
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   VSTest Exit Code Interpretation:
   ================================
@@ -22,8 +22,8 @@
     <TargetPlatform>x64</TargetPlatform>
     <!-- Framework version - net48 -->
     <TargetFrameworkVersion>net48</TargetFrameworkVersion>
-	<!-- Test timeout in milliseconds (15 minutes default for long-running tests) -->
-	<TestSessionTimeout>900000</TestSessionTimeout>
+      <!-- Test timeout in milliseconds (15 minutes default for long-running tests) -->
+      <TestSessionTimeout>900000</TestSessionTimeout>
     <!--
       InIsolation: Run tests in a separate process.
       This prevents native COM cleanup crashes from affecting VSTest's exit code.

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 	Builds the FieldWorks repository using the MSBuild Traversal SDK.
 
@@ -40,6 +40,7 @@
 .PARAMETER EnableTracing
 	If set, enables the dev diagnostics config (FieldWorks.Diagnostics.dev.config) so trace logging
 	is written next to the built executable. Use this for interactive diagnostics and crash investigation.
+	Legacy alias: -TraceCrashes.
 
 .PARAMETER NodeReuse
 	Controls MSBuild node reuse (/nr). Accepts true, false, or auto.
@@ -183,6 +184,7 @@ param(
 	[switch]$InstallerOnly,
 	[switch]$ForceInstallerOnly,
 	[switch]$SignInstaller,
+	[Alias('TraceCrashes')]
 	[switch]$EnableTracing,
 	[switch]$UseLocalLcm,
 	[string]$LocalLcmPath,
@@ -213,13 +215,14 @@ if (-not $PSBoundParameters.ContainsKey('StartedBy') -and -not [string]::IsNullO
 $env:PATH = "$env:WIX/bin;$env:PATH"
 
 if ($Configuration -like "--*") {
-	if ($Configuration -eq "--EnableTracing" -and -not $EnableTracing) {
+	if (($Configuration -eq "--EnableTracing" -or $Configuration -eq "--TraceCrashes") -and -not $EnableTracing) {
+		$traceArgument = $Configuration
 		$EnableTracing = $true
 		$Configuration = "Debug"
-		Write-Output "[WARN] Detected '--EnableTracing' passed without PowerShell switch parsing. Using -EnableTracing and defaulting Configuration to Debug."
+		Write-Output "[WARN] Detected '$traceArgument' passed without PowerShell switch parsing. Using -EnableTracing and defaulting Configuration to Debug."
 	}
 	else {
-		throw "Invalid Configuration value '$Configuration'. Use -EnableTracing (single dash) for trace-enabled builds."
+		throw "Invalid Configuration value '$Configuration'. Use -EnableTracing (or legacy alias -TraceCrashes) for trace-enabled builds."
 	}
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 	Builds the FieldWorks repository using the MSBuild Traversal SDK.
 
@@ -37,9 +37,9 @@
 	Values: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
 	Default is 'minimal'.
 
-.PARAMETER TraceCrashes
+.PARAMETER EnableTracing
 	If set, enables the dev diagnostics config (FieldWorks.Diagnostics.dev.config) so trace logging
-	is written next to the built executable. Useful for crash investigation.
+	is written next to the built executable. Use this for interactive diagnostics and crash investigation.
 
 .PARAMETER NodeReuse
 	Controls MSBuild node reuse (/nr). Accepts true, false, or auto.
@@ -183,7 +183,7 @@ param(
 	[switch]$InstallerOnly,
 	[switch]$ForceInstallerOnly,
 	[switch]$SignInstaller,
-	[switch]$TraceCrashes,
+	[switch]$EnableTracing,
 	[switch]$UseLocalLcm,
 	[string]$LocalLcmPath,
 	[ValidateSet('user', 'agent', 'unknown')]
@@ -193,6 +193,14 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+$runningOnWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+if (-not $runningOnWindows) {
+	Write-Host "[ERROR] FieldWorks builds are disabled on non-Windows hosts." -ForegroundColor Red
+	Write-Host "Linux and macOS are supported for editing, code search, specs, and documentation only." -ForegroundColor Yellow
+	Write-Host "Run build.ps1 on Windows if you need build output." -ForegroundColor Yellow
+	exit 1
+}
 
 if (-not $PSBoundParameters.ContainsKey('StartedBy') -and -not [string]::IsNullOrWhiteSpace($env:FW_BUILD_STARTED_BY)) {
 	$startedByFromEnv = $env:FW_BUILD_STARTED_BY.ToLowerInvariant()
@@ -205,13 +213,13 @@ if (-not $PSBoundParameters.ContainsKey('StartedBy') -and -not [string]::IsNullO
 $env:PATH = "$env:WIX/bin;$env:PATH"
 
 if ($Configuration -like "--*") {
-	if ($Configuration -eq "--TraceCrashes" -and -not $TraceCrashes) {
-		$TraceCrashes = $true
+	if ($Configuration -eq "--EnableTracing" -and -not $EnableTracing) {
+		$EnableTracing = $true
 		$Configuration = "Debug"
-		Write-Output "[WARN] Detected '--TraceCrashes' passed without PowerShell switch parsing. Using -TraceCrashes and defaulting Configuration to Debug."
+		Write-Output "[WARN] Detected '--EnableTracing' passed without PowerShell switch parsing. Using -EnableTracing and defaulting Configuration to Debug."
 	}
 	else {
-		throw "Invalid Configuration value '$Configuration'. Use -TraceCrashes (single dash) for the trace option."
+		throw "Invalid Configuration value '$Configuration'. Use -EnableTracing (single dash) for trace-enabled builds."
 	}
 }
 
@@ -516,6 +524,15 @@ try {
 		# Clean stale per-project obj/ folders
 		Remove-StaleObjFolders -RepoRoot $PSScriptRoot
 
+		$normalizedProjectPath = [System.IO.Path]::GetFullPath($projectPath)
+		$testViewsProjectPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'Src\views\Test\TestViews.vcxproj'))
+		if (-not $SkipNative -and ($normalizedProjectPath -eq $testViewsProjectPath) -and (Test-ViewsNativeArtifactsStale -RepoRoot $PSScriptRoot -Configuration $Configuration)) {
+			Write-Host "[INFO] Views native artifacts are stale; refreshing NativeBuild before building TestViews." -ForegroundColor Yellow
+			Invoke-MSBuild `
+				-Arguments @('Build/Src/NativeBuild/NativeBuild.csproj', '/t:Build', "/p:Configuration=$Configuration", "/p:Platform=$Platform", '/p:BuildNativeTests=true', '/v:minimal', '/nologo') `
+				-Description 'NativeBuild (Freshness Refresh)'
+		}
+
 		# LT-22382: Remove stale first-party DLLs from the output directory before building.
 		# Uses a whitelist of assembly names from Src/**/*.csproj to identify FW assemblies
 		# and checks their major version against FWMAJOR. See Build\Agent\Remove-StaleDlls.ps1.
@@ -568,7 +585,7 @@ try {
 		$installerMsBuildArgs = $finalMsBuildArgs
 
 		# Args specific to the main build (not the installer)
-		if ($TraceCrashes) {
+		if ($EnableTracing) {
 			$finalMsBuildArgs += "/p:UseDevTraceConfig=true"
 		}
 		$finalMsBuildArgs += "/p:CL_MPCount=$mpCount"

--- a/scripts/Agent/Git-Search.ps1
+++ b/scripts/Agent/Git-Search.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 	Git helper for cross-worktree and cross-branch operations.
 
@@ -81,19 +81,22 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Determine repository path
+# Assume current path is repo path and then verify it is the correct repo
 if (-not $RepoPath) {
-	# Try to find FieldWorks main repo
 	$candidates = @(
-		'C:\Users\johnm\Documents\repos\FieldWorks',
-		'C:\Users\johnm\Documents\repos\fw-worktrees\main',
-		(Get-Location).Path
-	)
+		(Get-Location).Path,
+		[System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+	) | Select-Object -Unique
+
 	foreach ($candidate in $candidates) {
-		if (Test-Path (Join-Path $candidate '.git')) {
+		if (Test-Path -Path (Join-Path $candidate '.git')) {
 			$RepoPath = $candidate
 			break
 		}
+	}
+
+	if (-not $RepoPath) {
+		throw "Current directory is not a git repository and the script could not infer the repo root. Specify -RepoPath explicitly."
 	}
 }
 

--- a/scripts/toolshims/environ.cmd
+++ b/scripts/toolshims/environ.cmd
@@ -1,6 +1,7 @@
-@echo off
+﻿@echo off
 :: DEPRECATED shim: the repository no longer uses `environ` files.
 :: Running this script will print a short notice and return success.
 echo This repository no longer uses 'environ' files.
-echo Use 'build.ps1' (Windows) or './build.sh' (Linux/macOS) to build and run FieldWorks.
+echo FieldWorks build and test workflows are Windows-only.
+echo On Linux or macOS, use this repo for editing, search, docs, and review work only.
 exit /b 0

--- a/scripts/toolshims/environ.cmd
+++ b/scripts/toolshims/environ.cmd
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 :: DEPRECATED shim: the repository no longer uses `environ` files.
 :: Running this script will print a short notice and return success.
 echo This repository no longer uses 'environ' files.


### PR DESCRIPTION
## Summary

This is a focused non-render cleanup for FieldWorks build, test, and installer reliability. It does not change product UI behavior; it makes local and CI workflows easier to reason about after branch switches, interrupted builds, installer work, and machine-specific test output.

## What changed and why

### Build and native-test reliability

- Add shared timestamp helpers in `Build/Agent/FwBuildHelpers.psm1` and use them from `build.ps1` / `Build/scripts/Invoke-CppTest.ps1` to detect stale Views/FwKernel native artifacts before building or running `TestViews`.
- Keep the freshness scan targeted by enumerating matching file patterns directly and including native project/build inputs such as `*.vcxproj`, `*.props`, `*.targets`, `*.inl`, and related files.
- Rationale: after branch switches or partial native builds, generated headers and native artifacts can exist but be older than their inputs. Treating "exists" as "fresh" leads to confusing downstream build/test failures.

### SDK-style build hygiene

- Set default `SolutionDir` / `SolutionName` in `Directory.Build.props` for nested SDK-style projects.
- Exclude known stale WPF temp project file types from SDK auto-globbing and clean those files before `MarkupCompilePass2` for WPF projects.
- Rationale: deeply nested test projects do not always infer solution metadata correctly, and interrupted WPF builds can leave temporary project files behind that break the next build. FieldWorks is mostly WinForms, but `ParserUI` contains a small WPF/XAML surface.

### Installer dependency and packaging cleanup

- Keep WiX DTF package versions centralized under `FLExInstaller/Directory.Packages.props` while keeping them scoped to installer projects.
- Remove explicit WiX package versions from the WiX 6 custom actions project.
- Adjust legacy installer harvesting so `ScrChecks.dll` / `ScrChecks.pdb` are treated consistently with files supplied from `DistFiles\Editorial Checks`.
- Rationale: installer package versions belong with installer-specific package policy, not scattered through individual projects or the root package map.

### Platform and diagnostics clarity

- Make `build.ps1` fail fast on non-Windows hosts and clarify in docs that Linux/macOS are useful for editing, search, docs, specs, and agent review, but not FieldWorks build/test/installer runs.
- Rename the preferred trace build switch to `-EnableTracing`, while keeping `-TraceCrashes` and the legacy `--TraceCrashes` fallback for compatibility.
- Simplify `Src/AppForTests.config` trace listener type binding so the test config is less tied to a specific assembly version string.
- Rationale: FieldWorks is a Windows/x64 build/test target. The scripts and docs now say that plainly, without breaking existing local trace commands.

### Agent helper and whitespace tooling cleanup

- Make `Verify-FwDependencies.ps1` handle singleton pipeline results as arrays so summary counts stay reliable.
- Make `Build/Agent/fix-whitespace.ps1` use explicit UTF-8 encodings, preserve existing BOM state for ordinary text files, and force BOM-less output only for `.cmd` / `.bat` entrypoint scripts.
- Make `scripts/Agent/Git-Search.ps1` prefer the current repo/worktree when inferring its root.
- Rationale: these are small reliability fixes for the repo's agent-facing helper scripts, and the whitespace tool should not create noisy encoding-only churn.

### Deterministic TonePars comparison

- Normalize absolute Windows path prefixes in `ToneParsInvokerTests` before comparing generated command content.
- Rationale: the test should verify generated command semantics, not the developer machine's absolute temp or repo path.

## Scope notes

- No `Src/xWorks` changes are included.
- No AI review workflow or generic code-review-skill changes are included; that work belongs in #905.
- This PR is intentionally non-render cleanup. Render-speedup and xWorks command-routing work are separate.

## Validation

- `CI: Commit messages` passed after the review-fix commit.
- `CI: Whitespace check` reported `No problems found` after the review-fix commit. Its fixer step tried to normalize unrelated files because `origin/main` advanced; that validation-time churn was discarded.
- Focused checks passed after the review-fix commit: `build.ps1` parses, `Build/Agent/fix-whitespace.ps1` parses, `FwBuildHelpers.psm1` imports, `-TraceCrashes` is registered as an alias for `-EnableTracing`, `scripts/toolshims/environ.cmd` has no UTF-8 BOM, and the timestamp helper smoke test passed.
- Earlier during this cleanup branch, `shell: Build` passed before the final PR recreation.
- Earlier during this cleanup branch, `shell: Test` passed before the final PR recreation: 4150 total, 4090 passed, 60 skipped.
- Product build/test were not rerun after the review-fix commit.

## Reviewer focus

- Native artifact freshness logic in `Build/Agent/FwBuildHelpers.psm1`, `build.ps1`, and `Build/scripts/Invoke-CppTest.ps1`.
- SDK-style defaults and WPF temp project cleanup in `Directory.Build.props` / `Directory.Build.targets`.
- Installer package scoping in `FLExInstaller/Directory.Packages.props` and the WiX custom actions project.
- Trace switch compatibility in `build.ps1`.
- BOM handling in `Build/Agent/fix-whitespace.ps1` and `scripts/toolshims/environ.cmd`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/908)
<!-- Reviewable:end -->
