### PR TITLE
Add ParserCore.dll.config and FwUtils.dll.config to rescue patching

### DIFF
--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -116,6 +116,8 @@
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll" />
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll.config" />
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.pdb" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/ParserCore.dll.config" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/FwUtils.dll.config" />
 		</ItemGroup>
 		<WriteLinesToFile
 			File="%(RemovedSinceLastBase.FullPath)"


### PR DESCRIPTION
## Summary

- Added `ParserCore.dll.config` and `FwUtils.dll.config` to the `RescuePatching` target in `Build/Installer.legacy.targets`
- These config files were removed since the last base installer build; without placeholder entries the patchable installer cannot generate a valid patch

## Background

The `RescuePatching` target writes empty placeholder files for anything that was present in the base build but has since been removed. This lets the patch diffing process succeed even when files disappear between base builds.

## Test plan

- [ ] Verify the patchable installer build completes without errors related to missing `ParserCore.dll.config` or `FwUtils.dll.config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/920)
<!-- Reviewable:end -->
