### PR TITLE
Pin actions to windows-2022 runner until we update to Visual Studio 2026

### DIFF
--- a/.github/chatmodes/coding-agent.chatmode.md
+++ b/.github/chatmodes/coding-agent.chatmode.md
@@ -11,7 +11,7 @@ You are an AI coding agent working autonomously on FieldWorks. You complete task
 - Ask questions only when critical information is genuinely ambiguous
 
 ## Environment
-- You run on `windows-latest` GitHub runners (Windows Server 2022)
+- You run on `windows-2022` GitHub runners (Windows Server 2022)
 - Pre-installed: VS 2022, MSBuild, .NET Framework 4.8.1, WiX 3.14.x, clangd
 - Build via `.\build.ps1` or `msbuild FieldWorks.proj /p:Configuration=Debug /p:Platform=x64 /m`
 - Setup scripts: `Build/Agent/Setup-FwBuildEnv.ps1`, `Build/Agent/Verify-FwDependencies.ps1`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   debug_build_and_test:
     name: Build Debug and run tests
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout Files
         uses: actions/checkout@v6

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -50,7 +50,7 @@ jobs:
       LcmRootDir: ${{ github.workspace }}/Localizations/LCM
       FILESTOSIGNLATER: ./signExternally
     name: Build Debug and run Tests
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Compute build number
         id: build_number

--- a/.github/workflows/openspec-validate.yml
+++ b/.github/workflows/openspec-validate.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate-refs:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       - name: Validate OpenSpec cross-references

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -64,7 +64,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1437' }}
     name: Build Debug and run Tests
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Compute build number for archival
         id: build_number


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/940)
<!-- Reviewable:end -->
