### PR TITLE
Fix new case for LT-11746: Make Preview aware of publication choice

### DIFF
--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -267,7 +267,10 @@ namespace SIL.FieldWorks.XWorks
 			// commented out until conditions are clarified (LT-11447)
 			string configurationName = DictionaryConfigurationListener.GetCurrentConfiguration(propertyTable, false);
 			var configuration = new DictionaryConfigurationModel(configurationName, cache);
-			if (entry.EntryRefsOS.Count > 0 && !entry.PublishAsMinorEntry && configuration.IsRootBased)
+			if (entry.EntryRefsOS.Count > 0 && !entry.PublishAsMinorEntry &&
+				(configuration.Type == DictionaryConfigurationModel.ConfigType.Hybrid ||
+				 configuration.Type == DictionaryConfigurationModel.ConfigType.Lexeme ||
+				 configuration.Type == DictionaryConfigurationModel.ConfigType.Root))
 			{
 				xrc = DictionaryConfigurationController.ExclusionReasonCode.ExcludedMinorEntry;
 				return false;


### PR DESCRIPTION
This fixes a new case in https://jira.sil.org/browse/LT-11746 that was reported in the comments by Kevin Warfel that is related to minor entries.  A warning message should be displayed for Lexeme-based and Hybrid-based configurations as well as Root-based when a minor entry is not to be shown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/911)
<!-- Reviewable:end -->
