### PR TITLE
LT-20524: Resolve install directories in silent (/quiet) installs

### DIFF
--- a/FLExInstaller/Directory.Packages.props
+++ b/FLExInstaller/Directory.Packages.props
@@ -9,7 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Installer Packages">
+		<PackageVersion Include="System.Resources.Extensions" Version="9.0.16" />
+		<PackageVersion Include="WixToolset.Bal.wixext" Version="6.0.2" />
 		<PackageVersion Include="WixToolset.Dtf.CustomAction" Version="6.0.0" />
 		<PackageVersion Include="WixToolset.Dtf.WindowsInstaller" Version="6.0.0" />
+		<PackageVersion Include="WixToolset.Heat" Version="6.0.2" />
+		<PackageVersion Include="WixToolset.NetFx.wixext" Version="6.0.2" />
+		<PackageVersion Include="WixToolset.UI.wixext" Version="6.0.2" />
+		<PackageVersion Include="WixToolset.Util.wixext" Version="6.0.2" />
 	</ItemGroup>
 </Project>

--- a/FLExInstaller/wix6/FieldWorks.Bundle.wixproj
+++ b/FLExInstaller/wix6/FieldWorks.Bundle.wixproj
@@ -38,9 +38,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.Bal.wixext" Version="6.0.2" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="6.0.2" />
-    <PackageReference Include="WixToolset.NetFx.wixext" Version="6.0.2" />
+  <PackageReference Include="WixToolset.Bal.wixext" />
+  <PackageReference Include="WixToolset.Util.wixext" />
+  <PackageReference Include="WixToolset.NetFx.wixext" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FLExInstaller/wix6/FieldWorks.Installer.wixproj
+++ b/FLExInstaller/wix6/FieldWorks.Installer.wixproj
@@ -13,8 +13,10 @@
 	  Installer validation:
 	  - Harvested inputs include many versionless resource/data files that trigger ICE60.
 	  - We intentionally allow downgrades (single-instance policy), which triggers ICE61.
+	  - Newtonsoft.Json is intentionally authored as both a private copy and a GAC assembly to match
+	    the legacy installer, which triggers ICE30 under WiX 6 validation.
 	-->
-	<SuppressIces>ICE60;ICE61</SuppressIces>
+	<SuppressIces>ICE30;ICE60;ICE61</SuppressIces>
   </PropertyGroup>
 
   <!--
@@ -74,10 +76,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="WixToolset.UI.wixext" Version="6.0.2" />
-	<PackageReference Include="WixToolset.Util.wixext" Version="6.0.2" />
-	<PackageReference Include="WixToolset.NetFx.wixext" Version="6.0.2" />
-	<PackageReference Include="WixToolset.Heat" Version="6.0.2" />
+	<PackageReference Include="WixToolset.UI.wixext" />
+	<PackageReference Include="WixToolset.Util.wixext" />
+	<PackageReference Include="WixToolset.NetFx.wixext" />
+	<PackageReference Include="WixToolset.Heat" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FLExInstaller/wix6/FieldWorks.OfflineBundle.wixproj
+++ b/FLExInstaller/wix6/FieldWorks.OfflineBundle.wixproj
@@ -38,9 +38,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.Bal.wixext" Version="6.0.2" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="6.0.2" />
-    <PackageReference Include="WixToolset.NetFx.wixext" Version="6.0.2" />
+  <PackageReference Include="WixToolset.Bal.wixext" />
+  <PackageReference Include="WixToolset.Util.wixext" />
+  <PackageReference Include="WixToolset.NetFx.wixext" />
+  </ItemGroup>
+
+  <ItemGroup>
+  <WixExtension Include="WixToolset.BootstrapperApplications.wixext">
+    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.bal.wixext\6.0.2\wixext6\WixToolset.BootstrapperApplications.wixext.dll</HintPath>
+  </WixExtension>
+  <WixExtension Include="WixToolset.Util.wixext">
+    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.util.wixext\6.0.2\wixext6\WixToolset.Util.wixext.dll</HintPath>
+  </WixExtension>
+  <WixExtension Include="WixToolset.Netfx.wixext">
+    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.netfx.wixext\6.0.2\wixext6\WixToolset.Netfx.wixext.dll</HintPath>
+  </WixExtension>
   </ItemGroup>
 
   <ItemGroup>

