### PR TITLE
Fix LT-22562 crash in use PcPatr with FLEx

### DIFF
--- a/Src/Utilities/pcpatrflex/PcPatrFLExDll/PcPatrFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/PcPatrFLExDll/PcPatrFLExForm.cs
@@ -254,16 +254,16 @@ namespace SIL.PcPatrFLEx
 				if (selectedText != null)
 				{
 					lbTexts.SelectedIndex = Texts.IndexOf(selectedText);
-				}
-				var selectedSegment = SegmentsInListBox.Where(s => s.Segment.Guid.ToString() == RetrievedLastSegment).FirstOrDefault();
-				if (selectedSegment != null)
-				{
-					int index = SegmentsInListBox.IndexOf(selectedSegment);
-					lbSegments.SelectedIndex = index;
-					if (lbSegments.GetSelected(0) && index != 0)
+					var selectedSegment = SegmentsInListBox.Where(s => s.Segment.Guid.ToString() == RetrievedLastSegment).FirstOrDefault();
+					if (selectedSegment != null)
 					{
-						// Only select the non-initial one
-						lbSegments.SetSelected(0, false);
+						int index = SegmentsInListBox.IndexOf(selectedSegment);
+						lbSegments.SelectedIndex = index;
+						if (lbSegments.GetSelected(0) && index != 0)
+						{
+							// Only select the non-initial one
+							lbSegments.SetSelected(0, false);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The solution is to move the offending code within a not null check.
This is similar to LT-22558.  Interestingly, it only crashes on a freshly created project using a Chinese writing system.  After fixing LT-22558, I tested this on the same peroject as I used for LT-22558, but it did not crash.  I had to creatre a brand new project in order for it to cerash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/955)
<!-- Reviewable:end -->
