### PR TITLE
LT-22568: Part 1 - Scope Pub/Sub to a Main Window

### DIFF
--- a/Src/Common/Controls/DetailControls/DataTree.cs
+++ b/Src/Common/Controls/DetailControls/DataTree.cs
@@ -4404,8 +4404,8 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			if (PersistenceProvder != null)
 				RestorePreferences();
 
-			Subscriber.Subscribe(EventConstants.PostponePropChanged, PostponePropChanged);
-			Subscriber.Subscribe(EventConstants.JumpToField, JumpToField);
+			Subscriber.Subscribe(EventConstants.PostponePropChanged, PostponePropChanged, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.JumpToField, JumpToField, m_propertyTable.GetWindow());
 		}
 
 		public IxCoreColleague[] GetMessageTargets()

--- a/Src/Common/Controls/DetailControls/GhostStringSlice.cs
+++ b/Src/Common/Controls/DetailControls/GhostStringSlice.cs
@@ -459,12 +459,12 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				int hvoNewObj;
 				try
 				{
-					Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, false));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, false, datatree.PropTable?.GetWindow()));
 					hvoNewObj = MakeRealObject(tssTyped);
 				}
 				finally
 				{
-					Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, true));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, true, datatree.PropTable?.GetWindow()));
 				}
 
 				// Now try to make a suitable selection in the slice that replaces this.

--- a/Src/Common/Controls/XMLViews/BrowseViewer.cs
+++ b/Src/Common/Controls/XMLViews/BrowseViewer.cs
@@ -3298,7 +3298,7 @@ namespace SIL.FieldWorks.Common.Controls
 			m_xbv.Init(mediator, propertyTable, configurationParameters);
 			m_xbv.AccessibleName = "BrowseViewer";
 			m_mediator = mediator;
-			Subscriber.Subscribe(EventConstants.RemoveFilters, RemoveFilters);
+			Subscriber.Subscribe(EventConstants.RemoveFilters, RemoveFilters, propertyTable.GetWindow());
 		}
 		/// <summary>
 		/// Should not be called if disposed.

--- a/Src/Common/Controls/XMLViews/XmlBrowseRDEView.cs
+++ b/Src/Common/Controls/XMLViews/XmlBrowseRDEView.cs
@@ -104,8 +104,8 @@ namespace SIL.FieldWorks.Common.Controls
 			// Use the ones in fakeFlid, and any we create.
 			base.Init(nodeSpec, hvoRoot, fakeFlid, cache, mediator, bv);
 
-			Subscriber.Subscribe(EventConstants.DeleteRecord, DeleteRecord);
-			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing);
+			Subscriber.Subscribe(EventConstants.DeleteRecord, DeleteRecord, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing, m_propertyTable.GetWindow());
 		}
 
 		#endregion Construction, initialization, and disposal.

--- a/Src/Common/Controls/XMLViews/XmlBrowseViewBase.cs
+++ b/Src/Common/Controls/XMLViews/XmlBrowseViewBase.cs
@@ -2085,9 +2085,9 @@ namespace SIL.FieldWorks.Common.Controls
 
 			SetSelectedRowHighlighting();//read the property table
 
-			Subscriber.Subscribe(EventConstants.SaveScrollPosition, SaveScrollPosition);
-			Subscriber.Subscribe(EventConstants.RestoreScrollPosition, RestoreScrollPosition);
-			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh);
+			Subscriber.Subscribe(EventConstants.SaveScrollPosition, SaveScrollPosition, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.RestoreScrollPosition, RestoreScrollPosition, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh, m_propertyTable.GetWindow());
 		}
 
 		#endregion XCore Colleague overrides

--- a/Src/Common/Controls/XMLViews/XmlBrowseViewBaseVc.cs
+++ b/Src/Common/Controls/XMLViews/XmlBrowseViewBaseVc.cs
@@ -1767,7 +1767,7 @@ namespace SIL.FieldWorks.Common.Controls
 						FwLinkArgs linkArgs = new FwLinkArgs(url);
 						linkArgs.DisplayErrorMsg = false;
 						var retObj = new ReturnObject(linkArgs);
-						Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, retObj));
+						Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, retObj, m_xbv?.m_bv?.PropTable?.GetWindow()));
 						if (retObj.ReturnValue)
 							return;
 					}

--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -1849,7 +1849,7 @@ namespace SIL.FieldWorks
 									s_projectId = projectToTry; // Window is open on this project, we must not try to initialize it again.
 									if (Form.ActiveForm is IxWindow mainWindow)
 									{
-										Publisher.Publish(new PublisherParameterObject(EventConstants.SFMImport));
+										Publisher.Publish(new PublisherParameterObject(EventConstants.SFMImport, null, mainWindow));
 									}
 									else
 									{

--- a/Src/Common/FwUtils/EndOfActionManager.cs
+++ b/Src/Common/FwUtils/EndOfActionManager.cs
@@ -64,6 +64,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 				m_events.Add(publisherParameterObject.Message, queued);
 			}
 			var sameScopeIndex = queued.FindIndex(e => ReferenceEquals(e.Scope, publisherParameterObject.Scope));
+			// If it is the same Message and scope then intentionally overwrite.
 			if (sameScopeIndex >= 0)
 			{
 				queued[sameScopeIndex] = publisherParameterObject;

--- a/Src/Common/FwUtils/EndOfActionManager.cs
+++ b/Src/Common/FwUtils/EndOfActionManager.cs
@@ -19,7 +19,11 @@ namespace SIL.FieldWorks.Common.FwUtils
 	public sealed class EndOfActionManager
 	{
 		private bool m_initialized = false;
-		private readonly Dictionary<string, object> m_events = new Dictionary<string, object>();
+		// The events are grouped by message, and then by scope within each message. At most a message
+		// is queued once per scope (last one wins). Note: Null is a valid scope, it follows the same
+		// rules; queued once and last one wins, but null scope is unique in that the message is delivered
+		// to all subscribers regardless of their scope (null or not null).
+		private readonly Dictionary<string, List<PublisherParameterObject>> m_events = new Dictionary<string, List<PublisherParameterObject>>();
 
 		/// <summary>
 		/// Returns the EndOfAction event that is currently being published.
@@ -51,8 +55,23 @@ namespace SIL.FieldWorks.Common.FwUtils
 				}
 			}
 
-			// Add the dictionary entry if the key is not present. Overwrite the value if the key is present.
-			m_events[publisherParameterObject.Message] = publisherParameterObject.Data;
+			// The whole parameter object is kept so the delivery scope survives until the idle publish.
+			// Group by both message and scope: overwrite an already-queued publish only if it has the
+			// same scope; publishes of the same message from different scopes are all delivered.
+			if (!m_events.TryGetValue(publisherParameterObject.Message, out var queued))
+			{
+				queued = new List<PublisherParameterObject>();
+				m_events.Add(publisherParameterObject.Message, queued);
+			}
+			var sameScopeIndex = queued.FindIndex(e => ReferenceEquals(e.Scope, publisherParameterObject.Scope));
+			if (sameScopeIndex >= 0)
+			{
+				queued[sameScopeIndex] = publisherParameterObject;
+			}
+			else
+			{
+				queued.Add(publisherParameterObject);
+			}
 		}
 
 		/// Should be private, but is public to support testing.
@@ -63,11 +82,14 @@ namespace SIL.FieldWorks.Common.FwUtils
 			{
 				foreach (var orderedEvent in EndOfActionOrder.Order)
 				{
-					if (m_events.TryGetValue(orderedEvent, out object data))
+					if (m_events.TryGetValue(orderedEvent, out var queuedEvents))
 					{
 						m_events.Remove(orderedEvent);
 						CurrentEndOfActionEvent = orderedEvent;
-						FwUtils.Publisher.Publish(new PublisherParameterObject(orderedEvent, data));
+						foreach (var publisherParameterObject in queuedEvents)
+						{
+							FwUtils.Publisher.Publish(publisherParameterObject);
+						}
 						CurrentEndOfActionEvent = null;
 					}
 

--- a/Src/Common/FwUtils/FwUtilsTests/PubSubSystemTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/PubSubSystemTests.cs
@@ -214,18 +214,18 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			// Set up.
 			var scopeA = new TestPubSubScope();
-			var subscriberA = new ScopeAwareSubscriber(scopeA) { One = true };
-			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { One = true };
-			var unscopedSubscriber = new ScopeAwareSubscriber(null) { One = true };
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { SelectionValue = int.MinValue };
+			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { SelectionValue = int.MinValue };
+			var unscopedSubscriber = new ScopeAwareSubscriber(null) { SelectionValue = int.MinValue };
 			subscriberA.DoSubscriptions();
 			subscriberB.DoSubscriptions();
 			unscopedSubscriber.DoSubscriptions();
 
 			// Run test.
-			FwUtils.Publisher.Publish(new PublisherParameterObject("MessageOne", false, scopeA));
-			Assert.That(subscriberA.One, Is.False); // Same scope: delivered.
-			Assert.That(subscriberB.One, Is.True); // Different scope: not delivered.
-			Assert.That(unscopedSubscriber.One, Is.False); // Unscoped subscriber: delivered.
+			FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.SelectionChanged, int.MaxValue, scopeA));
+			Assert.That(subscriberA.SelectionValue, Is.EqualTo(int.MaxValue)); // Same scope: delivered.
+			Assert.That(subscriberB.SelectionValue, Is.EqualTo(int.MinValue)); // Different scope: not delivered.
+			Assert.That(unscopedSubscriber.SelectionValue, Is.EqualTo(int.MaxValue)); // Unscoped subscriber: delivered.
 
 			subscriberA.DoUnsubscriptions();
 			subscriberB.DoUnsubscriptions();
