### PR TITLE
LT-21401: Part 1 - Move FollowLink to Pub/Sub

### DIFF
--- a/Src/Common/Controls/DetailControls/StringSlice.cs
+++ b/Src/Common/Controls/DetailControls/StringSlice.cs
@@ -13,6 +13,7 @@ using SIL.FieldWorks.Common.RootSites;
 using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using XCore;
 
 namespace SIL.FieldWorks.Common.Framework.DetailControls
@@ -333,10 +334,10 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 						{
 							FwLinkArgs linkArgs = new FwLinkArgs(url);
 							linkArgs.DisplayErrorMsg = false;
-#pragma warning disable 618 // suppress obsolete warning
-							if (m_mediator.SendMessage("FollowLink", linkArgs))
+							var retObj = new ReturnObject(linkArgs);
+							Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, retObj));
+							if (retObj.ReturnValue)
 								return;
-#pragma warning restore 618
 						}
 					}
 					catch

--- a/Src/Common/Controls/XMLViews/XmlBrowseViewBaseVc.cs
+++ b/Src/Common/Controls/XMLViews/XmlBrowseViewBaseVc.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Reflection; // for check-box icons.
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
@@ -1765,10 +1766,10 @@ namespace SIL.FieldWorks.Common.Controls
 					{
 						FwLinkArgs linkArgs = new FwLinkArgs(url);
 						linkArgs.DisplayErrorMsg = false;
-#pragma warning disable 618 // suppress obsolete warning
-						if (m_xbv.Mediator.SendMessage("FollowLink", linkArgs))
+						var retObj = new ReturnObject(linkArgs);
+						Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, retObj));
+						if (retObj.ReturnValue)
 							return;
-#pragma warning restore 618
 					}
 				}
 				catch

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -288,9 +288,7 @@ namespace SIL.FieldWorks.IText
 				return false;
 			if (!InDesiredTool("interlinearEdit"))
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("FollowLink", new FwLinkArgs("interlinearEdit", CurrentObject.Guid));
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("interlinearEdit", CurrentObject.Guid)));
 			}
 			// This is a workable alternative (where link is the one created above), but means this code has to know about the FwXApp class.
 			//(FwXApp.App as FwXApp).OnIncomingLink(link);

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -290,12 +290,6 @@ namespace SIL.FieldWorks.IText
 			{
 				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("interlinearEdit", CurrentObject.Guid)));
 			}
-			// This is a workable alternative (where link is the one created above), but means this code has to know about the FwXApp class.
-			//(FwXApp.App as FwXApp).OnIncomingLink(link);
-			// This alternative does NOT work; it produces a deadlock...I think the remote code is waiting for the target app
-			// to return to its message loop, but it never does, because it is the same app that is trying to send the link, so it is busy
-			// waiting for 'Activate' to return!
-			//link.Activate();
 			return true;
 		}
 

--- a/Src/LexText/Lexicon/LexReferenceMultiSlice.cs
+++ b/Src/LexText/Lexicon/LexReferenceMultiSlice.cs
@@ -20,6 +20,7 @@ using SIL.LCModel.Utils;
 using SIL.FieldWorks.Common.Framework.DetailControls;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.Utils;
 using XCore;
@@ -756,9 +757,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			ILexRefType newKid = list.Services.GetInstance<ILexRefTypeFactory>().Create();
 			list.PossibilitiesOS.Add(newKid);
 			m_cache.DomainDataByFlid.EndUndoTask();
-#pragma warning disable 618 // suppress obsolete warning
-			ContainingDataTree.Mediator.SendMessage("FollowLink", new FwLinkArgs("lexRefEdit", newKid.Guid));
-#pragma warning restore 618
+			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexRefEdit", newKid.Guid)));
 		}
 
 		protected void ExpandNewNode()