--- a/FLExInstaller/wix6/FieldWorks.OfflineBundle.wixproj
+++ b/FLExInstaller/wix6/FieldWorks.OfflineBundle.wixproj
@@ -44,18 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <WixExtension Include="WixToolset.BootstrapperApplications.wixext">
-    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.bal.wixext\6.0.2\wixext6\WixToolset.BootstrapperApplications.wixext.dll</HintPath>
-  </WixExtension>
-  <WixExtension Include="WixToolset.Util.wixext">
-    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.util.wixext\6.0.2\wixext6\WixToolset.Util.wixext.dll</HintPath>
-  </WixExtension>
-  <WixExtension Include="WixToolset.Netfx.wixext">
-    <HintPath>$(MSBuildProjectDirectory)\..\..\packages\wixtoolset.netfx.wixext\6.0.2\wixext6\WixToolset.Netfx.wixext.dll</HintPath>
-  </WixExtension>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="Shared\Base\OfflineBundle.wxs" />
   </ItemGroup>
 

--- a/FLExInstaller/wix6/Shared/Base/Framework.wxs
+++ b/FLExInstaller/wix6/Shared/Base/Framework.wxs
@@ -67,6 +67,23 @@
 	  <Custom Action="DeleteRegistryVersionNumber" Before="RemoveRegistryValues" Condition="(NOT UPGRADINGPRODUCTCODE) AND (REMOVE=&quot;ALL&quot;)" />
 	  <Custom Action="CheckPatchValue" Before="CheckUpgradeValue" Condition="PATCHNEWSUMMARYSUBJECT=&quot;Small Update Patch&quot;" />
 	  <Custom Action="CheckUpgradeValue" After="InstallFinalize" Condition="WIX_UPGRADE_DETECTED" />
+	  <!-- LT-20524: The InstallUISequence does not run for silent (/quiet, /qn) or basic (/qb) installs
+	       (UILevel &lt; 4), so the directory-resolution actions below must also run here; otherwise
+	       APPFOLDER/DATAFOLDER/HARVESTDATAFOLDER stay unset and files (including the ICU data that
+	       ICU_DATA points at) install to the wrong locations. Reduced (/passive, UILevel 4) and full
+	       UI installs continue to resolve these in the InstallUISequence, so the UILevel guard keeps
+	       this from overriding a user-chosen path. VerifyDataPath populates REGDATAFOLDER (used by the
+	       conditions below) and always returns Success, so it is safe in a silent install. -->
+	  <Custom Action="SetDefDataFolder" After="FindRelatedProducts" Condition="UILevel &lt; 4" />
+	  <Custom Action="VerifyDataPath" After="SetDefDataFolder" Condition="UILevel &lt; 4" />
+	  <Custom Action="UseDefAppFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (NOT OVRAPPFOLDER)" />
+	  <Custom Action="UseOvrAppFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (OVRAPPFOLDER)" />
+	  <Custom Action="UseRegAppFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (REGAPPFOLDER)" />
+	  <Custom Action="UseDefDataFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (NOT OVRDATAFOLDER)" />
+	  <Custom Action="UseOvrDataFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (OVRDATAFOLDER)" />
+	  <Custom Action="UseRegDataFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (REGDATAFOLDER)" />
+	  <Custom Action="UseDefHarvestDataFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (NOT OVRHARVESTDATAFOLDER)" />
+	  <Custom Action="UseOvrHarvestDataFolder" After="AppSearch" Condition="(UILevel &lt; 4) and (OVRHARVESTDATAFOLDER)" />
 	  <?include ../Common/CustomActionSteps.wxi?>
 	</InstallExecuteSequence>
 

--- a/FLExInstaller/wix6/Shared/Common/CustomComponents.wxi
+++ b/FLExInstaller/wix6/Shared/Common/CustomComponents.wxi
@@ -67,12 +67,14 @@
 		<Component Id="NewtonsoftJsonApp" Guid="{B8A47C61-2E90-4D1A-9F4E-7C3B5A682D01}">
 			<File Id="NewtonsoftJsonFileApp"
 				Name="Newtonsoft.Json.dll"