@@ -239,15 +239,15 @@ namespace SIL.FieldWorks.Common.FwUtils
 		public void Unscoped_Publish_Delivers_To_Scoped_And_Unscoped_Subscribers()
 		{
 			// Set up.
-			var scopedSubscriber = new ScopeAwareSubscriber(new TestPubSubScope()) { One = true };
-			var unscopedSubscriber = new ScopeAwareSubscriber(null) { One = true };
+			var scopedSubscriber = new ScopeAwareSubscriber(new TestPubSubScope()) { SelectionValue = int.MinValue };
+			var unscopedSubscriber = new ScopeAwareSubscriber(null) { SelectionValue = int.MinValue };
 			scopedSubscriber.DoSubscriptions();
 			unscopedSubscriber.DoSubscriptions();
 
 			// Run test.
-			FwUtils.Publisher.Publish(new PublisherParameterObject("MessageOne", false));
-			Assert.That(scopedSubscriber.One, Is.False); // Delivered.
-			Assert.That(unscopedSubscriber.One, Is.False); // Delivered.
+			FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.SelectionChanged, int.MaxValue));
+			Assert.That(scopedSubscriber.SelectionValue, Is.EqualTo(int.MaxValue)); // Delivered.
+			Assert.That(unscopedSubscriber.SelectionValue, Is.EqualTo(int.MaxValue)); // Delivered.
 
 			scopedSubscriber.DoUnsubscriptions();
 			unscopedSubscriber.DoUnsubscriptions();
@@ -261,22 +261,22 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			// Set up.
 			var scopeA = new TestPubSubScope();
-			var subscriberA = new ScopeAwareSubscriber(scopeA) { Two = int.MinValue };
-			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { Two = int.MinValue };
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { SelectionValue = int.MinValue };
+			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { SelectionValue = int.MinValue };
 			subscriberA.DoSubscriptions();
 			subscriberB.DoSubscriptions();
 
 			FwUtils.Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.SelectionChanged, int.MaxValue, scopeA));
 
 			// Nothing is delivered until the idle queue drains.
-			Assert.That(subscriberA.Two, Is.EqualTo(int.MinValue));
-			Assert.That(subscriberB.Two, Is.EqualTo(int.MinValue));
+			Assert.That(subscriberA.SelectionValue, Is.EqualTo(int.MinValue));
+			Assert.That(subscriberB.SelectionValue, Is.EqualTo(int.MinValue));
 
 			// SUT - Process the EndOfActionManager IdleQueue.
 			FwUtils.Publisher.EndOfActionManager.IdleEndOfAction(null);
 
-			Assert.That(subscriberA.Two, Is.EqualTo(int.MaxValue)); // Same scope: delivered.
-			Assert.That(subscriberB.Two, Is.EqualTo(int.MinValue)); // Different scope: not delivered.
+			Assert.That(subscriberA.SelectionValue, Is.EqualTo(int.MaxValue)); // Same scope: delivered.
+			Assert.That(subscriberB.SelectionValue, Is.EqualTo(int.MinValue)); // Different scope: not delivered.
 
 			subscriberA.DoUnsubscriptions();
 			subscriberB.DoUnsubscriptions();
@@ -292,8 +292,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 			// Set up.
 			var scopeA = new TestPubSubScope();
 			var scopeB = new TestPubSubScope();
-			var subscriberA = new ScopeAwareSubscriber(scopeA) { Two = int.MinValue };
-			var subscriberB = new ScopeAwareSubscriber(scopeB) { Two = int.MinValue };
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { SelectionValue = int.MinValue };
+			var subscriberB = new ScopeAwareSubscriber(scopeB) { SelectionValue = int.MinValue };
 			subscriberA.DoSubscriptions();
 			subscriberB.DoSubscriptions();
 
@@ -305,8 +305,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 			// SUT - Process the EndOfActionManager IdleQueue.
 			FwUtils.Publisher.EndOfActionManager.IdleEndOfAction(null);
 
-			Assert.That(subscriberA.Two, Is.EqualTo(3)); // Latest scopeA publish won.
-			Assert.That(subscriberB.Two, Is.EqualTo(2)); // scopeB publish survived independently.
+			Assert.That(subscriberA.SelectionValue, Is.EqualTo(3)); // Latest scopeA publish won.
+			Assert.That(subscriberB.SelectionValue, Is.EqualTo(2)); // scopeB publish survived independently.
 
 			subscriberA.DoUnsubscriptions();
 			subscriberB.DoUnsubscriptions();
@@ -737,34 +737,20 @@ namespace SIL.FieldWorks.Common.FwUtils
 				_scope = scope;
 			}
 
-			internal bool One { get; set; }
-			internal int Two { get; set; }
+			internal int SelectionValue { get; set; }
 
-			/// <summary>
-			/// This is the subscribed message handler for "MessageOne" message.
-			/// </summary>
-			private void MessageOneHandler(object newValue)
-			{
-				One = (bool)newValue;
-			}
-
-			/// <summary>
-			/// This is the subscribed message handler for the SelectionChanged message.
-			/// </summary>
 			private void SelectionChangedHandler(object newValue)
 			{
-				Two = (int)newValue;
+				SelectionValue = (int)newValue;
 			}
 
 			internal void DoSubscriptions()
 			{
-				FwUtils.Subscriber.Subscribe("MessageOne", MessageOneHandler, _scope);
 				FwUtils.Subscriber.Subscribe(EventConstants.SelectionChanged, SelectionChangedHandler, _scope);
 			}
 
 			internal void DoUnsubscriptions()
 			{
-				FwUtils.Subscriber.Unsubscribe("MessageOne", MessageOneHandler);
 				FwUtils.Subscriber.Unsubscribe(EventConstants.SelectionChanged, SelectionChangedHandler);
 			}
 		}

--- a/Src/Common/FwUtils/FwUtilsTests/PubSubSystemTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/PubSubSystemTests.cs
@@ -205,6 +205,147 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Assert.That(subscriber2.One, Is.True); // Did not change.
 		}
 
+		/// <summary>
+		/// A scoped publish goes to same-scope and unscoped subscribers, but not to
+		/// subscribers with a different scope.
+		/// </summary>
+		[Test]
+		public void Scoped_Publish_Delivers_Only_To_Matching_Scope_And_Unscoped_Subscribers()
+		{
+			// Set up.
+			var scopeA = new TestPubSubScope();
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { One = true };
+			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { One = true };
+			var unscopedSubscriber = new ScopeAwareSubscriber(null) { One = true };
+			subscriberA.DoSubscriptions();
+			subscriberB.DoSubscriptions();
+			unscopedSubscriber.DoSubscriptions();
+
+			// Run test.
+			FwUtils.Publisher.Publish(new PublisherParameterObject("MessageOne", false, scopeA));
+			Assert.That(subscriberA.One, Is.False); // Same scope: delivered.
+			Assert.That(subscriberB.One, Is.True); // Different scope: not delivered.
+			Assert.That(unscopedSubscriber.One, Is.False); // Unscoped subscriber: delivered.
+
+			subscriberA.DoUnsubscriptions();
+			subscriberB.DoUnsubscriptions();
+			unscopedSubscriber.DoUnsubscriptions();
+		}
+
+		/// <summary>
+		/// An unscoped publish is process-wide: every subscriber receives it, scoped or not.
+		/// </summary>
+		[Test]
+		public void Unscoped_Publish_Delivers_To_Scoped_And_Unscoped_Subscribers()
+		{
+			// Set up.
+			var scopedSubscriber = new ScopeAwareSubscriber(new TestPubSubScope()) { One = true };
+			var unscopedSubscriber = new ScopeAwareSubscriber(null) { One = true };
+			scopedSubscriber.DoSubscriptions();
+			unscopedSubscriber.DoSubscriptions();
+
+			// Run test.
+			FwUtils.Publisher.Publish(new PublisherParameterObject("MessageOne", false));
+			Assert.That(scopedSubscriber.One, Is.False); // Delivered.
+			Assert.That(unscopedSubscriber.One, Is.False); // Delivered.
+
+			scopedSubscriber.DoUnsubscriptions();
+			unscopedSubscriber.DoUnsubscriptions();
+		}
+
+		/// <summary>
+		/// The scope must survive the EndOfActionManager round trip through the idle queue.
+		/// </summary>
+		[Test]
+		public void Scope_Is_Preserved_Through_PublishAtEndOfAction()
+		{
+			// Set up.
+			var scopeA = new TestPubSubScope();
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { Two = int.MinValue };
+			var subscriberB = new ScopeAwareSubscriber(new TestPubSubScope()) { Two = int.MinValue };
+			subscriberA.DoSubscriptions();
+			subscriberB.DoSubscriptions();
+
+			FwUtils.Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.SelectionChanged, int.MaxValue, scopeA));
+
+			// Nothing is delivered until the idle queue drains.
+			Assert.That(subscriberA.Two, Is.EqualTo(int.MinValue));
+			Assert.That(subscriberB.Two, Is.EqualTo(int.MinValue));
+
+			// SUT - Process the EndOfActionManager IdleQueue.
+			FwUtils.Publisher.EndOfActionManager.IdleEndOfAction(null);
+
+			Assert.That(subscriberA.Two, Is.EqualTo(int.MaxValue)); // Same scope: delivered.
+			Assert.That(subscriberB.Two, Is.EqualTo(int.MinValue)); // Different scope: not delivered.
+
+			subscriberA.DoUnsubscriptions();
+			subscriberB.DoUnsubscriptions();
+		}
+
+		/// <summary>
+		/// EndOfAction coalescing is per (message, scope): the same message queued from two
+		/// scopes is delivered to both, while a re-publish from the same scope overwrites.
+		/// </summary>
+		[Test]
+		public void PublishAtEndOfAction_Coalesces_Per_Scope()
+		{
+			// Set up.
+			var scopeA = new TestPubSubScope();
+			var scopeB = new TestPubSubScope();
+			var subscriberA = new ScopeAwareSubscriber(scopeA) { Two = int.MinValue };
+			var subscriberB = new ScopeAwareSubscriber(scopeB) { Two = int.MinValue };
+			subscriberA.DoSubscriptions();
+			subscriberB.DoSubscriptions();
+
+			FwUtils.Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.SelectionChanged, 1, scopeA));
+			FwUtils.Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.SelectionChanged, 2, scopeB));
+			// Same scope again: coalesces with (overwrites) the first scopeA publish.
+			FwUtils.Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.SelectionChanged, 3, scopeA));
+
+			// SUT - Process the EndOfActionManager IdleQueue.
+			FwUtils.Publisher.EndOfActionManager.IdleEndOfAction(null);
+
+			Assert.That(subscriberA.Two, Is.EqualTo(3)); // Latest scopeA publish won.
+			Assert.That(subscriberB.Two, Is.EqualTo(2)); // scopeB publish survived independently.
+
+			subscriberA.DoUnsubscriptions();
+			subscriberB.DoUnsubscriptions();
+		}
+
+		/// <summary>
+		/// Prefix subscriptions honor the same scope rule as specific subscriptions:
+		/// scoped publishes skip other-scope prefix subscribers and reach same-scope and
+		/// unscoped ones; non-matching prefixes are never delivered.
+		/// </summary>
+		[Test]
+		public void Prefix_Subscriptions_Honor_Scope()
+		{
+			// Set up.
+			var scopeA = new TestPubSubScope();
+			var subscriberA = new PrefixScopeAwareSubscriber(scopeA);
+			var subscriberB = new PrefixScopeAwareSubscriber(new TestPubSubScope());
+			var unscopedSubscriber = new PrefixScopeAwareSubscriber(null);
+			subscriberA.DoSubscriptions();
+			subscriberB.DoSubscriptions();
+			unscopedSubscriber.DoSubscriptions();
+
+			// Run test.
+			FwUtils.Publisher.Publish(new PublisherParameterObject("PrefixedMessageOne", 7, scopeA));
+			Assert.That(subscriberA.LastMessage, Is.EqualTo("PrefixedMessageOne")); // Same scope: delivered.
+			Assert.That(subscriberB.LastMessage, Is.Null); // Different scope: not delivered.
+			Assert.That(unscopedSubscriber.LastMessage, Is.EqualTo("PrefixedMessageOne")); // Unscoped subscriber: delivered.
+
+			subscriberA.LastMessage = null;
+			unscopedSubscriber.LastMessage = null;
+			FwUtils.Publisher.Publish(new PublisherParameterObject("UnrelatedMessage", 7, scopeA));
+			Assert.That(subscriberA.LastMessage, Is.Null); // Prefix does not match: not delivered.
+			Assert.That(unscopedSubscriber.LastMessage, Is.Null);
+
+			subscriberA.DoUnsubscriptions();
+			subscriberB.DoUnsubscriptions();
+			unscopedSubscriber.DoUnsubscriptions();
+		}
+
 		[Test]
 		[TestCase(null)]
 		[TestCase("")]
