### PR TITLE
Exclude RenderBenchmark tests from installer builds

### DIFF
--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' *>&1 | Tee-Object -FilePath test.log
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired&TestCategory!=RenderBenchmark' *>&1 | Tee-Object -FilePath test.log
 
       - name: Analyze Build Log
         if: always() && steps.build.outcome != 'skipped'

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Run tests
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired' *>&1 | Tee-Object -FilePath test.log
+          .\test.ps1 -Configuration Release -NoBuild -TestFilter 'TestCategory!=DesktopRequired&TestCategory!=RenderBenchmark' *>&1 | Tee-Object -FilePath test.log
 
       - name: Analyze Build Log
         if: always() && steps.build.outcome != 'skipped'


### PR DESCRIPTION
## Summary

Adds `TestCategory!=RenderBenchmark` to the test filters in the base and patch installer workflows. These timing/pixel-sensitive tests (`RenderTimingSuiteTests`, `RenderBaselineTests`, `RenderVerifyTests`) are unreliable on Release builds on shared GitHub runners, and the installer pipeline doesn't collect the render-comparison artifacts needed to diagnose failures.

Flex CI (`CI.yml`) is intentionally left unchanged — it keeps running these tests with full artifact collection and PR reporting, so coverage is preserved where the diagnostics exist.

## Follow-up

Reliability of these tests (notably a failure that appears tied to the cursor flashing in a selected text field) is being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/942)
<!-- Reviewable:end -->
