### PR TITLE
Fix patch installer after ManagedVwWindow removal

### DIFF
--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -113,6 +113,9 @@
 	<Target Name="RescuePatching">
 		<ItemGroup>
 			<!-- <RemovedSinceLastBase Include="$(dir-outputBase)/Helps/WW-ConceptualIntro/ConceptualIntroduction.htm" /> -->
+			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll.config" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.pdb" />
 		</ItemGroup>
 		<WriteLinesToFile
 			File="%(RemovedSinceLastBase.FullPath)"


### PR DESCRIPTION
## Summary
- Adds `ManagedVwWindow.dll`, `ManagedVwWindow.dll.config`, and `ManagedVwWindow.pdb` to the existing `RescuePatching` placeholders.
- Keeps the retired Linux-era shim removed while preserving the legacy patch installer component graph for the current base build.
- Fixes the post-merge Patch Installer failure from https://github.com/sillsdev/FieldWorks/actions/runs/26286364180, where Pyro reported `PYRO0305` because those base components disappeared from the update harvest.

## Verification
- Confirmed the failing CI log reported `PYRO0305` for the three `ManagedVwWindow` components in `PatchableInstaller/CreateUpdatePatch/Master/AppHarvest.wxs`.
- Ran the focused placeholder check for all three files.
- Ran MSBuild target `Setup;RescuePatching` and verified all three placeholders were created as zero-byte files under `Output\Release`.
- Ran `Build\Agent\Remove-StaleDlls.ps1 -OutputDir "Output\Release" -RepoRoot "." -ReferenceDir "Output\Release" -ValidateOnly` and it accepted the placeholders.
- Ran `CI: Commit messages` locally; no gitlint errors were reported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/909)
<!-- Reviewable:end -->