@@ -550,6 +691,81 @@ namespace SIL.FieldWorks.Common.FwUtils
 			private void MessageTwoHandler(object newValue)
 			{
 				Two = (int)newValue;
+			}
+		}
+
+		private sealed class TestPubSubScope : IPubSubScope
+		{
+		}
+
+		private sealed class PrefixScopeAwareSubscriber
+		{
+			private readonly IPubSubScope _scope;
+
+			internal PrefixScopeAwareSubscriber(IPubSubScope scope)
+			{
+				_scope = scope;
+			}
+
+			internal string LastMessage { get; set; }
+
+			/// <summary>
+			/// This is the subscribed prefix handler for messages starting with "PrefixedMessage".
+			/// </summary>
+			private void PrefixedMessageHandler(string message, object newValue)
+			{
+				LastMessage = message;
+			}
+
+			internal void DoSubscriptions()
+			{
+				FwUtils.Subscriber.PrefixSubscribe("PrefixedMessage", PrefixedMessageHandler, _scope);
+			}
+
+			internal void DoUnsubscriptions()
+			{
+				FwUtils.Subscriber.PrefixUnsubscribe("PrefixedMessage", PrefixedMessageHandler);
+			}
+		}
+
+		private sealed class ScopeAwareSubscriber
+		{
+			private readonly IPubSubScope _scope;
+
+			internal ScopeAwareSubscriber(IPubSubScope scope)
+			{
+				_scope = scope;
+			}
+
+			internal bool One { get; set; }
+			internal int Two { get; set; }
+
+			/// <summary>
+			/// This is the subscribed message handler for "MessageOne" message.
+			/// </summary>
+			private void MessageOneHandler(object newValue)
+			{
+				One = (bool)newValue;
+			}
+
+			/// <summary>
+			/// This is the subscribed message handler for the SelectionChanged message.
+			/// </summary>
+			private void SelectionChangedHandler(object newValue)
+			{
+				Two = (int)newValue;
+			}
+
+			internal void DoSubscriptions()
+			{
+				FwUtils.Subscriber.Subscribe("MessageOne", MessageOneHandler, _scope);
+				FwUtils.Subscriber.Subscribe(EventConstants.SelectionChanged, SelectionChangedHandler, _scope);
+			}
+
+			internal void DoUnsubscriptions()
+			{
+				FwUtils.Subscriber.Unsubscribe("MessageOne", MessageOneHandler);
+				FwUtils.Subscriber.Unsubscribe(EventConstants.SelectionChanged, SelectionChangedHandler);
 			}
 		}
 

--- a/Src/Common/FwUtils/IPubSubScope.cs
+++ b/Src/Common/FwUtils/IPubSubScope.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+namespace SIL.FieldWorks.Common.FwUtils
+{
+	/// <summary>
+	/// Marker interface for objects that scope Pub/Sub delivery.
+	///
+	/// The Publisher and Subscriber are process-wide singletons, but most messages are
+	/// window-scoped: the legacy Mediator they replace delivered only within one main window.
+	/// To reproduce that, a subscriber passes its main window when subscribing, and a publisher
+	/// passes the same window in its PublisherParameterObject; the Publisher then delivers a
+	/// scoped publish only to subscribers with the identical (reference-equal) scope.
+	/// A Publisher with a null scope will go to all the message subscribers and a Subscriber
+	/// with a null scope will receive all the messages, regardless of them being published
+	/// with or without a scope.
+	/// Null is for publishers with no window context (e.g. app bootstrap code) and for
+	/// messages that must reach a window the publisher cannot name (e.g. Send/Receive messages
+	/// aimed at the project's reopened instance). (Process-wide delivery is a Pub/Sub-era
+	/// capability, not preserved Mediator behavior. The Mediator had no all-windows broadcast;
+	/// instead its app-wide coordination was accomplished by iterating FwApp.MainWindows directly.)
+	///
+	/// The scope IS the main window: the XCore IxWindow interface extends this one, so main
+	/// windows pass <c>this</c> and everything else obtains the window via
+	/// <c>PropertyTable.GetWindow()</c>.
+	/// Do not implement this interface on anything that is not a main window.
+	/// </summary>
+	public interface IPubSubScope
+	{
+	}
+}

--- a/Src/Common/FwUtils/ISubscriber.cs
+++ b/Src/Common/FwUtils/ISubscriber.cs
@@ -20,7 +20,11 @@ namespace SIL.FieldWorks.Common.FwUtils
 		/// <param name="message">The message being subscribed to receive.</param>
 		/// <param name="messageHandler">The method on subscriber to call, when <paramref name="message"/>
 		/// has been published</param>
-		void Subscribe(string message, Action<object> messageHandler);
+		/// <param name="scope">Optional delivery scope (normally the subscriber's main window).
+		/// When non-null, scoped publishes of <paramref name="message"/> are delivered only if they
+		/// carry the same scope. Null subscribes will receive messages from all publishers.
+		/// See <see cref="IPubSubScope"/>.</param>
+		void Subscribe(string message, Action<object> messageHandler, IPubSubScope scope = null);
 
 		/// <summary>
 		/// An object subscribes to messages that begin with <paramref name="messagePrefix"/> using
@@ -33,7 +37,11 @@ namespace SIL.FieldWorks.Common.FwUtils
 		/// <param name="messagePrefix">The message prefix being subscribed to receive.</param>
 		/// <param name="messageHandler">The method on subscriber to call, when a message that
 		/// begins with <paramref name="messagePrefix"/> has been published.</param>
-		void PrefixSubscribe(string messagePrefix, Action<string, object> messageHandler);
+		/// <param name="scope">Optional delivery scope (normally the subscriber's main window).
+		/// When non-null, scoped publishes of matching messages are delivered only if they
+		/// carry the same scope. Null subscribes will receive messages from all publishers.
+		/// See <see cref="IPubSubScope"/>.</param>
+		void PrefixSubscribe(string messagePrefix, Action<string, object> messageHandler, IPubSubScope scope = null);
 
 		/// <summary>
 		/// Register end of interest (unsubscribe) of an object in receiving <paramref name="message"/>
@@ -52,14 +60,16 @@ namespace SIL.FieldWorks.Common.FwUtils
 		void PrefixUnsubscribe(string messagePrefix, Action<string, object> messageHandler);
 
 		/// <summary>
-		/// Get all current subscriptions.
+		/// Get all current subscriptions: per message, each handler with the scope it subscribed
+		/// under (null scope = process-wide).
 		/// </summary>
-		IReadOnlyDictionary<string, HashSet<Action<object>>> Subscriptions { get; }
+		IReadOnlyDictionary<string, Dictionary<Action<object>, IPubSubScope>> Subscriptions { get; }
 
 		/// <summary>
-		/// Get all the current prefix subscriptions. If a message starts with one of these
+		/// Get all the current prefix subscriptions: per prefix, each handler with the scope it
+		/// subscribed under (null scope = process-wide). If a message starts with one of these
 		/// prefixes then the prefix subscribers will get notified.
 		/// </summary>
-		IReadOnlyDictionary<string, HashSet<Action<string, object>>> PrefixSubscriptions { get; }
+		IReadOnlyDictionary<string, Dictionary<Action<string, object>, IPubSubScope>> PrefixSubscriptions { get; }
 	}
 }

