### PR TITLE
LT-22518: Fix Sense Numbering Display in Reversals

### DIFF
--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -394,7 +394,7 @@ namespace SIL.FieldWorks.XWorks
 				if (_model == args.ConfigurationPicked)
 					return;
 				_model = args.ConfigurationPicked;
-				SetConfigureHomographParameters(_model, cache);
+				SetConfigureHomographParameters(_propertyTable, cache);
 				RefreshView(); // isChangeInDictionaryModel: true, because we update the current config in the PropertyTable when we save the model.
 			};
 
@@ -501,38 +501,58 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Sets Parameters for Numbering styles.
+		/// Sets parameters for sense numbering styles.
+		/// Note: homograph parameters are used for sense numbers in both the dictionary and reversal. They are never used for reversal numbers.
+		/// So, homograph parameters should always be set based on the dictionary configuration and not the reversal index configuration.
 		/// </summary>
 		/// <param name="model"></param>
 		/// <param name="cache"></param>
-		public static void SetConfigureHomographParameters(DictionaryConfigurationModel model, LcmCache cache)
+		public static void SetConfigureHomographParameters(PropertyTable propertyTable, LcmCache cache)
 		{
 			var cacheHc = cache.ServiceLocator.GetInstance<HomographConfiguration>();
-			if (model.HomographConfiguration == null)
+
+			// Load the dictionary configuration.
+			var dictionaryConfigPath = propertyTable.GetStringProperty("DictionaryPublicationLayout", string.Empty);
+			var dictionaryModel = new DictionaryConfigurationModel(dictionaryConfigPath, cache);
+			if (dictionaryModel.HomographConfiguration == null)
 			{
-				model.HomographConfiguration = new DictionaryHomographConfiguration(new HomographConfiguration());
+				dictionaryModel.HomographConfiguration = new DictionaryHomographConfiguration(new HomographConfiguration());
 			}
-			model.HomographConfiguration.ExportToHomographConfiguration(cacheHc);
-			if (model.Parts.Count == 0) return;
-			var mainEntryNode = model.Parts[0];
-			//Sense Node
-			string senseType = (mainEntryNode.DisplayLabel == "Reversal Entry") ? "Referenced Senses" : "Senses";
-			var senseNode = mainEntryNode.Children.Where(prop => prop.Label == senseType).FirstOrDefault();
-			if (senseNode == null) return;
-			var senseOptions = (DictionaryNodeSenseOptions)senseNode.DictionaryNodeOptions;
-			cacheHc.ksSenseNumberStyle = senseOptions.NumberingStyle;
-			//SubSense Node
-			var subSenseNode = senseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
-			if (subSenseNode == null) return;
-			var subSenseOptions = (DictionaryNodeSenseOptions)subSenseNode.DictionaryNodeOptions;
-			cacheHc.ksSubSenseNumberStyle = subSenseOptions.NumberingStyle;
-			cacheHc.ksParentSenseNumberStyle = subSenseOptions.ParentSenseNumberingStyle;
-			//SubSubSense Node
-			var subSubSenseNode = subSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
-			if (subSubSenseNode == null) return;
-			var subSubSenseOptions = (DictionaryNodeSenseOptions)subSubSenseNode.DictionaryNodeOptions;
-			cacheHc.ksSubSubSenseNumberStyle = subSubSenseOptions.NumberingStyle;
-			cacheHc.ksParentSubSenseNumberStyle = subSubSenseOptions.ParentSenseNumberingStyle;
+
+			ConfigurableDictionaryNode dictionarySenseNode = null;
+
+			if (dictionaryModel.Parts.Count > 0)
+			{
+				// Find the "Senses" node in the dictionary configuration
+				var dictionaryMainEntry = dictionaryModel.Parts[0];
+				dictionarySenseNode = dictionaryMainEntry.Children
+					.Where(prop => prop.Label == "Senses").FirstOrDefault();
+			}
+
+			if (dictionarySenseNode != null)
+			{
+				var dictionarySenseOptions = (DictionaryNodeSenseOptions)dictionarySenseNode.DictionaryNodeOptions;
+				// Apply the dictionary sense numbering styles to the cache
+				cacheHc.ksSenseNumberStyle = dictionarySenseOptions.NumberingStyle;
+
+				// Similarly for subsenses
+				var dictionarySubSenseNode = dictionarySenseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
+				if (dictionarySubSenseNode != null)
+				{
+					var dictionarySubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSenseNode.DictionaryNodeOptions;
+					cacheHc.ksSubSenseNumberStyle = dictionarySubSenseOptions.NumberingStyle;
+					cacheHc.ksParentSenseNumberStyle = dictionarySubSenseOptions.ParentSenseNumberingStyle;
+				}
+
+				// And for subsubsenses
+				var dictionarySubSubSenseNode = dictionarySubSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
+				if (dictionarySubSubSenseNode != null)
+				{
+					var dictionarySubSubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSubSenseNode.DictionaryNodeOptions;
+					cacheHc.ksSubSubSenseNumberStyle = dictionarySubSubSenseOptions.NumberingStyle;
+					cacheHc.ksParentSubSenseNumberStyle = dictionarySubSubSenseOptions.ParentSenseNumberingStyle;
+				}
+			}
 		}
 
 		private void SetManagerTypeInfo(DictionaryConfigurationManagerDlg dialog)

