### PR TITLE
Retarget patch installer to base build 1439

### DIFF
--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -39,11 +39,11 @@ on:
 # on Jenkins-built bases.
       base_release:
         description: 'The github release for the base build artifacts (separate only for bootstrapping; should be removed after 9.3 is the stable)'
-        default: 'build-1437' # When updating this, update base_build_number and their fallbacks below, too.
+        default: 'build-1439' # When updating this, update base_build_number and their fallbacks below, too.
       base_build_number:
         description: 'The base build number'
         required: false
-        default: '1437'
+        default: '1439'
       make_release:
         description: 'Should the release be pushed to s3 - use false for test builds'
         required: false
@@ -62,7 +62,7 @@ jobs:
       LcmRootDir: ${{ github.workspace }}/Localizations/LCM
       FILESTOSIGNLATER: ./signExternally
       GH_TOKEN: ${{ github.token }}
-      BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1437' }}
+      BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1439' }}
     name: Build Debug and run Tests
     runs-on: windows-2022
     steps:
@@ -170,7 +170,7 @@ jobs:
       - name: Import Base Build Artifacts
         shell: pwsh
         run: |
-          $release = "${{ inputs.base_release || 'build-1437' }}"
+          $release = "${{ inputs.base_release || 'build-1439' }}"
           $repo    = "${{ github.repository }}"
 
           Write-Host "Downloading artifacts for release $release from $repo"


### PR DESCRIPTION
## Quick Summary

Retargets the patch installer workflow to build patches on top of the `build-1439` base release instead of `build-1437`. Updates all four references in `.github/workflows/patch-installer-cd.yml`:

- `base_release` input default: `build-1437` -> `build-1439`
- `base_build_number` input default: `1437` -> `1439`
- `BASE_BUILD_NUMBER` env fallback: `1437` -> `1439`
- Base artifact download fallback: `build-1437` -> `build-1439`

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject <= 72 chars, no trailing punctuation; if body present, blank line then <= 80-char lines).
- [x] No whitespace warnings locally (`git diff --check --cached` clean).
- [x] Builds/tests pass locally (workflow-only change; no code touched, validated by the Patch Installer workflow itself).
- [x] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate (no `Src/**` changes).

## Notes for reviewers (optional)

Verified via `gh release view build-1439` that the release exists on sillsdev/FieldWorks and contains both artifacts the workflow downloads (`BuildDir.zip` and `ProcRunner.zip`). Scheduled and push-triggered runs use the fallback values, so they pick up 1439 immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/951)
<!-- Reviewable:end -->