--- a/Src/Common/FwUtils/Publisher.cs
+++ b/Src/Common/FwUtils/Publisher.cs
@@ -26,36 +26,48 @@ namespace SIL.FieldWorks.Common.FwUtils
 		}
 
 		/// <summary>
-		/// Publish the message using the new value.
+		/// Publish the message using the given data.
 		/// </summary>
 		/// <param name="message">The message to publish.</param>
-		/// <param name="newValue">The new value to send to subscribers. This may be null.</param>
-		private void PublishMessage(string message, object newValue)
+		/// <param name="data">The data to send to subscribers. This may be null.</param>
+		/// <param name="scope">The delivery scope. When non-null, only subscribers with the same
+		/// scope (or none) are invoked; when null, every subscriber is. See <see cref="IPubSubScope"/>.</param>
+		private void PublishMessage(string message, object data, IPubSubScope scope)
 		{
 			Guard.AgainstNullOrEmptyString(message, nameof(message));
 
 			// Check if 'message' was subscribed to.
 			if (_subscriber.Subscriptions.TryGetValue(message, out var subscribers))
 			{
-				foreach (var subscriberAction in subscribers.ToList())
+				foreach (var subscription in subscribers.ToList())
 				{
-					// NB: It is possible that the action's object is disposed,
-					// but we'll not fret about making sure it isn't disposed,
-					// but we will expect the subscribers to be well-behaved and unsubscribe,
-					// when they get disposed.
-					subscriberAction(newValue);
+					// A scoped publish is delivered only to subscribers in the same scope (e.g. the
+					// same main window). A null scope on either end means process-wide delivery.
+					if (scope == null || subscription.Value == null || ReferenceEquals(scope, subscription.Value))
+					{
+						// NB: It is possible that the action's object is disposed,
+						// but we'll not fret about making sure it isn't disposed,
+						// but we will expect the subscribers to be well-behaved and unsubscribe,
+						// when they get disposed.
+						subscription.Key(data);
+					}
 				}
 			}
 
 			// Check if 'message' contains a prefix that was subscribed to.
 			// Note: ToArray() is important to avoid new entries being added while iterating over the collection.
-			foreach (KeyValuePair<string, HashSet<Action<string, object>>> entry in _subscriber.PrefixSubscriptions.ToArray())
+			foreach (KeyValuePair<string, Dictionary<Action<string, object>, IPubSubScope>> entry in _subscriber.PrefixSubscriptions.ToArray())
 			{
 				if (message.StartsWith(entry.Key))
 				{
-					foreach (var subscriberAction in entry.Value.ToList())
+					foreach (var subscription in entry.Value.ToList())
 					{
-						subscriberAction(message, newValue);
+						// Same delivery rule as specific subscriptions: a null scope on either end
+						// means process-wide; otherwise the scopes must be the same window.
+						if (scope == null || subscription.Value == null || ReferenceEquals(scope, subscription.Value))
+						{
+							subscription.Key(message, data);
+						}
 					}
 				}
 			}
@@ -70,7 +82,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			Guard.AgainstNull(publisherParameterObject, nameof(publisherParameterObject));
 
-			PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data);
+			PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data, publisherParameterObject.Scope);
 		}
 
 		/// <inheritdoc />
@@ -89,7 +101,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			foreach (var publisherParameterObject in publisherParameterObjects)
 			{
-				PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data);
+				PublishMessage(publisherParameterObject.Message, publisherParameterObject.Data, publisherParameterObject.Scope);
 			}
 		}
 		#endregion

--- a/Src/Common/FwUtils/PublisherParameterObject.cs
+++ b/Src/Common/FwUtils/PublisherParameterObject.cs
@@ -8,7 +8,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 {
 	public sealed class PublisherParameterObject
 	{
-		public PublisherParameterObject(string message, object data = null)
+		public PublisherParameterObject(string message, object data = null, IPubSubScope scope = null)
 		{
 			if (string.IsNullOrWhiteSpace(message))
 			{
@@ -17,10 +17,18 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 			Message = message;
 			Data = data;
+			Scope = scope;
 		}
 
 		public string Message { get; }
 		public object Data { get; }
+
+		/// <summary>
+		/// Delivery scope (normally the publishing main window). When non-null, only
+		/// subscribers that subscribed with the same scope (or with none) receive this publish.
+		/// A null scope publishes to all subscribers, regardless of their scope. See <see cref="IPubSubScope"/>.
+		/// </summary>
+		public IPubSubScope Scope { get; }
 	}
 
 	/// <summary>

--- a/Src/Common/FwUtils/Subscriber.cs
+++ b/Src/Common/FwUtils/Subscriber.cs
@@ -13,10 +13,10 @@ namespace SIL.FieldWorks.Common.FwUtils
 	/// </summary>
 	internal sealed class Subscriber : ISubscriber
 	{
-		private readonly Dictionary<string, HashSet<Action<object>>> _subscriptions =
-			new Dictionary<string, HashSet<Action<object>>>();
-		private readonly Dictionary<string, HashSet<Action<string, object>>> _prefixSubscriptions =
-			new Dictionary<string, HashSet<Action<string, object>>>();
+		private readonly Dictionary<string, Dictionary<Action<object>, IPubSubScope>> _subscriptions =
+			new Dictionary<string, Dictionary<Action<object>, IPubSubScope>>();
+		private readonly Dictionary<string, Dictionary<Action<string, object>, IPubSubScope>> _prefixSubscriptions =
+			new Dictionary<string, Dictionary<Action<string, object>, IPubSubScope>>();
 
 		#region Implementation of ISubscriber
 
@@ -27,16 +27,20 @@ namespace SIL.FieldWorks.Common.FwUtils
 		/// <param name="message">The message being subscribed to receive.</param>
 		/// <param name="messageHandler">The method on subscriber to call, when <paramref name="message"/>
 		/// has been published</param>
-		public void Subscribe(string message, Action<object> messageHandler)
+		/// <param name="scope">Optional delivery scope (normally the subscriber's main window).
+		/// When non-null, scoped publishes of <paramref name="message"/> are delivered only if they
+		/// carry the same scope. Null subscribes will receive messages from all publishers.
+		/// See <see cref="IPubSubScope"/>.</param>
+		public void Subscribe(string message, Action<object> messageHandler, IPubSubScope scope = null)
 		{
 			if (!_subscriptions.TryGetValue(message, out var subscribers))
 			{
-				subscribers = new HashSet<Action<object>>();
+				subscribers = new Dictionary<Action<object>, IPubSubScope>();
 				_subscriptions.Add(message, subscribers);
 			}
 			// NB: If an ill-behaved subscribing object registers the same delegate more than once
-			// for the same message, then only one registration will 'take'.
-			subscribers.Add(messageHandler);
+			// for the same message, then only one registration will 'take' (the latest scope wins).
+			subscribers[messageHandler] = scope;
 		}
 
 		/// <summary>
@@ -50,16 +54,20 @@ namespace SIL.FieldWorks.Common.FwUtils
 		/// <param name="messagePrefix">The message prefix being subscribed to receive.</param>
 		/// <param name="messageHandler">The method on subscriber to call, when a message that
 		/// begins with <paramref name="messagePrefix"/> has been published.</param>
-		public void PrefixSubscribe(string messagePrefix, Action<string, object> messageHandler)
+		/// <param name="scope">Optional delivery scope (normally the subscriber's main window).
+		/// When non-null, scoped publishes of matching messages are delivered only if they
+		/// carry the same scope. Null subscribes will receive messages from all publishers.
+		/// See <see cref="IPubSubScope"/>.</param>
+		public void PrefixSubscribe(string messagePrefix, Action<string, object> messageHandler, IPubSubScope scope = null)
 		{
 			if (!_prefixSubscriptions.TryGetValue(messagePrefix, out var prefixSubscribers))
 			{
-				prefixSubscribers = new HashSet<Action<string, object>>();
+				prefixSubscribers = new Dictionary<Action<string, object>, IPubSubScope>();
 				_prefixSubscriptions.Add(messagePrefix, prefixSubscribers);
 			}
 			// NB: If an ill-behaved subscribing object registers the same delegate more than once
-			// for the same message, then only one registration will 'take'.
-			prefixSubscribers.Add(messageHandler);
+			// for the same message, then only one registration will 'take' (the latest scope wins).
+			prefixSubscribers[messageHandler] = scope;
 		}
 
 		/// <summary>
@@ -103,17 +111,19 @@ namespace SIL.FieldWorks.Common.FwUtils
 		}
 
 		/// <summary>
-		/// Get all current subscriptions.
+		/// Get all current subscriptions: per message, each handler with the scope it subscribed
+		/// under (null scope = process-wide).
 		/// </summary>
-		public IReadOnlyDictionary<string, HashSet<Action<object>>> Subscriptions =>
-			new ReadOnlyDictionary<string, HashSet<Action<object>>>(_subscriptions);
+		public IReadOnlyDictionary<string, Dictionary<Action<object>, IPubSubScope>> Subscriptions =>
+			new ReadOnlyDictionary<string, Dictionary<Action<object>, IPubSubScope>>(_subscriptions);
 
 		/// <summary>
-		/// Get all the current prefix subscriptions. If a message starts with one of these
+		/// Get all the current prefix subscriptions: per prefix, each handler with the scope it
+		/// subscribed under (null scope = process-wide). If a message starts with one of these
 		/// prefixes then the prefix subscribers will get notified.
 		/// </summary>
-		public IReadOnlyDictionary<string, HashSet<Action<string, object>>> PrefixSubscriptions =>
-			new ReadOnlyDictionary<string, HashSet<Action<string, object>>>(_prefixSubscriptions);
+		public IReadOnlyDictionary<string, Dictionary<Action<string, object>, IPubSubScope>> PrefixSubscriptions =>
+			new ReadOnlyDictionary<string, Dictionary<Action<string, object>, IPubSubScope>>(_prefixSubscriptions);
 
 		#endregion
 	}

--- a/Src/FdoUi/FdoUiCore.cs
+++ b/Src/FdoUi/FdoUiCore.cs
@@ -400,7 +400,7 @@ namespace SIL.FieldWorks.FdoUi
 			try
 			{
 				// Don't postpone PropChanged (cf. LT-22095).
-				Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, false));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, false, propertyTable.GetWindow()));
 				var cache = propertyTable.GetValue<LcmCache>("cache");
 				switch (classId)
 				{
@@ -420,7 +420,7 @@ namespace SIL.FieldWorks.FdoUi
 			}
 			finally
 			{
-				Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, true));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.PostponePropChanged, true, propertyTable.GetWindow()));
 			}
 		}
 