--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -542,15 +542,15 @@ namespace SIL.FieldWorks.XWorks
 					var dictionarySubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSenseNode.DictionaryNodeOptions;
 					cacheHc.ksSubSenseNumberStyle = dictionarySubSenseOptions.NumberingStyle;
 					cacheHc.ksParentSenseNumberStyle = dictionarySubSenseOptions.ParentSenseNumberingStyle;
-				}
 
-				// And for subsubsenses
-				var dictionarySubSubSenseNode = dictionarySubSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
-				if (dictionarySubSubSenseNode != null)
-				{
-					var dictionarySubSubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSubSenseNode.DictionaryNodeOptions;
-					cacheHc.ksSubSubSenseNumberStyle = dictionarySubSubSenseOptions.NumberingStyle;
-					cacheHc.ksParentSubSenseNumberStyle = dictionarySubSubSenseOptions.ParentSenseNumberingStyle;
+					// And for subsubsenses
+					var dictionarySubSubSenseNode = dictionarySubSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
+					if (dictionarySubSubSenseNode != null)
+					{
+						var dictionarySubSubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSubSenseNode.DictionaryNodeOptions;
+						cacheHc.ksSubSubSenseNumberStyle = dictionarySubSubSenseOptions.NumberingStyle;
+						cacheHc.ksParentSubSenseNumberStyle = dictionarySubSubSenseOptions.ParentSenseNumberingStyle;
+					}
 				}
 			}
 		}

--- a/Src/xWorks/DictionaryConfigurationListener.cs
+++ b/Src/xWorks/DictionaryConfigurationListener.cs
@@ -262,10 +262,9 @@ namespace SIL.FieldWorks.XWorks
 			return GetCurrentConfiguration(propertyTable, true, innerConfigDir, obj);
 		}
 
-		private static void SetConfigureHomographParameters(string currentConfig, LcmCache cache)
+		private static void SetConfigureHomographParameters(PropertyTable propertyTable, LcmCache cache)
 		{
-			var model = new DictionaryConfigurationModel(currentConfig, cache);
-			DictionaryConfigurationController.SetConfigureHomographParameters(model, cache);
+			DictionaryConfigurationController.SetConfigureHomographParameters(propertyTable, cache);
 		}
 
 
@@ -304,7 +303,8 @@ namespace SIL.FieldWorks.XWorks
 			var cache = propertyTable.GetValue<LcmCache>("cache");
 			if (!string.IsNullOrEmpty(currentConfig) && File.Exists(currentConfig))
 			{
-				SetConfigureHomographParameters(currentConfig, cache);
+				var dictionaryConfigDir = GetProjectConfigurationDirectory(propertyTable, DictConfigDirName);
+				SetConfigureHomographParameters(propertyTable, cache);
 				return currentConfig;
 			}
 			var defaultConfigFileName = GetDefaultConfigFileName(innerConfigDir);

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -426,10 +426,10 @@ namespace SIL.FieldWorks.XWorks
 
 			// Register eventhandlers
 			senseOptionsView.BeforeTextChanged += (sender, e) => { senseOptions.BeforeNumber = senseOptionsView.BeforeText; RefreshPreview(); };
-			senseOptionsView.NumberingStyleChanged += (sender, e) => SenseNumbingStyleChanged(senseOptions, senseOptionsView, isSubsense, isSubSubsense);
+			senseOptionsView.NumberingStyleChanged += (sender, e) => SenseNumberingStyleChanged(senseOptions, senseOptionsView, isSubsense, isSubSubsense);
 			senseOptionsView.AfterTextChanged += (sender, e) => { senseOptions.AfterNumber = senseOptionsView.AfterText; RefreshPreview(); };
 			senseOptionsView.NumberStyleChanged += (sender, e) => { senseOptions.NumberStyle = senseOptionsView.NumberStyle; RefreshPreview(); };
