### PR TITLE
LT-22557 Fix NA features for Bantu Features in catalog

### DIFF
--- a/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
+++ b/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
@@ -16114,7 +16114,7 @@ or using a tool called AddGuids, and re-insert this comment. -->
             </fs>
          </item>
          <item guid="1caada1c-9a01-4cb7-ac1c-2fba2bcf9910" id="vBantuClassNASg" type="value">
-            <abbrev ws="en">NASg</abbrev>
+            <abbrev ws="en">NAsg</abbrev>
          	<term ws="en">NC Sg Not Applicable</term>
          	<def ws="en">The class labeled NAsg is for situations where BantuSg has no value ("not applicable"). For instance, if a noun only has a plural class but no singular class, then for parsing to work correctly, it needs to have BantuSg set to NAsg so that it will not agree with forms that have a value for BantuSg. (If there is no value set for BantuSg, then it will be allowed to take any BantuSg prefix, whereas none should be allowed.)</def>
             <citation>Katamba 2003:114ff;</citation>

--- a/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
+++ b/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
@@ -16114,9 +16114,9 @@ or using a tool called AddGuids, and re-insert this comment. -->
             </fs>
          </item>
          <item guid="1caada1c-9a01-4cb7-ac1c-2fba2bcf9910" id="vBantuClassNASg" type="value">
-            <abbrev ws="en">NA</abbrev>
-            <term ws="en">NC NA</term>
-            <def ws="en">The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</def>
+            <abbrev ws="en">NASg</abbrev>
+         	<term ws="en">NC Sg Not Applicable</term>
+         	<def ws="en">The class labeled NAsg is for situations where BantuSg has no value ("not applicable"). For instance, if a noun only has a plural class but no singular class, then for parsing to work correctly, it needs to have BantuSg set to NAsg so that it will not agree with forms that have a value for BantuSg. (If there is no value set for BantuSg, then it will be allowed to take any BantuSg prefix, whereas none should be allowed.)</def>
             <citation>Katamba 2003:114ff;</citation>
             <citation>Hinnebusch 1989:466-467,</citation>
             <citation>Gardner 2005:54.</citation>
@@ -16340,9 +16340,9 @@ or using a tool called AddGuids, and re-insert this comment. -->
             </fs>
          </item>
          <item guid="ad93d8eb-7515-4bdd-b034-8462c78de50a" id="vBantuClassNAPl" type="value">
-            <abbrev ws="en">NA</abbrev>
-            <term ws="en">NC NA</term>
-            <def ws="en">The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</def>
+         	<abbrev ws="en">NApl</abbrev>
+         	<term ws="en">NC Pl Not Applicable</term>
+         	<def ws="en">The class labeled NApl is for situations where BantuPl has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NApl so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</def>
             <citation>Katamba 2003:114ff;</citation>
             <citation>Hinnebusch 1989:466-467,</citation>
             <citation>Gardner 2005:54.</citation>
@@ -16540,9 +16540,9 @@ or using a tool called AddGuids, and re-insert this comment. -->
             </fs>
          </item>
          <item guid="880a016d-cdc4-4bfe-8a28-83f658c43aae" id="vBantuClassNAMany" type="value">
-            <abbrev ws="en">NA</abbrev>
-            <term ws="en">NC NA</term>
-            <def ws="en">The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</def>
+         	<abbrev ws="en">NAmany</abbrev>
+         	<term ws="en">NC Many Not Applicable</term>
+         	<def ws="en">The class labeled NAmany is for situations where BantuMany has no value ("not applicable"). For instance, if a noun only has a singular and plural class but no "many" class, then for parsing to work correctly, it needs to have BantuMany set to NAmany so that it will not agree with forms that have a value for BantuMany. (If there is no value set for BantuMany, then it will be allowed to take any BantuMany prefix, whereas none should be allowed.)</def>
             <citation>Katamba 2003:114ff;</citation>
             <citation>Hinnebusch 1989:466-467,</citation>
             <citation>Gardner 2005:54.</citation>

--- a/Src/LexText/Morphology/MGA/GlossLists/FeatureCatalog.xml
+++ b/Src/LexText/Morphology/MGA/GlossLists/FeatureCatalog.xml
@@ -6164,11 +6164,11 @@ type="value"
 ><LangCode
 >en</LangCode
 ><Name
->NC NAsg</Name
+>NC Sg Not Applicable</Name
 ><Abbreviation
 >NAsg</Abbreviation
 ><Description
->The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</Description
+>The class labeled NAsg is for situations where BantuSg has no value ("not applicable"). For instance, if a noun only has a plural class but no singular class, then for parsing to work correctly, it needs to have BantuSg set to NAsg so that it will not agree with forms that have a value for BantuSg. (If there is no value set for BantuSg, then it will be allowed to take any BantuSg prefix, whereas none should be allowed.)</Description
 ><Citations
 ><Citation
 >Katamba 2003:114ff;</Citation
@@ -6591,11 +6591,11 @@ type="value"
 ><LangCode
 >en</LangCode
 ><Name
->NC NApl</Name
+>NC Pl Not Applicable</Name
 ><Abbreviation
 >NApl</Abbreviation
 ><Description
->The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</Description
+>The class labeled NApl is for situations where BantuPl has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NApl so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.) </Description
 ><Citations
 ><Citation
 >Katamba 2003:114ff;</Citation
@@ -6968,11 +6968,11 @@ type="value"
 ><LangCode
 >en</LangCode
 ><Name
->NC NAmany</Name
+>NC Many Not Applicable</Name
 ><Abbreviation
 >NAmany</Abbreviation
 ><Description
->The class labeled NA is for situations where one of the sets has no value ("not applicable"). For instance, if a noun only has a singular class but no plural class, then for parsing to work correctly, it needs to have BantuPl set to NA so that it will not agree with forms that have a value for BantuPl. (If there is no value set for BantuPl, then it will be allowed to take any BantuPl prefix, whereas none should be allowed.)</Description
+>The class labeled NAmany is for situations where BantuMany has no value ("not applicable"). For instance, if a noun only has a singular and plural class but no "many" class, then for parsing to work correctly, it needs to have BantuMany set to NAmany so that it will not agree with forms that have a value for BantuMany. (If there is no value set for BantuMany, then it will be allowed to take any BantuMany prefix, whereas none should be allowed.) </Description
 ><Citations
 ><Citation
 >Katamba 2003:114ff;</Citation


### PR DESCRIPTION
The wording for the "not applicable" values of the recently added BantuSg, BantuPl, and BantuMany inflection features need to be refined.  There are two places where this is needed: the feature catalog and the etic gloss list.   This makes the needed wording changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/946)
<!-- Reviewable:end -->