@@ -1026,7 +1026,7 @@ namespace SIL.FieldWorks.FdoUi
 				object command = this;
 				if (m_command != null)
 					command = m_command;
-				Publisher.Publish(new PublisherParameterObject(EventConstants.DeleteRecord, command));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.DeleteRecord, command, m_propertyTable.GetWindow()));
 			}
 			else
 			{

--- a/Src/LexText/Interlinear/ConcordanceControl.cs
+++ b/Src/LexText/Interlinear/ConcordanceControl.cs
@@ -99,7 +99,7 @@ namespace SIL.FieldWorks.IText
 			// Load any saved settings.
 			LoadSettings();
 
-			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing);
+			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>

--- a/Src/LexText/Interlinear/InterlinMaster.cs
+++ b/Src/LexText/Interlinear/InterlinMaster.cs
@@ -775,8 +775,8 @@ namespace SIL.FieldWorks.IText
 			m_fullyInitialized = true;
 			RefreshPaneBar();
 
-			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh);
-			Subscriber.Subscribe(EventConstants.RefreshInterlin, RefreshInterlin);
+			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.RefreshInterlin, RefreshInterlin, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>
@@ -1356,7 +1356,7 @@ namespace SIL.FieldWorks.IText
 				link.PropertyTableEntries.Add(new Property("InterlinearTab",
 					InterlinearTab.ToString()));
 				Clerk.SelectedRecordChanged(true, true); // make sure we update the record count in the Status bar.
-				Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, link));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, link, m_propertyTable.GetWindow()));
 			}
 		}
 

--- a/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
+++ b/Src/LexText/Interlinear/InterlinearTextsRecordClerk.cs
@@ -41,7 +41,7 @@ namespace SIL.FieldWorks.IText
 		public override void ActivateUI(bool useRecordTreeBar, bool updateStatusBar = true)
 		{
 			// Only needs to handle changes if this RecordClerk is being used in the GUI.
-			Subscriber.Subscribe(EventConstants.AddTexts, AddTexts);
+			Subscriber.Subscribe(EventConstants.AddTexts, AddTexts, m_propertyTable.GetWindow());
 
 			base.ActivateUI(useRecordTreeBar, updateStatusBar);
 		}
@@ -259,7 +259,7 @@ namespace SIL.FieldWorks.IText
 			{
 				// Tell the user we're turning off the filter, and then do it.
 				MessageBox.Show(ITextStrings.ksTurningOffFilter, ITextStrings.ksNote, MessageBoxButtons.OK);
-				Publisher.Publish(new PublisherParameterObject(EventConstants.RemoveFilters, this));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.RemoveFilters, this, m_propertyTable.GetWindow()));
 				m_activeMenuBarFilter = null;
 			}
 			SaveOnChangeRecord(); // commit any changes before we create a new text.
@@ -288,7 +288,7 @@ namespace SIL.FieldWorks.IText
 				return false;
 			if (!InDesiredTool("interlinearEdit"))
 			{
-				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("interlinearEdit", CurrentObject.Guid)));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("interlinearEdit", CurrentObject.Guid), m_propertyTable.GetWindow()));
 			}
 			return true;
 		}

--- a/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
+++ b/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
@@ -2630,7 +2630,7 @@ namespace SIL.FieldWorks.IText
 			private void OnSelectEditLexicalEntry(object sender, EventArgs args)
 			{
 				ILexEntry lexEntry = GetLexEntry();
-				Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToPopupLexEntry, lexEntry.Hvo));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToPopupLexEntry, lexEntry.Hvo, m_sandbox.m_propertyTable?.GetWindow()));
 			}
 
 			private ILexEntry GetLexEntry()

--- a/Src/LexText/Interlinear/StatisticsView.cs
+++ b/Src/LexText/Interlinear/StatisticsView.cs
@@ -88,7 +88,7 @@ namespace SIL.FieldWorks.IText
 			mediator.AddColleague(this);
 			//add our current state to the history system
 			string toolName = _propertyTable.GetStringProperty("currentContentControl", "");
-			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, Guid.Empty)));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, Guid.Empty), _propertyTable.GetWindow()));
 		}
 
 		private void RebuildStatisticsTable()

--- a/Src/LexText/LexTextControls/DataNotebook/AnthroFieldMappingDlg.cs
+++ b/Src/LexText/LexTextControls/DataNotebook/AnthroFieldMappingDlg.cs
@@ -279,7 +279,7 @@ namespace SIL.FieldWorks.LexText.Controls.DataNotebook
 		{
 			// Show the ConfigureCustomFields dialog (by publisher to avoid circular dependencies)
 			Publisher.Publish(new PublisherParameterObject(EventConstants.ConfigureCustomFields,
-				new Tuple<Mediator, PropertyTable, string>(m_mediator, m_propertyTable, AreaConstants.notebook)));
+				new Tuple<Mediator, PropertyTable, string>(m_mediator, m_propertyTable, AreaConstants.notebook), m_propertyTable.GetWindow()));
 			// Now, clean up our map of possible field targets and reload the field combo list.
 			List<int> delFields = new List<int>();
 			foreach (int key in m_mapFlidName.Keys)

--- a/Src/LexText/LexTextControls/EntryDlgListener.cs
+++ b/Src/LexText/LexTextControls/EntryDlgListener.cs
@@ -34,7 +34,12 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public InsertEntryDlgListener()
 		{
-			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		public override void Init(Mediator mediator, PropertyTable propertyTable, System.Xml.XmlNode configurationParameters)
+		{
+			base.Init(mediator, propertyTable, configurationParameters);
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector, propertyTable.GetWindow());
 		}
 
 		#endregion Construction and Initialization

--- a/Src/LexText/LexTextControls/InsertEntryDlg.cs
+++ b/Src/LexText/LexTextControls/InsertEntryDlg.cs
@@ -1428,7 +1428,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					CreateNewEntry();
 					if (DialogResult == DialogResult.Retry)
 					{
-						Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToPopupLexEntry, m_entry.Hvo));
+						Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToPopupLexEntry, m_entry.Hvo, m_propertyTable.GetWindow()));
 						DialogResult = DialogResult.OK;
 					}
 					break;

--- a/Src/LexText/LexTextControls/LexImportWizardMarker.cs
+++ b/Src/LexText/LexTextControls/LexImportWizardMarker.cs
@@ -1061,7 +1061,7 @@ namespace SIL.FieldWorks.LexText.Controls
 				return;
 			}
 			Publisher.Publish(new PublisherParameterObject(EventConstants.ConfigureCustomFields,
-				new Tuple<Mediator, PropertyTable, string>(med, m_propertyTable, AreaConstants.lexicon)));
+				new Tuple<Mediator, PropertyTable, string>(med, m_propertyTable, AreaConstants.lexicon), m_propertyTable.GetWindow()));
 
 			// The above call can cause the Mediator to 'go away', so check it and
 			// restore the member variable for everyone else who may be surprised

--- a/Src/LexText/LexTextControls/RecordDlgListener.cs
+++ b/Src/LexText/LexTextControls/RecordDlgListener.cs
@@ -30,7 +30,12 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		public InsertRecordDlgListener()
 		{
-			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		public override void Init(Mediator mediator, PropertyTable propertyTable, System.Xml.XmlNode configurationParameters)
+		{
+			base.Init(mediator, propertyTable, configurationParameters);
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector, propertyTable.GetWindow());
 		}
 
 		#endregion Construction and Initialization

--- a/Src/LexText/LexTextDll/AreaListener.cs
+++ b/Src/LexText/LexTextDll/AreaListener.cs
@@ -154,11 +154,11 @@ namespace SIL.FieldWorks.XWorks.LexText
 			mediator.AddColleague(this);
 			m_ctotalLists = 0;
 			m_ccustomLists = 0;
-			Subscriber.Subscribe(EventConstants.SetInitialContentObject, SetInitialContentObject);
-			Subscriber.Subscribe(EventConstants.SetToolFromName, SetToolFromName);
-			Subscriber.Subscribe(EventConstants.ReloadAreaTools, ReloadAreaTools);
-			Subscriber.Subscribe(EventConstants.GetContentControlParameters, GetContentControlParameters);
-			Subscriber.Subscribe(EventConstants.GetToolForList, GetToolForList);
+			Subscriber.Subscribe(EventConstants.SetInitialContentObject, SetInitialContentObject, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.SetToolFromName, SetToolFromName, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.ReloadAreaTools, ReloadAreaTools, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.GetContentControlParameters, GetContentControlParameters, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.GetToolForList, GetToolForList, m_propertyTable.GetWindow());
 		}
 
 		private DateTime m_lastToolChange = DateTime.MinValue;

--- a/Src/LexText/Lexicon/FLExBridgeListener.cs
+++ b/Src/LexText/Lexicon/FLExBridgeListener.cs
@@ -348,7 +348,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 				if (conflictOccurred)
 				{
 					// Send a message for the reopened instance to display the message viewer (used to be conflict report),
-					// we have been disposed by now
+					// we have been disposed by now.
 					Publisher.Publish(new PublisherParameterObject(EventConstants.ViewMessages, null));
 				}
 			}
