### PR TITLE
Add missing manifest files to RescuePatching

### DIFF
--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -116,6 +116,8 @@
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll" />
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.dll.config" />
 			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.pdb" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/ManagedVwWindow.manifest" />
+			<RemovedSinceLastBase Include="$(dir-outputBase)/SimpleRootSite.manifest" />
 		</ItemGroup>
 		<WriteLinesToFile
 			File="%(RemovedSinceLastBase.FullPath)"


### PR DESCRIPTION
## Summary
- PR #909 added `ManagedVwWindow.dll`, `.dll.config`, and `.pdb` to `RescuePatching` but missed two manifest files that were also removed by #906
- Adds `ManagedVwWindow.manifest` and `SimpleRootSite.manifest` to the `RescuePatching` target, fixing PYRO0305 errors during patch builds against base 1437

## Test plan
- [ ] Patch installer builds successfully without PYRO0305 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/929)
<!-- Reviewable:end -->