-			senseOptionsView.ParentSenseNumberingStyleChanged += (sender, e) => ParentSenseNumbingStyleChanged(senseOptions, senseOptionsView, isSubsense, isSubSubsense);
+			senseOptionsView.ParentSenseNumberingStyleChanged += (sender, e) => ParentSenseNumberingStyleChanged(senseOptions, senseOptionsView, isSubsense, isSubSubsense);
 			// ReSharper disable ImplicitlyCapturedClosure
 			// Justification: senseOptions, senseOptionsView, and all of these lambda functions will all disappear at the same time.
 			senseOptionsView.StyleButtonClick += (sender, e) => HandleStylesBtn((ComboBox)sender, senseOptionsView.NumberStyle);
@@ -1025,27 +1025,39 @@ namespace SIL.FieldWorks.XWorks
 		#endregion ListChanges
 
 		#region SenseChanges
-		private void SenseNumbingStyleChanged(DictionaryNodeSenseOptions senseOptions, IDictionarySenseOptionsView senseOptionsView, bool isSubsense, bool isSubSubsense)
+		private void SenseNumberingStyleChanged(DictionaryNodeSenseOptions senseOptions, IDictionarySenseOptionsView senseOptionsView, bool isSubsense, bool isSubSubsense)
 		{
-			var hc = m_cache.ServiceLocator.GetInstance<HomographConfiguration>();
-			if (isSubSubsense)
-				hc.ksSubSubSenseNumberStyle = senseOptionsView.NumberingStyle;
-			else if (isSubsense)
-				hc.ksSubSenseNumberStyle = senseOptionsView.NumberingStyle;
-			else
-				hc.ksSenseNumberStyle = senseOptionsView.NumberingStyle;
+			// Homograph configuration is used for sense numbers, not reversal numbers.
+			// Do not update it if reversal number style has changed.
+			if (!m_configModel.IsReversal)
+			{
+				var hc = m_cache.ServiceLocator.GetInstance<HomographConfiguration>();
+				if (isSubSubsense)
+					hc.ksSubSubSenseNumberStyle = senseOptionsView.NumberingStyle;
+				else if (isSubsense)
+					hc.ksSubSenseNumberStyle = senseOptionsView.NumberingStyle;
+				else
+					hc.ksSenseNumberStyle = senseOptionsView.NumberingStyle;
+			}
+
 			senseOptions.NumberingStyle = senseOptionsView.NumberingStyle;
 			senseOptionsView.NumberMetaConfigEnabled = !string.IsNullOrEmpty(senseOptions.NumberingStyle);
 			RefreshPreview();
 		}
 
-		private void ParentSenseNumbingStyleChanged(DictionaryNodeSenseOptions senseOptions, IDictionarySenseOptionsView senseOptionsView, bool isSubsense, bool isSubSubsense)
+		private void ParentSenseNumberingStyleChanged(DictionaryNodeSenseOptions senseOptions, IDictionarySenseOptionsView senseOptionsView, bool isSubsense, bool isSubSubsense)
 		{
-			var hc = m_cache.ServiceLocator.GetInstance<HomographConfiguration>();
-			if (isSubSubsense)
-				hc.ksParentSubSenseNumberStyle = senseOptionsView.ParentSenseNumberingStyle;
-			else if (isSubsense)
-				hc.ksParentSenseNumberStyle = senseOptionsView.ParentSenseNumberingStyle;
+			// Homograph configuration is used for sense numbers, not reversal numbers.
+			// Do not update it if reversal number style has changed.
+			if (!m_configModel.IsReversal)
+			{
+				var hc = m_cache.ServiceLocator.GetInstance<HomographConfiguration>();
+				if (isSubSubsense)
+					hc.ksParentSubSenseNumberStyle = senseOptionsView.ParentSenseNumberingStyle;
+				else if (isSubsense)
+					hc.ksParentSenseNumberStyle = senseOptionsView.ParentSenseNumberingStyle;
+			}
+
 			senseOptions.ParentSenseNumberingStyle = senseOptionsView.ParentSenseNumberingStyle;
 			RefreshPreview();
 		}

--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -133,6 +133,9 @@ namespace SIL.FieldWorks.XWorks
 			if (progress != null)
 			  progress.Maximum = entriesToSave.Length;
 
+			var dictConfig = new DictionaryConfigurationModel(
+				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable, "ReversalIndex"), m_cache);
+
 			string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-reversal-" + reversalWs + ".docx";
 			LcmWordGenerator.SavePublishedDocx(entriesToSave, revClerk, pubDecorator, int.MaxValue, revConfig, m_propertyTable,
 				reversalFilePath, progress);


### PR DESCRIPTION
The homograph configuration is used only for sense numbers, not for reversal numbers.

Save the sense numbering in homograph config, and don't update it if reversal numbering is changed. Otherwise, sense numbering will always be overwritten in the reversal display to match the numbering system chosen for reversal numbers.

Also, ensure the Reversal Word Export loads the Reversal Index Configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/939)
<!-- Reviewable:end -->