@@ -498,7 +498,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 				if (conflictOccurred)
 				{
 					// Send a message for the reopened instance to display the message viewer (used to be conflict report),
-					// we have been disposed by now
+					// we have been disposed by now.
 					Publisher.Publish(new PublisherParameterObject(EventConstants.ViewLiftMessages, null));
 				}
 			}
@@ -1512,7 +1512,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			if (!string.IsNullOrEmpty(e.JumpUrl))
 			{
 				var args = new LocalLinkArgs { Link = e.JumpUrl };
-				Publisher.Publish(new PublisherParameterObject(EventConstants.HandleLocalHotlink, args));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.HandleLocalHotlink, args, _propertyTable.GetWindow()));
 			}
 		}
 

--- a/Src/LexText/Lexicon/LexReferenceMultiSlice.cs
+++ b/Src/LexText/Lexicon/LexReferenceMultiSlice.cs
@@ -757,7 +757,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			ILexRefType newKid = list.Services.GetInstance<ILexRefTypeFactory>().Create();
 			list.PossibilitiesOS.Add(newKid);
 			m_cache.DomainDataByFlid.EndUndoTask();
-			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexRefEdit", newKid.Guid)));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexRefEdit", newKid.Guid), m_propertyTable.GetWindow()));
 		}
 
 		protected void ExpandNewNode()

--- a/Src/LexText/Lexicon/LexReferenceSequenceView.cs
+++ b/Src/LexText/Lexicon/LexReferenceSequenceView.cs
@@ -85,7 +85,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			{
 				if (m_displayParent != null && hvoObj == m_displayParent.Hvo)
 					// We need to handle this the same way as the delete command in the slice menu.
-					Publisher.Publish(new PublisherParameterObject(EventConstants.DataTreeDelete, null));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.DataTreeDelete, null, m_propertyTable.GetWindow()));
 				else
 					DeleteObjectFromVector(sel, cvsli, hvoObj, LexEdStrings.ksUndoDeleteRef, LexEdStrings.ksRedoDeleteRef);
 			}

--- a/Src/LexText/Lexicon/ReversalListener.cs
+++ b/Src/LexText/Lexicon/ReversalListener.cs
@@ -449,7 +449,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 					SetOwningObject(newOwningObj, updateAndNotify); // Reloads and sorts the list.
 					m_propertyTable.SetProperty("ActiveClerkOwningObject", newOwningObj, true);
 					m_propertyTable.SetPropertyPersistence("ActiveClerkOwningObject", false);
-					Publisher.Publish(new PublisherParameterObject(EventConstants.ClerkOwningObjChanged, this));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.ClerkOwningObjChanged, this, m_propertyTable.GetWindow()));
 				}
 				else
 				{

--- a/Src/LexText/Morphology/MasterCatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterCatDlgListener.cs
@@ -35,7 +35,12 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterCatDlgListener()
 		{
-			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		public override void Init(Mediator mediator, PropertyTable propertyTable, System.Xml.XmlNode configurationParameters)
+		{
+			base.Init(mediator, propertyTable, configurationParameters);
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector, propertyTable.GetWindow());
 		}
 
 		#endregion Construction and Initialization

--- a/Src/LexText/Morphology/MasterDlgListener.cs
+++ b/Src/LexText/Morphology/MasterDlgListener.cs
@@ -155,7 +155,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// <summary>
 		/// Initialize the IxCoreColleague object.
 		/// </summary>
-		public void Init(Mediator mediator, PropertyTable propertyTable, XmlNode configurationParameters)
+		public virtual void Init(Mediator mediator, PropertyTable propertyTable, XmlNode configurationParameters)
 		{
 			CheckDisposed();
 

--- a/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
@@ -36,7 +36,12 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterInflFeatDlgListener()
 		{
-			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		public override void Init(Mediator mediator, PropertyTable propertyTable, System.Xml.XmlNode configurationParameters)
+		{
+			base.Init(mediator, propertyTable, configurationParameters);
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector, propertyTable.GetWindow());
 		}
 
 		#endregion Construction and Initialization

--- a/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
@@ -39,7 +39,12 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// </summary>
 		public MasterPhonFeatDlgListener()
 		{
-			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector);
+		}
+
+		public override void Init(Mediator mediator, PropertyTable propertyTable, System.Xml.XmlNode configurationParameters)
+		{
+			base.Init(mediator, propertyTable, configurationParameters);
+			Subscriber.Subscribe(EventConstants.DialogInsertItemInVector, DialogInsertItemInVector, propertyTable.GetWindow());
 		}
 
 		#endregion Construction and Initialization

--- a/Src/LexText/Morphology/ParserAnalysisRemover.cs
+++ b/Src/LexText/Morphology/ParserAnalysisRemover.cs
@@ -103,7 +103,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			m_dlg.ProgressBar.Step = 1;
 
 			// stop parser if it's running.
-			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser, null, m_dlg.PropTable?.GetWindow()));
 
 			NonUndoableUnitOfWorkHelper.Do(cache.ActionHandlerAccessor, () =>
 			{
@@ -125,7 +125,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			});
 
 			// Interlin display may be affected.
-			Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshInterlin, null));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshInterlin, null, m_dlg.PropTable?.GetWindow()));
 		}
 
 		#endregion IUtility implementation

--- a/Src/LexText/Morphology/RespellerDlg.cs
+++ b/Src/LexText/Morphology/RespellerDlg.cs
@@ -572,7 +572,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 				// On the other hand, we don't want to update the new wordform until after DoIt...it might not exist before,
 				// and we won't be messing up any existing occurrences.
-				Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, m_cache.ServiceLocator.GetObject(m_respellUndoaction.NewWordform)));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, m_cache.ServiceLocator.GetObject(m_respellUndoaction.NewWordform), m_propertyTable.GetWindow()));
 				ChangesWereMade = true;
 
 
@@ -1537,10 +1537,10 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 					}
 					else
 					{
-						Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, wfOld));
+						Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, wfOld, RespellSda?.PropTable?.GetWindow()));
 					}
 				}
-				Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, wfNew));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.ItemDataModified, wfNew, RespellSda?.PropTable?.GetWindow()));
 				uuow.RollBack = false;
 			}
 		}

--- a/Src/LexText/Morphology/UserAnalysisRemover.cs
+++ b/Src/LexText/Morphology/UserAnalysisRemover.cs
@@ -125,7 +125,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 				}
 			});
 
-			Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshInterlin, null));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshInterlin, null, m_dlg.PropTable?.GetWindow()));
 
 		}
 

--- a/Src/LexText/ParserUI/ImportWordSetDlg.cs
+++ b/Src/LexText/ParserUI/ImportWordSetDlg.cs
@@ -32,6 +32,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// xCore Mediator.
 		/// </summary>
 		protected Mediator m_mediator;
+		protected PropertyTable m_propertyTable;
 		/// <summary>
 		///
 		/// </summary>
@@ -72,6 +73,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			//InitializeComponent();
 			m_mediator = mediator;
+			m_propertyTable = propertyTable;
 			m_cache = propertyTable.GetValue<LcmCache>("cache");
 
 			m_helpTopicProvider = propertyTable.GetValue<IHelpTopicProvider>("HelpTopicProvider");
@@ -208,10 +210,10 @@ namespace SIL.FieldWorks.LexText.Controls
 				return;
 			}
 
-			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser, null, m_propertyTable.GetWindow()));
 			CreateWordsetFromFiles(m_paths);
 
-			Publisher.Publish(new PublisherParameterObject(EventConstants.FilterListChanged, null)); // let record clerk know the list of filters has changed.
+			Publisher.Publish(new PublisherParameterObject(EventConstants.FilterListChanged, null, m_propertyTable.GetWindow())); // let record clerk know the list of filters has changed.
 
 			DialogResult = DialogResult.OK;
 		}

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -86,9 +86,9 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_sda = m_cache.MainCacheAccessor;
 			m_sda.AddNotification(this);
 
-			Subscriber.Subscribe(EventConstants.StopParser, StopParser);
-			Subscriber.Subscribe(EventConstants.RefreshPopupWindowFonts, RefreshPopupWindowFonts);
-			Subscriber.Subscribe(EventConstants.Idle, Idle);
+			Subscriber.Subscribe(EventConstants.StopParser, StopParser, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.RefreshPopupWindowFonts, RefreshPopupWindowFonts, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.Idle, Idle, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>

--- a/Src/XCore/xCoreInterfaces/IxCoreColleague.cs
+++ b/Src/XCore/xCoreInterfaces/IxCoreColleague.cs
@@ -11,6 +11,7 @@
 using System.Xml;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using SIL.FieldWorks.Common.FwUtils;
 
 namespace XCore
 {
@@ -137,8 +138,10 @@ namespace XCore
 	/// <summary>
 	/// This is an interface implemented by xWindow (and perhaps other main window classes?)
 	/// that allows a few of their key functions to be called by things that don't reference xCore.
+	/// A main window is also the Pub/Sub delivery scope (IPubSubScope): messages published with a
+	/// window as their scope are delivered only to subscribers that subscribed with the same window.
 	/// </summary>
-	public interface IxWindow : IMediatorProvider, IPropertyTableProvider
+	public interface IxWindow : IMediatorProvider, IPropertyTableProvider, IPubSubScope
 	{
 		/// <summary>
 		/// Call this for the duration of a block of code where we don't want idle events.

--- a/Src/XCore/xCoreInterfaces/PropertyTable.cs
+++ b/Src/XCore/xCoreInterfaces/PropertyTable.cs
@@ -324,6 +324,22 @@ namespace XCore
 		}
 
 		/// <summary>
+		/// The main window owning this property table (each main window registers itself under
+		/// "window" in its own table), or null when unavailable — a private or test property
+		/// table, or early window construction. Being an IxWindow, the result also serves as the
+		/// Pub/Sub delivery scope; a null scope means process-wide delivery, so "unavailable"
+		/// can only widen delivery, never lose a message.
+		/// </summary>
+		/// <remarks>Null-safe by design: unlike GetValue&lt;T&gt;, this never throws when the
+		/// "window" property holds a non-window (as some test fixtures do).</remarks>
+		public IxWindow GetWindow()
+		{
+			CheckDisposed();
+
+			return GetValue<object>("window") as IxWindow;
+		}
+
+		/// <summary>
 		/// Get the value of the property of the specified settingsGroup.
 		/// </summary>
 		/// <param name="name"></param>

--- a/Src/XCore/xWindow.cs
+++ b/Src/XCore/xWindow.cs
@@ -441,8 +441,8 @@ namespace XCore
 
 			InitializeComponent();
 
-			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh);
-			Subscriber.Subscribe(EventConstants.SetInitialContentObject, SetInitialContentObject);
+			Subscriber.Subscribe(EventConstants.PrepareToRefresh, PrepareToRefresh, this);
+			Subscriber.Subscribe(EventConstants.SetInitialContentObject, SetInitialContentObject, this);
 		}
 
 		/// <summary>
