### PR TITLE
LT-22558 Fix crash in TonePars utility with Chinese WS

### DIFF
--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -346,13 +346,13 @@ namespace SIL.ToneParsFLEx
 				if (selectedText != null)
 				{
 					lbTexts.SelectedIndex = Texts.IndexOf(selectedText);
-				}
-				var selectedSegment = SegmentsInListBox
-					.Where(s => s.Segment.Guid.ToString() == RetrievedLastSegment)
-					.FirstOrDefault();
-				if (selectedSegment != null)
-				{
-					lbSegments.SelectedIndex = SegmentsInListBox.IndexOf(selectedSegment);
+					var selectedSegment = SegmentsInListBox
+						.Where(s => s.Segment.Guid.ToString() == RetrievedLastSegment)
+						.FirstOrDefault();
+					if (selectedSegment != null)
+					{
+						lbSegments.SelectedIndex = SegmentsInListBox.IndexOf(selectedSegment);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The solution is to move offending code within a not-null check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/947)
<!-- Reviewable:end -->
