### PR TITLE
Fix LT-22529: both allo and variant generators get wrong title

### DIFF
--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenForm.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenForm.cs
@@ -2,23 +2,15 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using Microsoft.Win32;
 using SIL.AlloGenModel;
 using SIL.AlloGenService;
-using SIL.AllomorphGenerator;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
-using SIL.LCModel.Infrastructure;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using XCore;
 

--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
@@ -3,32 +3,24 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using Microsoft.Win32;
-using PtxUtils;
 using SIL.AlloGenModel;
 using SIL.AlloGenService;
-using SIL.FieldWorks.Common.Controls;
 using SIL.FieldWorks.Common.FwUtils;
-using SIL.FieldWorks.Common.ViewsInterfaces;
 using SIL.FieldWorks.Common.Widgets;
-using SIL.FieldWorks.Filters;
 using SIL.FieldWorks.FwCoreDlgs;
 using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
-using SIL.Utils;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using XCore;
 using static SIL.AlloGenService.FLExCustomFieldsObtainer;
@@ -1381,15 +1373,15 @@ namespace SIL.AllomorphGenerator
 
 		protected void ShowChangeStatusOnForm()
 		{
-			if (AlloGenForm.ActiveForm != null)
+			const string kStar = "*";
+			bool hasStar = Text.EndsWith(kStar);
+			if (ChangesMade && !hasStar)
 			{
-				const string kStar = "*";
-				if (ActiveForm.Text.EndsWith(kStar))
-				{
-					ActiveForm.Text = ActiveForm.Text.Substring(0, ActiveForm.Text.Length-1);
-				}
-				if (ChangesMade)
-					ActiveForm.Text += kStar;
+				Text += kStar;
+			}
+			else if (!ChangesMade && hasStar)
+			{
+				Text = Text.Substring(0, Text.Length - 1);
 			}
 		}
 

--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
@@ -3,6 +3,7 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using Microsoft.Win32;
+using PtxUtils;
 using SIL.AlloGenModel;
 using SIL.AlloGenService;
 using SIL.FieldWorks.Common.Controls;
@@ -94,7 +95,6 @@ namespace SIL.AllomorphGenerator
 		protected ListBox currentListBox;
 		protected ContextMenuStrip editContextMenu;
 		protected ContextMenuStrip editReplaceOpsContextMenu;
-		protected string formTitle = AllomorphGeneratorDll_Strings.ksTitle;
 		protected string cmAdd = AllomorphGeneratorDll_Strings.cmAdd;
 		protected string cmEdit = AllomorphGeneratorDll_Strings.cmEdit;
 		protected string cmInsertBefore = AllomorphGeneratorDll_Strings.cmInsertBefore;
@@ -1383,9 +1383,13 @@ namespace SIL.AllomorphGenerator
 		{
 			if (AlloGenForm.ActiveForm != null)
 			{
-				AlloGenForm.ActiveForm.Text = formTitle;
+				const string kStar = "*";
+				if (ActiveForm.Text.EndsWith(kStar))
+				{
+					ActiveForm.Text = ActiveForm.Text.Substring(0, ActiveForm.Text.Length-1);
+				}
 				if (ChangesMade)
-					AlloGenForm.ActiveForm.Text += "*";
+					ActiveForm.Text += kStar;
 			}
 		}
 

--- a/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
+++ b/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
@@ -2,24 +2,18 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using Microsoft.Win32;
 using SIL.AlloGenModel;
 using SIL.AlloGenService;
 using SIL.AllomorphGenerator;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
-using SIL.LCModel.Infrastructure;
 using SIL.VarGenService;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using XCore;
 

--- a/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
+++ b/Src/Utilities/AlloVarGen/VariantGeneratorDll/VariantGenForm.cs
@@ -67,7 +67,6 @@ namespace SIL.VariantGenerator
 				InitializePublishEntryInControls();
 				SetBackColor();
 				this.Text = VariantGeneratorDll_Strings.ksTitle;
-				formTitle = VariantGeneratorDll_Strings.ksTitle;
 			}
 			// Create an instance of a ListView column sorter and assign it
 			// to the ListView control.


### PR DESCRIPTION
When starting both the Allomorph and Variant Generator utilties at the same time, the title of one of them had the title for the other.
The solution is to remove the formTitle variable and just use the form's actual title.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/927)
<!-- Reviewable:end -->