@@ -802,7 +802,7 @@ namespace XCore
 
 			// Add the content control
 			// Note: We should be able to do it directly, since everything needed is in the default properties.
-			Publisher.Publish(new PublisherParameterObject(EventConstants.SetInitialContentObject, m_windowConfigurationNode));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.SetInitialContentObject, m_windowConfigurationNode, this));
 			m_sidebarAdapter.FinishInit();
 			m_menuBarAdapter.FinishInit();
 
@@ -1230,8 +1230,10 @@ namespace XCore
 		/// <returns></returns>
 		private void SetInitialContentObject(object windowConfigurationNode)
 		{
-			// We only want to handle this if there are no other listeners
-			if (Subscriber.Subscriptions[EventConstants.SetInitialContentObject].Count > 1)
+			// We only want to handle this if there are no other listeners for this window
+			// (count only subscriptions in this window's scope or with no scope).
+			if (Subscriber.Subscriptions[EventConstants.SetInitialContentObject]
+					.Count(subscription => subscription.Value == null || ReferenceEquals(subscription.Value, this)) > 1)
 				return;
 			CheckDisposed();
 
@@ -1789,8 +1791,8 @@ namespace XCore
 
 			UpdateControls();
 
-			// Notify any subscribers that the application is idle.
-			Publisher.Publish(new PublisherParameterObject(EventConstants.Idle, null));
+			// Notify this window's subscribers that the application is idle.
+			Publisher.Publish(new PublisherParameterObject(EventConstants.Idle, null, this));
 		}
 
 		/// <summary>
@@ -1912,7 +1914,7 @@ namespace XCore
 		{
 			CheckDisposed();
 
-			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser, null, this));
 			this.Close();
 
 			return true;
@@ -2243,7 +2245,7 @@ namespace XCore
 			m_widgetUpdateTimer.Enabled = false;
 
 			e.Cancel = false;
-			Publisher.Publish(new PublisherParameterObject(EventConstants.ConsideringClosing, e));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.ConsideringClosing, e, this));
 			if (e.Cancel)
 			{
 				m_widgetUpdateTimer.Enabled = true;

--- a/Src/xWorks/CustomListDlg.cs
+++ b/Src/xWorks/CustomListDlg.cs
@@ -315,7 +315,7 @@ namespace SIL.FieldWorks.XWorks
 
 		private void ReloadListsArea()
 		{
-			Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists"));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", m_propertyTable.GetWindow()));
 		}
 
 		/// <summary>

--- a/Src/xWorks/DTMenuHandler.cs
+++ b/Src/xWorks/DTMenuHandler.cs
@@ -173,7 +173,7 @@ namespace SIL.FieldWorks.XWorks
 			m_mediator = mediator;
 			m_propertyTable = propertyTable;
 			m_configuration = configurationParameters;
-			Subscriber.Subscribe(EventConstants.DataTreeDelete, DataTreeDelete);
+			Subscriber.Subscribe(EventConstants.DataTreeDelete, DataTreeDelete, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>

--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -374,7 +374,7 @@ namespace SIL.FieldWorks.XWorks
 						SaveModel();
 						MasterRefreshRequired = false; // We're reloading the whole app, that's refresh enough
 						View.Close();
-						Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists"));
+						Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", _propertyTable.GetWindow()));
 					};
 					SetManagerTypeInfo(dialog);
 					dialog.ShowDialog(View as Form);

--- a/Src/xWorks/DictionaryConfigurationMigrators/PreHistoricMigrator.cs
+++ b/Src/xWorks/DictionaryConfigurationMigrators/PreHistoricMigrator.cs
@@ -128,7 +128,7 @@ namespace SIL.FieldWorks.XWorks.DictionaryConfigurationMigrators
 		{
 			var collector = new XmlNode[1];
 			var parameter = new Tuple<string, string, XmlNode[]>("lexicon", tool, collector);
-			Publisher.Publish(new PublisherParameterObject(EventConstants.GetContentControlParameters, parameter));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.GetContentControlParameters, parameter, m_propertyTable.GetWindow()));
 			var controlNode = collector[0];
 			var parameters = controlNode.SelectSingleNode("parameters");
 			var configureLayouts = XmlUtils.FindNode(parameters, "configureLayouts");

--- a/Src/xWorks/ExportDialog.cs
+++ b/Src/xWorks/ExportDialog.cs
@@ -518,7 +518,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			var collector = new XmlNode[1];
 			var parameter = new Tuple<string, string, XmlNode[]>(area, tool, collector);
-			Publisher.Publish(new PublisherParameterObject(EventConstants.GetContentControlParameters, parameter));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.GetContentControlParameters, parameter, m_propertyTable.GetWindow()));
 			var controlNode = collector[0];
 			Debug.Assert(controlNode != null);
 			XmlNode dynLoaderNode = controlNode.SelectSingleNode("dynamicloaderinfo");
@@ -1078,7 +1078,7 @@ namespace SIL.FieldWorks.XWorks
 			var sXslts = (string)args[2];
 			m_progressDlg = progress;
 			var parameter = new Tuple<string, string, string>(sDataType, outPath, sXslts);
-			Publisher.Publish(new PublisherParameterObject(EventConstants.SaveAsWebpage, parameter));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.SaveAsWebpage, parameter, m_propertyTable.GetWindow()));
 			m_progressDlg.Step(1000);
 			return null;
 		}

--- a/Src/xWorks/FwXApp.cs
+++ b/Src/xWorks/FwXApp.cs
@@ -200,7 +200,7 @@ namespace SIL.FieldWorks.XWorks
 			FwXWindow fwxwnd = m_rgMainWindows.Count > 0 ? (FwXWindow)m_rgMainWindows[0] : null;
 			if (fwxwnd != null)
 			{
-				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, link));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, link, fwxwnd));
 				bool topmost = fwxwnd.TopMost;
 				fwxwnd.TopMost = true;
 				fwxwnd.TopMost = topmost;

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -314,7 +314,7 @@ namespace SIL.FieldWorks.XWorks
 				m_propertyTable.SetProperty("App", app, true);
 				m_propertyTable.SetPropertyPersistence("App", false);
 			}
-			Subscriber.Subscribe(EventConstants.JumpToPopupLexEntry, JumpToPopupLexEntry);
+			Subscriber.Subscribe(EventConstants.JumpToPopupLexEntry, JumpToPopupLexEntry, this);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -1673,7 +1673,7 @@ namespace SIL.FieldWorks.XWorks
 			// REVIEW (Hasso) 2023.07: we had used MediatorSendMessageToAllNow as this needs to go to everyone right now.  This
 			// method on the mediator will not stop when the message is handled, nor is it deferred.
 			// REVIEW: do we need to replicate this urgency in PubSub?
-			Publisher.Publish(new PublisherParameterObject(EventConstants.PrepareToRefresh));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.PrepareToRefresh, null, this));
 		}
 
 		/// <summary>
@@ -1870,7 +1870,7 @@ namespace SIL.FieldWorks.XWorks
 				(m_app as FwXApp).OnMasterRefresh(null);
 
 				// Refresh the fonts on popup windows.
-				Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshPopupWindowFonts, null));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshPopupWindowFonts, null, this));
 			}
 			return false;   // refresh already called if needed
 		}
@@ -2136,7 +2136,7 @@ namespace SIL.FieldWorks.XWorks
 			// into a situation where the main window was disposed of while the parser
 			// thread was trying to execute com calls on the UI thread and using the
 			// main form as the Invoke point.
-			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser, null, this));
 			base.XWindow_Closing(sender, e);
 		}
 
@@ -2260,7 +2260,7 @@ namespace SIL.FieldWorks.XWorks
 
 			if (m_startupLink != null)
 			{
-				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, m_startupLink));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, m_startupLink, this));
 			}
 			UpdateControls();
 			return true;

--- a/Src/xWorks/GeneratedHtmlViewer.cs
+++ b/Src/xWorks/GeneratedHtmlViewer.cs
@@ -789,9 +789,9 @@ namespace SIL.FieldWorks.XWorks
 
 			//add our current state to the history system
 			string toolName = m_propertyTable.GetStringProperty("currentContentControl", "");
-			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, Guid.Empty)));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, Guid.Empty), m_propertyTable.GetWindow()));
 
-			Subscriber.Subscribe(EventConstants.SaveAsWebpage, SaveAsWebpage);
+			Subscriber.Subscribe(EventConstants.SaveAsWebpage, SaveAsWebpage, m_propertyTable.GetWindow());
 		}
 #if notnow
 		void Browser_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)

--- a/Src/xWorks/LinkListener.cs
+++ b/Src/xWorks/LinkListener.cs
@@ -195,9 +195,9 @@ namespace SIL.FieldWorks.XWorks
 			m_propertyTable.SetProperty("LinkListener", this, true);
 			m_propertyTable.SetPropertyPersistence("LinkListener", false);
 
