### PR TITLE
Exclude .wav files from Webonary upload

### DIFF
--- a/Src/xWorks/UploadToWebonaryController.cs
+++ b/Src/xWorks/UploadToWebonaryController.cs
@@ -590,7 +590,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var supportedFileExtensions = new List<string>
 			{
-				".xhtml", ".css", ".html", ".htm", ".json", ".xml", ".wav",
+				".xhtml", ".css", ".html", ".htm", ".json", ".xml",
 				".jpg", ".jpeg", ".gif", ".png", ".mp3", ".mp4", ".3gp", ".webm"
 			};
 			return supportedFileExtensions.Any(path.ToLowerInvariant().EndsWith);

--- a/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
@@ -329,7 +329,7 @@ namespace SIL.FieldWorks.XWorks
 
 			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.mp3"), Is.True);
 			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.MP4"), Is.True); // avoid failure because of capitalization
-			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.wav"), Is.True);
+			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.wav"), Is.False);
 			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.webm"), Is.True);
 
 			Assert.That(UploadToWebonaryController.IsSupportedWebonaryFile("foo.wmf"), Is.False);


### PR DESCRIPTION
## Summary
- Removed `.wav` from the supported file extensions in `IsSupportedWebonaryFile`, so raw `.wav` files are no longer uploaded to Webonary.
- The export pipeline already converts `.wav` to `.mp3` via `WavConverter.WavToMp3` in `CopyFileSafely` when `IsWebExport` is true. However, `.wav` was still listed as a supported upload format, meaning any `.wav` that survived into the export directory (e.g. if conversion failed) would be uploaded as-is -- large, uncompressed, and unintended.
- Updated the corresponding test assertion to expect `.wav` to be rejected.

## Test plan
- [ ] `IsSupportedWebonaryFile_reportsAccurately` test passes with updated assertion

Created in collaboration with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/922)
<!-- Reviewable:end -->
