### PR TITLE
Fix LT-22530: Error message when cutting in Concordance view

### DIFF
--- a/Src/Common/SimpleRootSite/EditingHelper.cs
+++ b/Src/Common/SimpleRootSite/EditingHelper.cs
@@ -3257,9 +3257,17 @@ namespace SIL.FieldWorks.Common.RootSites
 		/// </summary>
 		protected virtual void DeleteSelectionTask(string undoLabel, string redoLabel)
 		{
-			Callbacks.EditedRootBox.DataAccess.GetActionHandler().BeginUndoTask(undoLabel, redoLabel);
-			DeleteSelection();
-			Callbacks.EditedRootBox.DataAccess.GetActionHandler().EndUndoTask();
+			IActionHandler actionHandler = Callbacks.EditedRootBox.DataAccess.GetActionHandler();
+			if (actionHandler != null)
+			{
+				actionHandler.BeginUndoTask(undoLabel, redoLabel);
+				DeleteSelection();
+				actionHandler.EndUndoTask();
+			}
+			else
+			{
+				DeleteSelection();
+			}
 		}
 
 		/// -----------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22530.  It was crashing when there wasn't an action handler.  I decided to call DeleteSelection non-undoably in this case since the user can also delete the text by typing into the selection.  Not that changing the text does anything.  If the user wants to start a new search, they need to use "Specify concordance criteria...".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/913)
<!-- Reviewable:end -->
