### PR TITLE
Update HarfBuzzSharp version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -157,8 +157,8 @@
 		=============================================================
 	-->
 	<ItemGroup Label="Test Infrastructure">
-		<PackageVersion Include="HarfBuzzSharp" Version="7.3.0" />
-		<PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="7.3.0" />
+		<PackageVersion Include="HarfBuzzSharp" Version="7.3.0.3" />
+		<PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="7.3.0.3" />
 		<PackageVersion Include="Moq" Version="4.20.70" />
 		<PackageVersion Include="NUnit" Version="3.14.0" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />


### PR DESCRIPTION
Fix HarfBuzzSharp downgrade warning as error by updating version from 7.3.0 to 7.3.0.3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/941)
<!-- Reviewable:end -->