-			Subscriber.Subscribe(EventConstants.AddContextToHistory, AddContextToHistory);
-			Subscriber.Subscribe(EventConstants.HandleLocalHotlink, HandleLocalHotlink);
-			Subscriber.Subscribe(EventConstants.FollowLink, FollowLink);
+			Subscriber.Subscribe(EventConstants.AddContextToHistory, AddContextToHistory, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.HandleLocalHotlink, HandleLocalHotlink, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.FollowLink, FollowLink, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>
@@ -418,7 +418,7 @@ namespace SIL.FieldWorks.XWorks
 			CheckDisposed();
 			LcmCache cache = m_propertyTable.GetValue<LcmCache>("cache");
 			Guid[] guids = (from entry in cache.LanguageProject.LexDbOA.Entries select entry.Guid).ToArray();
-			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexiconEdit", guids[guids.Length - 1])));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.FollowLink, new FwLinkArgs("lexiconEdit", guids[guids.Length - 1]), m_propertyTable.GetWindow()));
 			return true;
 		}
 
@@ -512,7 +512,7 @@ namespace SIL.FieldWorks.XWorks
 							// Thus we've created this method (on AreaListener) which we call through the FwUtils Publisher/Subscriber.
 							var parameters = new object[2];
 							parameters[0] = majorObject;
-							Publisher.Publish(new PublisherParameterObject(EventConstants.GetToolForList, parameters));
+							Publisher.Publish(new PublisherParameterObject(EventConstants.GetToolForList, parameters, m_propertyTable.GetWindow()));
 							realTool = (string)parameters[1];
 							break;
 						case RnResearchNbkTags.kClassId:
@@ -555,7 +555,7 @@ namespace SIL.FieldWorks.XWorks
 						true);
 					m_propertyTable.SetPropertyPersistence("SuspendLoadingRecordUntilOnJumpToRecord", false);
 				}
-				Publisher.Publish(new PublisherParameterObject(EventConstants.SetToolFromName, m_lnkActive.ToolName));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.SetToolFromName, m_lnkActive.ToolName, m_propertyTable.GetWindow()));
 				// Note: It can be Guid.Empty in cases where it was never set,
 				// or more likely, when the HVO was set to -1.
 				if (m_lnkActive.TargetGuid != Guid.Empty)

--- a/Src/xWorks/RecordBrowseView.cs
+++ b/Src/xWorks/RecordBrowseView.cs
@@ -678,8 +678,8 @@ namespace SIL.FieldWorks.XWorks
 			// so call it again, since we are ready now.
 			ShowRecord();
 
-			Subscriber.Subscribe(EventConstants.ClerkOwningObjChanged, ClerkOwningObjChanged);
-			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing);
+			Subscriber.Subscribe(EventConstants.ClerkOwningObjChanged, ClerkOwningObjChanged, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing, m_propertyTable.GetWindow());
 		}
 
 		private void CheckExpectedListItemsClassInSync()

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -1375,7 +1375,7 @@ namespace SIL.FieldWorks.XWorks
 					}
 				}
 				if (old != newObj)
-					Publisher.Publish(new PublisherParameterObject(EventConstants.ClerkOwningObjChanged, this));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.ClerkOwningObjChanged, this, m_propertyTable.GetWindow()));
 			}
 		}
 
@@ -2102,8 +2102,8 @@ namespace SIL.FieldWorks.XWorks
 		virtual public void ActivateUI(bool useRecordTreeBar, bool updateStatusBar = true)
 		{
 			// RecordClerk only needs to handle changes if RecordClerk is being used in GUI
-			Subscriber.Subscribe(EventConstants.FilterListChanged, FilterListChanged);
-			Subscriber.Subscribe(EventConstants.DeleteRecord, DeleteRecord);
+			Subscriber.Subscribe(EventConstants.FilterListChanged, FilterListChanged, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.DeleteRecord, DeleteRecord, m_propertyTable.GetWindow());
 
 			m_fIsActiveInGui = true;
 			CheckDisposed();
@@ -2312,7 +2312,7 @@ namespace SIL.FieldWorks.XWorks
 					{
 						m_list.CurrentIndex = FindClosestValidIndex(idx, cobj);
 					}
-					Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser));
+					Publisher.Publish(new PublisherParameterObject(EventConstants.StopParser, null, m_propertyTable.GetWindow()));
 				}
 				finally
 				{
@@ -2539,7 +2539,7 @@ namespace SIL.FieldWorks.XWorks
 			try
 			{
 				var retObj = new ReturnObject(argument);
-				Publisher.Publish(new PublisherParameterObject(EventConstants.DialogInsertItemInVector, retObj));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.DialogInsertItemInVector, retObj, m_propertyTable.GetWindow()));
 				if (retObj.ReturnValue)
 					return true;
 			}
@@ -3160,13 +3160,13 @@ namespace SIL.FieldWorks.XWorks
 			// For now, we'll not try to be concerned about restoring scroll position
 			// in a context where we're reloading after suppressing a reload.
 			if (!m_fReloadingDueToMissingObject)
-				Publisher.Publish(new PublisherParameterObject(EventConstants.SaveScrollPosition, this));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.SaveScrollPosition, this, m_propertyTable.GetWindow()));
 		}
 
 		private void m_list_DoneReload(object sender, EventArgs e)
 		{
 			if (!m_fReloadingDueToMissingObject)
-				Publisher.Publish(new PublisherParameterObject(EventConstants.RestoreScrollPosition, this));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.RestoreScrollPosition, this, m_propertyTable.GetWindow()));
 		}
 
 		internal ListUpdateHelper UpdateHelper { get; set; }

--- a/Src/xWorks/RecordDocView.cs
+++ b/Src/xWorks/RecordDocView.cs
@@ -68,7 +68,7 @@ namespace SIL.FieldWorks.XWorks
 			InitBase(mediator, propertyTable, configurationParameters);
 			m_fullyInitialized = true;
 
-			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing);
+			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing, m_propertyTable.GetWindow());
 		}
 
 		protected override void GetMessageAdditionalTargets(System.Collections.Generic.List<IxCoreColleague> collector)

--- a/Src/xWorks/RecordEditView.cs
+++ b/Src/xWorks/RecordEditView.cs
@@ -126,7 +126,7 @@ namespace SIL.FieldWorks.XWorks
 			m_dataEntryForm.StyleSheet = FontHeightAdjuster.StyleSheetFromPropertyTable(m_propertyTable);
 			m_fullyInitialized = true;
 
-			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing);
+			Subscriber.Subscribe(EventConstants.ConsideringClosing, ConsideringClosing, m_propertyTable.GetWindow());
 		}
 
 		/// -----------------------------------------------------------------------------------

--- a/Src/xWorks/RecordView.cs
+++ b/Src/xWorks/RecordView.cs
@@ -163,7 +163,7 @@ namespace SIL.FieldWorks.XWorks
 				if (Clerk.CurrentObject != null)
 					guid = Clerk.CurrentObject.Guid;
 				Clerk.SelectedRecordChanged(true, true); // make sure we update the record count in the Status bar.
-				Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, guid)));
+				Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, guid), m_propertyTable.GetWindow()));
 			}
 		}
 

--- a/Src/xWorks/XWorksViewBase.cs
+++ b/Src/xWorks/XWorksViewBase.cs
@@ -565,7 +565,7 @@ namespace SIL.FieldWorks.XWorks
 
 		private void ReloadListsArea()
 		{
-			Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists"));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", m_propertyTable.GetWindow()));
 		}
 
 		private void DoDeleteCustomListCmd(ICmPossibilityList curList)

--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -713,7 +713,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 				// Jump to field on idle to allow JumpToRecord to finish.
 				object[] arguments = new object[] { fieldObj.Hvo, fieldName, fieldElement.TextContent };
-				Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.JumpToField, arguments));
+				Publisher.PublishAtEndOfAction(new PublisherParameterObject(EventConstants.JumpToField, arguments, propertyTable.GetWindow()));
 			}
 		}
 
@@ -1520,7 +1520,7 @@ namespace SIL.FieldWorks.XWorks
 				{
 					if (progressDlg.IsCanceling)
 					{
-						Publisher.Publish(new PublisherParameterObject(EventConstants.SetToolFromName, "lexiconEdit"));
+						Publisher.Publish(new PublisherParameterObject(EventConstants.SetToolFromName, "lexiconEdit", m_propertyTable.GetWindow()));
 					}
 					else
 					{

--- a/Src/xWorks/XmlDocView.cs
+++ b/Src/xWorks/XmlDocView.cs
@@ -798,7 +798,7 @@ namespace SIL.FieldWorks.XWorks
 			Guid guid = Guid.Empty;
 			if (clerk.CurrentObject != null)
 				guid = clerk.CurrentObject.Guid;
-			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, guid)));
+			Publisher.Publish(new PublisherParameterObject(EventConstants.AddContextToHistory, new FwLinkArgs(toolName, guid), m_propertyTable.GetWindow()));
 
 			SelectAndScrollToCurrentRecord();
 			base.ShowRecord();
@@ -1269,7 +1269,7 @@ namespace SIL.FieldWorks.XWorks
 
 			InitBase(mediator, propertyTable, configurationParameters);
 
-			Subscriber.Subscribe(EventConstants.ClerkOwningObjChanged, ClerkOwningObjChanged);
+			Subscriber.Subscribe(EventConstants.ClerkOwningObjChanged, ClerkOwningObjChanged, m_propertyTable.GetWindow());
 		}
 
 		/// <summary>


### PR DESCRIPTION
The Pub/Sub framework was allowing Subscribers to receive messages from all Publishers.  In most cases we want this to be scoped to only include Subscribers with the same Main Window (IxWindow) as the Publisher. Now both the Publish() and Subscribe() methods take a IPubSubScope object as a Parameter (IxWindow is not available in the Pub/Sub dll).
Note: We use the interface to prevent accidentally passing a dialog instead of the main window (ex. passing Form.ActiveForm inside a modal).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/957)
<!-- Reviewable:end -->