+				ShortName="NJSONAPP.DLL"
 				Source="$(var.MASTERBUILDDIR)\Newtonsoft.Json.dll"
 				KeyPath="yes" />
 		</Component>
 		<Component Id="NewtonsoftJsonGac" Guid="*">
 			<File Id="NewtonsoftJsonFileGac"
 				Name="Newtonsoft.Json.dll"
+				ShortName="NJSONGAC.DLL"
 				Source="$(var.MASTERBUILDDIR)\Newtonsoft.Json.dll"
 				KeyPath="yes"
 				Assembly=".net" />

--- a/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomAction.cs
+++ b/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomAction.cs
@@ -220,9 +220,17 @@ namespace CustomActions
             try
             {
                 if (RegistryU.KeyExists(dataPathKey))
-                    projPath = RegistryU.GetKey("HKLM", "SOFTWARE\\" + path).GetValue(valueName).ToString();
+                {
+                    var value = RegistryU.GetKey("HKLM", "SOFTWARE\\" + path).GetValue(valueName);
+                    if (value != null)
+                        projPath = value.ToString();
+                }
                 if (RegistryU.KeyExists(dataPathKeyWow))
-                    projPath = RegistryU.GetKey("HKLM", "SOFTWARE\\Wow6432Node\\" + path).GetValue(valueName).ToString();
+                {
+                    var value = RegistryU.GetKey("HKLM", "SOFTWARE\\Wow6432Node\\" + path).GetValue(valueName);
+                    if (value != null)
+                        projPath = value.ToString();
+                }
             }
             catch (Exception ex)
             {

--- a/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomActions.csproj
+++ b/FLExInstaller/wix6/Shared/CustomActions/CustomActions/CustomActions.csproj
@@ -10,6 +10,7 @@
     <Content Include="CustomAction.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+  <PackageReference Include="System.Resources.Extensions" />
     <PackageReference Include="WixToolset.Dtf.CustomAction" />
     <PackageReference Include="WixToolset.Dtf.WindowsInstaller" />
   </ItemGroup>

--- a/scripts/Agent/Collect-InstallerSnapshot.ps1
+++ b/scripts/Agent/Collect-InstallerSnapshot.ps1
@@ -227,4 +227,4 @@ $json = $snapshot | ConvertTo-Json -Depth 10
 Set-Content -LiteralPath $outPath -Value $json -Encoding UTF8
 
 Write-Output "Wrote snapshot: $outPath"
-Write-Output ("UninstallEntries: {0}, RegistryRoots: {1}, Files: {2}" -f $snapshot.UninstallEntries.Count, $snapshot.Registry.Count, $snapshot.Files.Count)
+Write-Output ("UninstallEntries: {0}, RegistryRoots: {1}, Files: {2}" -f @($snapshot.UninstallEntries).Count, @($snapshot.Registry).Count, @($snapshot.Files).Count)

--- a/scripts/Agent/Compare-InstallerSnapshots.ps1
+++ b/scripts/Agent/Compare-InstallerSnapshots.ps1
@@ -29,10 +29,10 @@ function Read-Snapshot {
 }
 
 function To-StringSet {
-	param([Parameter(Mandatory = $true)][object[]]$Items)
+	param([Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Items)
 	$set = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 	foreach ($item in $Items) { $null = $set.Add([string]$item) }
-	return $set
+	return ,$set
 }
 
 function Diff-Sets {
@@ -52,6 +52,28 @@ function Diff-Sets {
 	}
 
 	return [pscustomobject]@{ Added = $added; Removed = $removed }
+}
+
+function ConvertTo-PropertyMap {
+	param([Parameter(Mandatory = $false)]$Value)
+
+	$map = @{}
+	if ($null -eq $Value) {
+		return $map
+	}
+
+	if ($Value -is [System.Collections.IDictionary]) {
+		foreach ($key in $Value.Keys) {
+			$map[[string]$key] = $Value[$key]
+		}
+		return $map
+	}
+
+	foreach ($property in $Value.PSObject.Properties) {
+		$map[[string]$property.Name] = $property.Value
+	}
+
+	return $map
 }
 
 $before = Read-Snapshot -Path $BeforeSnapshotPath
@@ -100,9 +122,9 @@ foreach ($k in $afterRegByPath.Keys) { $null = $allRegPaths.Add($k) }
 
 foreach ($path in ($allRegPaths | Sort-Object)) {
 	$beforeValues = @{}
-	if ($beforeRegByPath.ContainsKey($path)) { $beforeValues = $beforeRegByPath[$path].Values }
+	if ($beforeRegByPath.ContainsKey($path)) { $beforeValues = ConvertTo-PropertyMap -Value $beforeRegByPath[$path].Values }
 	$afterValues = @{}
-	if ($afterRegByPath.ContainsKey($path)) { $afterValues = $afterRegByPath[$path].Values }
+	if ($afterRegByPath.ContainsKey($path)) { $afterValues = ConvertTo-PropertyMap -Value $afterRegByPath[$path].Values }
 
 	$allNames = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
 	foreach ($n in $beforeValues.Keys) { $null = $allNames.Add([string]$n) }
@@ -123,7 +145,7 @@ foreach ($path in ($allRegPaths | Sort-Object)) {
 		}
 		if ([string]$bn -ne [string]$an) {
 			$regDiffCount++
-			if ($regDiffCount -le $MaxListItems) { $reportLines.Add("  ~ $path\\$n: '$bn' -> '$an'") }
+			if ($regDiffCount -le $MaxListItems) { $reportLines.Add("  ~ ${path}\\${n}: '$bn' -> '$an'") }
 		}
 	}
 }

--- a/scripts/Agent/Invoke-InstallerCheck.ps1
+++ b/scripts/Agent/Invoke-InstallerCheck.ps1
@@ -52,6 +52,31 @@ function New-DirectoryIfMissing {
 	}
 }
 