--- a/Src/xWorks/FwXApp.cs
+++ b/Src/xWorks/FwXApp.cs
@@ -11,6 +11,7 @@ using SIL.LCModel;
 using SIL.FieldWorks.Common.Framework;
 using SIL.LCModel.Utils;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -199,9 +200,7 @@ namespace SIL.FieldWorks.XWorks
 			FwXWindow fwxwnd = m_rgMainWindows.Count > 0 ? (FwXWindow)m_rgMainWindows[0] : null;
 			if (fwxwnd != null)
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				fwxwnd.Mediator.SendMessage("FollowLink", link);
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, link));
 				bool topmost = fwxwnd.TopMost;
 				fwxwnd.TopMost = true;
 				fwxwnd.TopMost = topmost;

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -2283,9 +2283,7 @@ namespace SIL.FieldWorks.XWorks
 
 			if (m_startupLink != null)
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("FollowLink", m_startupLink);
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, m_startupLink));
 			}
 			UpdateControls();
 			return true;

--- a/Src/xWorks/LinkListener.cs
+++ b/Src/xWorks/LinkListener.cs
@@ -147,6 +147,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				Subscriber.Unsubscribe(EventConstants.AddContextToHistory, AddContextToHistory);
 				Subscriber.Unsubscribe(EventConstants.HandleLocalHotlink, HandleLocalHotlink);
+				Subscriber.Unsubscribe(EventConstants.FollowLink, FollowLink);
 
 				// Dispose managed resources here.
 				if (m_mediator != null)
@@ -196,6 +197,7 @@ namespace SIL.FieldWorks.XWorks
 
 			Subscriber.Subscribe(EventConstants.AddContextToHistory, AddContextToHistory);
 			Subscriber.Subscribe(EventConstants.HandleLocalHotlink, HandleLocalHotlink);
+			Subscriber.Subscribe(EventConstants.FollowLink, FollowLink);
 		}
 
 		/// <summary>
@@ -416,10 +418,40 @@ namespace SIL.FieldWorks.XWorks
 			CheckDisposed();
 			LcmCache cache = m_propertyTable.GetValue<LcmCache>("cache");
 			Guid[] guids = (from entry in cache.LanguageProject.LexDbOA.Entries select entry.Guid).ToArray();
-#pragma warning disable 618 // suppress obsolete warning
-			m_mediator.SendMessage("FollowLink", new FwLinkArgs("lexiconEdit", guids[guids.Length - 1]));
-#pragma warning restore 618
+			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexiconEdit", guids[guids.Length - 1])));
 			return true;
+		}
+
+		/// <summary>
+		/// Method to handle published messages for FollowLink.
+		/// NOTE: This will not handle link requests for other databases/applications. To handle other
+		/// databases or applications, pass a FwAppArgs to the IFieldWorksManager.HandleLinkRequest method.
+		/// </summary>
+		/// <param name="obj">Either a bare FwLinkArgs, or a ReturnObject wrapping a FwLinkArgs for
+		/// callers that need to know whether the link was followed (via its ReturnValue).</param>
+		private void FollowLink(object obj)
+		{
+			CheckDisposed();
+
+			// Callers that need to know whether the link was followed wrap the FwLinkArgs in a
+			// ReturnObject and read its ReturnValue.
+			if (obj is ReturnObject retObj)
+			{
+				if (!(retObj.Data is FwLinkArgs))
+				{
+					Debug.Assert(false, "Received unexpected object type.");
+					return;
+				}
+				retObj.ReturnValue = OnFollowLink(retObj.Data);
+				return;
+			}
+
+			if (!(obj is FwLinkArgs))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			OnFollowLink(obj);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This replaces the easy Mediator.SendMessage() calls that execute immediately. The more difficult Mediator.PostMessage() calls, that execute OnIdle, will be in separate changes.

These changes are very similar to the changes that are in commit b886d2e8, in the PubSub branch. The changes were done using AI instead of a cherry-pick, mainly to avoid regressing commit 42aad335 (which fixed FollowLink defect LT-20930).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/921)
<!-- Reviewable:end -->
