### PR TITLE
Fix intermittent access violation in RenderBenchmark tests

### DIFF
--- a/Src/Common/RootSite/RootSiteTests/RenderTimingSuiteTests.cs
+++ b/Src/Common/RootSite/RootSiteTests/RenderTimingSuiteTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.RootSites.RenderBenchmark;
 using SIL.FieldWorks.Common.RenderVerification;
@@ -15,6 +16,7 @@ namespace SIL.FieldWorks.Common.RootSites
 	[TestFixture]
 	[Category("RenderBenchmark")]
 	[Category("Performance")]
+	[Apartment(ApartmentState.STA)]
 	public class RenderTimingSuiteTests : RenderBenchmarkTestsBase
 	{
 		private static List<BenchmarkResult> m_results;

--- a/Src/Common/RootSite/RootSiteTests/RenderVerifyTests.cs
+++ b/Src/Common/RootSite/RootSiteTests/RenderVerifyTests.cs
@@ -3,6 +3,7 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.RootSites.RenderBenchmark;
@@ -22,6 +23,7 @@ namespace SIL.FieldWorks.Common.RootSites
 	/// </summary>
 	[TestFixture]
 	[Category("RenderBenchmark")]
+	[Apartment(ApartmentState.STA)]
 	public class RenderVerifyTests : RenderBenchmarkTestsBase
 	{
 		/// <summary>


### PR DESCRIPTION
## Summary
- Add `[Apartment(ApartmentState.STA)]` to `RenderTimingSuiteTests` and `RenderVerifyTests`
- Views COM objects (`VwGraphicsWin32Class`, `_VwRootBoxClass`) require STA threading — without the attribute, NUnit runs these on an MTA thread, causing intermittent access violations during `RootBox.Layout` in CI
- The sibling `StVcTests` fixture already had this attribute correctly

## Test plan
- [ ] Verify RenderBenchmark tests pass consistently in CI (previously intermittent AV failures)
- [ ] Confirm no regression in other RootSite tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/919)
<!-- Reviewable:end -->
