### PR TITLE
LT-20644: Fix SFM import stripping upper Unicode plane chars

### DIFF
--- a/Src/Utilities/SfmToXml/Converter.cs
+++ b/Src/Utilities/SfmToXml/Converter.cs
@@ -2583,7 +2583,11 @@ namespace Sfm2Xml
 			processedText = processedText.Trim();	// remove whitespace
 
 			// make sure the data is only in the following range:
-			// 0x09, 0x0a, 0x0d, 0x20-0xd7ff, 0xe000-0xfffd
+			// 0x09, 0x0a, 0x0d, 0x20-0xd7ff, 0xe000-0xfffd, 0x10000-0x10ffff
+			// The last range (supplementary planes) is encoded in .NET strings as
+			// surrogate pairs (a high surrogate 0xd800-0xdbff followed by a low
+			// surrogate 0xdc00-0xdfff). These are valid XML characters and must be
+			// preserved; only lone/unpaired surrogates are invalid (LT-20644).
 			// not using foreach so chars can be removed during processing w/o messing up the iterator
 			System.Text.StringBuilder strTemp = new System.Text.StringBuilder(processedText);
 			int lastPos = strTemp.Length;
@@ -2596,6 +2600,10 @@ namespace Sfm2Xml
 					c == 0x09 || c == 0x0d || c== 0x0a)
 				{
 					pos++;	// valid data
+				}
+				else if (char.IsHighSurrogate(c) && pos + 1 < lastPos && char.IsLowSurrogate(strTemp[pos + 1]))
+				{
+					pos += 2;	// valid surrogate pair (supplementary-plane character)
 				}
 				else
 				{

--- a/Src/Utilities/SfmToXml/Sfm2XmlTests/ConverterTests.cs
+++ b/Src/Utilities/SfmToXml/Sfm2XmlTests/ConverterTests.cs
@@ -135,6 +135,61 @@ namespace Sfm2XmlTests
 				$"Expected NFD normalization, but got: {string.Join(" ", outputText.Select(c => $"U+{(int)c:X4}"))}");
 		}
 
+		[Test]
+		public void ConverterPreservesSupplementaryPlaneCharacters()
+		{
+			// Wancho letters in the Supplementary Multilingual Plane (U+1E2C0 block),
+			// each encoded in .NET as a UTF-16 surrogate pair. Previously the importer
+			// stripped these as "invalid" characters because the validity check omitted
+			// the U+10000-U+10FFFF range (LT-20644).
+			const string supplementary = "\U0001E2CC\U0001E2C1\U0001E2D4"; // three Wancho letters
+
+			string sfmString = $@"\lx {supplementary}
+\ps n
+\ge test";
+
+			const string mappingString = @"<sfmMapping version='6.1'>
+<settings>
+<meaning app='fw.sil.org'/>
+</settings>
+<languages>
+<langDef id='English' xml:lang='en'/>
+<langDef id='Vernacular' xml:lang='fr'/>
+</languages>
+<hierarchy>
+<level name='Entry' partOf='records' beginFields='lx'/>
+<level name='Sense' partOf='Entry' beginFields='ge ps'/>
+</hierarchy>
+<fieldDescriptions>
+<field sfm='lx' name='Lexeme Form' type='string' lang='Vernacular'/>
+<field sfm='ps' name='Category' type='string' lang='English'/>
+<field sfm='ge' name='Gloss' type='string' lang='English'/>
+</fieldDescriptions>
+</sfmMapping>";
+
+			var sfmFile = Path.GetTempFileName();
+			var mappingFile = Path.GetTempFileName();
+			var outputFile = Path.GetTempFileName();
+
+			// SFM files are read as UTF-8 by the importer.
+			File.WriteAllText(sfmFile, sfmString, new UTF8Encoding(false));
+			File.WriteAllText(mappingFile, mappingString);
+
+			var converter = new Converter(null);
+			converter.Convert(sfmFile, mappingFile, outputFile);
+
+			var doc = new XmlDocument();
+			doc.Load(outputFile);
+
+			var lexemeNode = doc.SelectSingleNode("//lx | //LexemeForm | //Lexeme");
+			Assert.NotNull(lexemeNode, "Lexeme node was not found in output XML");
+
+			// The supplementary characters must survive the import unchanged
+			// (NFD normalization leaves these code points untouched).
+			Assert.AreEqual(supplementary, lexemeNode.InnerText,
+				"Supplementary-plane characters were not preserved during SFM import");
+		}
+
 		private static bool IsNfd(string s)
 		{
 			return s == s.Normalize(NormalizationForm.FormD);


### PR DESCRIPTION
## Summary

The SFM importer's character-validity check allowed only the BMP XML ranges (`[0x20-0xD7FF]`, `[0xE000-0xFFFD]`) and omitted the supplementary planes (`[0x10000-0x10FFFF]`). .NET strings encode those code points as UTF-16 **surrogate pairs**, so each surrogate code unit was flagged invalid and removed — corrupting any imported data containing characters above U+FFFF (e.g. Wancho, Gothic, Adlam, emoji).

This produced errors like *"SFM 'de' contains character value 0xD800, which is invalid and has been removed"* and silently dropped the affected characters from the import.

## Fix

In `Sfm2Xml.Converter.ProcessSFMandData`, recognize a valid high+low surrogate pair as a single supplementary-plane character and preserve it. Lone/unpaired surrogates are still removed (they remain invalid XML).

## Testing

- **New unit test** `ConverterPreservesSupplementaryPlaneCharacters` imports an SFM entry with supplementary-plane (Wancho) characters and asserts they survive the conversion. All Sfm2XmlTests pass.
- **Real-data verification**: ran the production converter against the ticket's actual `.db` + `.map` files. Before: 14 invalid-character errors; after: **0 errors**, with all supplementary code points (Gothic, Adlam, emoji) preserved intact and the belly/navel synonym cross-references correct.

The conversion-to-XML stage (where the bug lived and where the reported errors originated) is fully validated. End-to-end GUI import was not automated in this change.

## Notes

LT-22020 (Adlam block import) shares this exact root cause and is also resolved by this fix, but is intentionally **not referenced here** — it is not in the current sprint and will be tested/closed separately once a build is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/960)
<!-- Reviewable:end -->