+function Invoke-InstallerWithResult {
+	param(
+		[Parameter(Mandatory = $true)]
+		[hashtable]$InstallerArguments
+	)
+
+	$result = $null
+	foreach ($item in @(& "$repoRoot\scripts\Agent\Invoke-Installer.ps1" @InstallerArguments)) {
+		if ($null -ne $item -and $item.PSObject.Properties.Match('ExitCode').Count -gt 0 -and $item.PSObject.Properties.Match('InstallerType').Count -gt 0) {
+			$result = $item
+			continue
+		}
+
+		if ($null -ne $item) {
+			Write-Host $item
+		}
+	}
+
+	if ($null -eq $result) {
+		throw "Invoke-Installer did not return a structured result."
+	}
+
+	return $result
+}
+
 $repoRoot = Resolve-RepoRoot
 
 if ([string]::IsNullOrWhiteSpace($LogRoot)) {
@@ -75,10 +100,17 @@ Write-Output "Collecting snapshot: before install"
 & "$repoRoot\scripts\Agent\Collect-InstallerSnapshot.ps1" -OutputPath $beforePath -Name 'before-install' -MaxFileCount $MaxFileCount
 
 Write-Output "Running installer"
-$installResult = & "$repoRoot\scripts\Agent\Invoke-Installer.ps1" -InstallerType $InstallerType -Configuration $Configuration -Platform $Platform -InstallerPath $InstallerPath -LogRoot $LogRoot -RunId $RunId -Arguments $InstallArguments -IncludeTempLogs -PassThru -NoExit
-
-if ($null -eq $installResult) {
-	throw "Invoke-Installer did not return a result."
+$installResult = Invoke-InstallerWithResult -InstallerArguments @{
+	InstallerType = $InstallerType
+	Configuration = $Configuration
+	Platform = $Platform
+	InstallerPath = $InstallerPath
+	LogRoot = $LogRoot
+	RunId = $RunId
+	Arguments = $InstallArguments
+	IncludeTempLogs = $true
+	PassThru = $true
+	NoExit = $true
 }
 
 $exitCode = [int]$installResult.ExitCode
@@ -97,7 +129,18 @@ if ($RunUninstall) {
 	} else {
 		Write-Output "Running uninstall"
 		$uninstallRunId = "$RunId-uninstall"
-		$uninstallResult = & "$repoRoot\scripts\Agent\Invoke-Installer.ps1" -InstallerType 'Bundle' -Configuration $Configuration -Platform $Platform -InstallerPath $InstallerPath -LogRoot $LogRoot -RunId $uninstallRunId -Arguments $UninstallArguments -IncludeTempLogs -PassThru -NoExit
+		$uninstallResult = Invoke-InstallerWithResult -InstallerArguments @{
+			InstallerType = 'Bundle'
+			Configuration = $Configuration
+			Platform = $Platform
+			InstallerPath = $InstallerPath
+			LogRoot = $LogRoot
+			RunId = $uninstallRunId
+			Arguments = $UninstallArguments
+			IncludeTempLogs = $true
+			PassThru = $true
+			NoExit = $true
+		}
 		$uninstallExit = [int]$uninstallResult.ExitCode
 		Write-Output "Uninstall exit code: $uninstallExit"
 


### PR DESCRIPTION
## Problem

[LT-20524](https://jira.sil.org/browse/LT-20524) — FieldWorks fails
to install in `/quiet` mode (PDQ Deploy / PDQ Connect / Intune).

The directory-resolution custom actions (`SetDefDataFolder`,
`VerifyDataPath`, and the `Use*AppFolder` / `Use*DataFolder` /
`Use*HarvestDataFolder` set) were scheduled **only** in the
`InstallUISequence`. Windows Installer skips that sequence for silent
(`/quiet`, `/qn`) and basic-UI (`/qb`) installs, so `APPFOLDER`,
`DATAFOLDER`, and `HARVESTDATAFOLDER` were never assigned.
Consequences:

- FieldWorks installed to `C:\Program Files\FieldWorks9` instead of
  `C:\Program Files\SIL\FieldWorks 9`.
- The harvested ICU data installed to the wrong location, while the
  `ICU_DATA` launcher command pointed at `C:\ProgramData\SIL\Icu70`.
- No shortcut was created.

`/passive` worked only because it still ran the reduced-UI sequence.

## Fix

Schedule the same directory-resolution actions in the
`InstallExecuteSequence`, guarded by `UILevel < 4` so they run **only**
when the UI sequence is skipped. Reduced (`/passive`) and full UI
installs continue to resolve these in the `InstallUISequence`, so a
user-chosen path is never overridden.

While validating the fix, I also reconciled the WiX 6 projects and the
local installer-evidence scripts so the MSI and bundle builds can be run
end to end again from this branch.

A matching change is required in the legacy WiX 3 installer
(`sillsdev/genericinstaller`) and is tracked in the paired PR there.

## Validation

- `./Build/Agent/commit-messages.ps1`
- `./Build/Agent/check-and-fix-whitespace.ps1`
- `./build.ps1 -Configuration Release -BuildInstaller -InstallerToolset
  Wix6 -InstallerOnly -ForceInstallerOnly`
- Elevated MSI validation on this machine with logs under
  `Output/InstallerEvidence/LT20524-*`:
  - `/quiet`: success; `APPFOLDER=C:\Program Files\SIL\FieldWorks 9\`,
    `DATAFOLDER=C:\ProgramData\SIL\FieldWorks\Projects\`,
    `HARVESTDATAFOLDER=C:\ProgramData\SIL\`; desktop and Start Menu
    shortcuts target `C:\Program Files\SIL\FieldWorks 9\FieldWorks.exe`.
  - `/qb`: success with the same resolved paths and shortcut targets.
  - `/passive`: success with the same resolved paths and shortcut
    targets.
  - Full UI with the default selections: success with the same resolved
    paths and shortcut targets.
- Non-elevated `/quiet` fails with `Error 1925`, which is expected for a
  per-machine MSI without administrator rights and is not part of
  LT-20524.
- Cleanup check: the final elevated uninstall completed successfully and
  removed the installed `FieldWorks.exe` and shortcuts.

## Notes

The separate report that even `/passive` fails when launched as
**LOCAL SYSTEM** via PDQ Connect / Intune still looks like a distinct
relative-path or elevation issue and is **not** addressed here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/937)
<!-- Reviewable:end -->