### PR TITLE
Fix LT-22561: Incorrect gram. info combos on create for an affix

### DIFF
--- a/Src/LexText/LexTextControls/LexTextControlsTests/MsaTypeRulesTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/MsaTypeRulesTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using NUnit.Framework;
+using SIL.FieldWorks.LexText.Controls;
+using SIL.LCModel;
+
+namespace LexTextControlsTests
+{
+	/// <summary>
+	/// Pure tests (no cache, no UI, no STA) for the MSA editing rules extracted from MSAGroupBox.
+	/// </summary>
+	[TestFixture]
+	public class MsaTypeRulesTests
+	{
+		[TestCase(MsaType.kUnclassified, true)]
+		[TestCase(MsaType.kInfl, true)]
+		[TestCase(MsaType.kDeriv, true)]
+		[TestCase(MsaType.kStem, false)]
+		[TestCase(MsaType.kRoot, false)]
+		[TestCase(MsaType.kNotSet, false)]
+		[TestCase(MsaType.kMixed, false)]
+		public void IsAffixMsaType_OnlyAffixTypesAreAffixes(MsaType type, bool expected)
+		{
+			Assert.That(MsaTypeRules.IsAffixMsaType(type), Is.EqualTo(expected));
+		}
+
+		// Encodes the regression fix (LT-22194): setting the main category must not force kStem
+		// when an affix type has already been established.
+		[TestCase(MsaType.kUnclassified, false)]
+		[TestCase(MsaType.kInfl, false)]
+		[TestCase(MsaType.kDeriv, false)]
+		[TestCase(MsaType.kStem, false)]
+		[TestCase(MsaType.kRoot, true)]
+		[TestCase(MsaType.kNotSet, true)]
+		[TestCase(MsaType.kMixed, true)]
+		public void ShouldForceStemForMainPos_PreservesAffixTypes(MsaType current, bool expected)
+		{
+			Assert.That(MsaTypeRules.ShouldForceStemForMainPos(current), Is.EqualTo(expected));
+		}
+
+		[TestCase(MoMorphTypeTags.kMorphStem)]
+		[TestCase(MoMorphTypeTags.kMorphBoundStem)]
+		[TestCase(MoMorphTypeTags.kMorphPhrase)]
+		[TestCase(MoMorphTypeTags.kMorphDiscontiguousPhrase)]
+		public void MsaTypeForMorphType_StemLikeTypes_ReturnStem(string morphTypeGuid)
+		{
+			// Result is independent of the current type for stem-like morpheme types.
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(morphTypeGuid, MsaType.kNotSet), Is.EqualTo(MsaType.kStem));
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(morphTypeGuid, MsaType.kInfl), Is.EqualTo(MsaType.kStem));
+		}
+
+		[TestCase(MoMorphTypeTags.kMorphProclitic)]
+		[TestCase(MoMorphTypeTags.kMorphClitic)]
+		[TestCase(MoMorphTypeTags.kMorphEnclitic)]
+		[TestCase(MoMorphTypeTags.kMorphParticle)]
+		[TestCase(MoMorphTypeTags.kMorphRoot)]
+		[TestCase(MoMorphTypeTags.kMorphBoundRoot)]
+		public void MsaTypeForMorphType_RootLikeTypes_ReturnRoot(string morphTypeGuid)
+		{
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(morphTypeGuid, MsaType.kNotSet), Is.EqualTo(MsaType.kRoot));
+		}
+
+		[TestCase(MoMorphTypeTags.kMorphPrefix)]
+		[TestCase(MoMorphTypeTags.kMorphSuffix)]
+		[TestCase(MoMorphTypeTags.kMorphInfix)]
+		[TestCase(MoMorphTypeTags.kMorphCircumfix)]
+		public void MsaTypeForMorphType_AffixTypes_FromStemLike_ReturnUnclassified(string morphTypeGuid)
+		{
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(morphTypeGuid, MsaType.kStem), Is.EqualTo(MsaType.kUnclassified));
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(morphTypeGuid, MsaType.kRoot), Is.EqualTo(MsaType.kUnclassified));
+		}
+
+		[TestCase(MsaType.kUnclassified)]
+		[TestCase(MsaType.kInfl)]
+		[TestCase(MsaType.kDeriv)]
+		public void MsaTypeForMorphType_AffixTypes_KeepExistingAffixType(MsaType current)
+		{
+			// An affix morpheme type must not downgrade a more specific affix type already chosen.
+			Assert.That(MsaTypeRules.MsaTypeForMorphType(MoMorphTypeTags.kMorphPrefix, current), Is.EqualTo(current));
+		}
+	}
+
+	/// <summary>
+	/// Cache-backed tests (no UI, no STA) for <see cref="MsaTypeRules.BuildSandboxMsa"/>, which needs
+	/// real IPartOfSpeech / IMoInflAffixSlot model objects. The objects are created in CreateTestData
+	/// so they run inside the base fixture's unit of work (avoiding nested-task errors).
+	/// </summary>
+	[TestFixture]
+	public class MsaTypeRulesSandboxMsaTests : MemoryOnlyBackendProviderRestoredForEachTestTestBase
+	{
+		private IPartOfSpeech m_mainPos;
+		private IPartOfSpeech m_secondaryPos;
+		private IMoInflAffixSlot m_slot;
+
+		protected override void CreateTestData()
+		{
+			base.CreateTestData();
+			var posFactory = Cache.ServiceLocator.GetInstance<IPartOfSpeechFactory>();
+			m_mainPos = posFactory.Create();
+			Cache.LangProject.PartsOfSpeechOA.PossibilitiesOS.Add(m_mainPos);
+			m_secondaryPos = posFactory.Create();
+			Cache.LangProject.PartsOfSpeechOA.PossibilitiesOS.Add(m_secondaryPos);
+			m_slot = Cache.ServiceLocator.GetInstance<IMoInflAffixSlotFactory>().Create();
+			m_mainPos.AffixSlotsOC.Add(m_slot);
+		}
+
+		// SandboxGenericMSA stores a root as a stem MSA, so kRoot reads back as kStem.
+		[TestCase(MsaType.kStem, MsaType.kStem)]
+		[TestCase(MsaType.kRoot, MsaType.kStem)]
+		[TestCase(MsaType.kUnclassified, MsaType.kUnclassified)]
+		public void BuildSandboxMsa_SimpleTypes_SetOnlyMainPos(MsaType type, MsaType expectedMsaType)
+		{
+			var msa = MsaTypeRules.BuildSandboxMsa(type, m_mainPos, null, null, false);
+
+			Assert.That(msa.MsaType, Is.EqualTo(expectedMsaType));
+			Assert.That(msa.MainPOS, Is.EqualTo(m_mainPos));
+			Assert.That(msa.SecondaryPOS, Is.Null);
+			Assert.That(msa.Slot, Is.Null);
+		}
+
+		[Test]
+		public void BuildSandboxMsa_Deriv_SetsSecondaryPos()
+		{
+			var msa = MsaTypeRules.BuildSandboxMsa(MsaType.kDeriv, m_mainPos, m_secondaryPos, null, false);
+
+			Assert.That(msa.MsaType, Is.EqualTo(MsaType.kDeriv));
+			Assert.That(msa.MainPOS, Is.EqualTo(m_mainPos));
+			Assert.That(msa.SecondaryPOS, Is.EqualTo(m_secondaryPos));
+			Assert.That(msa.Slot, Is.Null);
+		}
+
+		[Test]
+		public void BuildSandboxMsa_Infl_IncludesSlotOnlyWhenValid()
+		{
+			Assert.That(MsaTypeRules.BuildSandboxMsa(MsaType.kInfl, m_mainPos, null, m_slot, true).Slot,
+				Is.EqualTo(m_slot), "a valid slot should be included");
+			Assert.That(MsaTypeRules.BuildSandboxMsa(MsaType.kInfl, m_mainPos, null, m_slot, false).Slot,
+				Is.Null, "slot must be dropped when not valid for the category");
+			Assert.That(MsaTypeRules.BuildSandboxMsa(MsaType.kInfl, m_mainPos, null, null, true).Slot,
+				Is.Null, "a null slot stays null");
+		}
+	}
+}

--- a/Src/LexText/LexTextControls/MSAGroupBox.cs
+++ b/Src/LexText/LexTextControls/MSAGroupBox.cs
@@ -69,36 +69,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			{
 				CheckDisposed();
 
-				SandboxGenericMSA sandoxMSA = new SandboxGenericMSA();
-				sandoxMSA.MsaType = MSAType;
-				switch (MSAType)
-				{
-					case MsaType.kRoot: // Fall through
-					case MsaType.kStem:
-					{
-						sandoxMSA.MainPOS = MainPOS;
-						break;
-					}
-					case MsaType.kInfl:
-					{
-						sandoxMSA.MainPOS = MainPOS;
-						if (Slot != null && SlotIsValidForPos)
-							sandoxMSA.Slot = Slot;
-						break;
-					}
-					case MsaType.kDeriv:
-					{
-						sandoxMSA.MainPOS = MainPOS;
-						sandoxMSA.SecondaryPOS = SecondaryPOS;
-						break;
-					}
-					case MsaType.kUnclassified:
-					{
-						sandoxMSA.MainPOS = MainPOS;
-						break;
-					}
-				}
-				return sandoxMSA;
+				return MsaTypeRules.BuildSandboxMsa(MSAType, MainPOS, SecondaryPOS, Slot, SlotIsValidForPos);
 			}
 		}
 
@@ -127,7 +98,8 @@ namespace SIL.FieldWorks.LexText.Controls
 					return; // Can't set it zero, no matter what, until PopupTree supports it.
 
 				m_selectedMainPOS = value;
-				if (MSAType != MsaType.kStem)
+				// Setting the category must not turn an affix entry into a stem (see ShouldForceStemForMainPos).
+				if (MsaTypeRules.ShouldForceStemForMainPos(MSAType))
 					MSAType = MsaType.kStem;
 				// In order to select the node, we must have loaded the tree.
 				TrySelectNode(m_tcMainPOS, m_selectedMainPOS.Hvo);
@@ -357,40 +329,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					ResetSlotCombo();
 				string sGuid = m_morphType.Guid.ToString();
 				Debug.Assert(sGuid != null && sGuid != String.Empty);
-				switch (sGuid)
-				{
-					case MoMorphTypeTags.kMorphStem:
-					case MoMorphTypeTags.kMorphBoundStem:
-					case MoMorphTypeTags.kMorphPhrase:
-					case MoMorphTypeTags.kMorphDiscontiguousPhrase:
-						MSAType = MsaType.kStem;
-						break;
-					case MoMorphTypeTags.kMorphProclitic:
-					case MoMorphTypeTags.kMorphClitic:
-					case MoMorphTypeTags.kMorphEnclitic:
-					case MoMorphTypeTags.kMorphParticle:
-					case MoMorphTypeTags.kMorphRoot:
-					case MoMorphTypeTags.kMorphBoundRoot:
-						MSAType = MsaType.kRoot;
-						break;
-					default:
-						/*
-						  MoMorphTypeTags.kMorphInfix
-						  MoMorphTypeTags.kMorphPrefix
-						  MoMorphTypeTags.kMorphSimulfix
-						  MoMorphTypeTags.kMorphSuffix
-						  MoMorphTypeTags.kMorphSuprafix
-						  MoMorphTypeTags.kMorphCircumfix
-						  MoMorphTypeTags.kMorphInfixingInterfix
-						  MoMorphTypeTags.kMorphPrefixingInterfix
-						  MoMorphTypeTags.kMorphSuffixingInterfix
-						*/
-						// It may already be set to a better type than MsaType.kUnclassified,
-						// so leave it alone, if it is.
-						if (MSAType == MsaType.kRoot || MSAType == MsaType.kStem)
-							MSAType = MsaType.kUnclassified;
-						break;
-				}
+				MSAType = MsaTypeRules.MsaTypeForMorphType(sGuid, MSAType);
 			}
 		}
 

--- a/Src/LexText/LexTextControls/MsaTypeRules.cs
+++ b/Src/LexText/LexTextControls/MsaTypeRules.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using SIL.LCModel;
+using SIL.LCModel.DomainServices;
+
+namespace SIL.FieldWorks.LexText.Controls
+{
+	/// <summary>
+	/// Presentation-agnostic rules for editing a morpho-syntactic analysis (MSA). These mappings
+	/// are extracted from <see cref="MSAGroupBox"/> so they can be unit tested without a WinForms
+	/// control, a running cache, or an STA thread, and so a future non-WinForms view can reuse
+	/// exactly the same logic instead of reimplementing it.
+	/// </summary>
+	internal static class MsaTypeRules
+	{
+		/// <summary>
+		/// The three affix MSA types. These mirror the three affix MSA classes
+		/// (kInfl=MoInflAffMsa, kDeriv=MoDerivAffMsa, kUnclassified=MoUnclassifiedAffixMsa) and the
+		/// three entries of the affix-type combo (Inflectional/Derivational/Not Sure). For all of
+		/// them the editor shows the affix layout ("Attaches to category"); kStem/kRoot show the
+		/// stem layout, and kNotSet/kMixed are not used by the editor.
+		/// </summary>
+		internal static bool IsAffixMsaType(MsaType type)
+		{
+			return type == MsaType.kUnclassified || type == MsaType.kInfl || type == MsaType.kDeriv;
+		}
+
+		/// <summary>
+		/// Whether setting the main category should fall back to kStem. Setting the category must
+		/// not turn an affix entry into a stem, so only default to kStem from a stem-like or unset
+		/// type; an affix type that the morpheme type already established is preserved.
+		/// </summary>
+		internal static bool ShouldForceStemForMainPos(MsaType current)
+		{
+			return current != MsaType.kStem && !IsAffixMsaType(current);
+		}
+
+		/// <summary>
+		/// The MSA type implied by a morpheme type, given the type currently selected. Stem-like
+		/// morpheme types map to kStem/kRoot; affix morpheme types map to kUnclassified unless an
+		/// affix type is already chosen, in which case the (more specific) current type is kept.
+		/// </summary>
+		/// <param name="morphTypeGuid">The morpheme type's Guid as a string (IMoMorphType.Guid.ToString()).</param>
+		/// <param name="current">The currently selected MSA type.</param>
+		internal static MsaType MsaTypeForMorphType(string morphTypeGuid, MsaType current)
+		{
+			switch (morphTypeGuid)
+			{
+				case MoMorphTypeTags.kMorphStem:
+				case MoMorphTypeTags.kMorphBoundStem:
+				case MoMorphTypeTags.kMorphPhrase:
+				case MoMorphTypeTags.kMorphDiscontiguousPhrase:
+					return MsaType.kStem;
+				case MoMorphTypeTags.kMorphProclitic:
+				case MoMorphTypeTags.kMorphClitic:
+				case MoMorphTypeTags.kMorphEnclitic:
+				case MoMorphTypeTags.kMorphParticle:
+				case MoMorphTypeTags.kMorphRoot:
+				case MoMorphTypeTags.kMorphBoundRoot:
+					return MsaType.kRoot;
+				default:
+					// Affix morpheme types (prefix/suffix/infix/circumfix/simulfix/suprafix/interfixes).
+					// kInfl/kDeriv are more specific than kUnclassified, so leave them alone; only
+					// upgrade to kUnclassified from a stem-like type.
+					return (current == MsaType.kRoot || current == MsaType.kStem)
+						? MsaType.kUnclassified
+						: current;
+			}
+		}
+
+		/// <summary>
+		/// Build the <see cref="SandboxGenericMSA"/> described by the current editor state. The slot
+		/// is included only for an inflectional affix whose slot is valid for the selected category,
+		/// and the secondary category only for a derivational affix.
+		/// </summary>
+		internal static SandboxGenericMSA BuildSandboxMsa(MsaType type, IPartOfSpeech mainPos,
+			IPartOfSpeech secondaryPos, IMoInflAffixSlot slot, bool slotValid)
+		{
+			var sandboxMsa = new SandboxGenericMSA { MsaType = type };
+			switch (type)
+			{
+				case MsaType.kRoot: // Fall through
+				case MsaType.kStem:
+					sandboxMsa.MainPOS = mainPos;
+					break;
+				case MsaType.kInfl:
+					sandboxMsa.MainPOS = mainPos;
+					if (slot != null && slotValid)
+						sandboxMsa.Slot = slot;
+					break;
+				case MsaType.kDeriv:
+					sandboxMsa.MainPOS = mainPos;
+					sandboxMsa.SecondaryPOS = secondaryPos;
+					break;
+				case MsaType.kUnclassified:
+					sandboxMsa.MainPOS = mainPos;
+					break;
+			}
+			return sandboxMsa;
+		}
+	}
+}


### PR DESCRIPTION
* Fix a regression from LT-22194 where StemPOS forced the MSAType to stem. It did this whenever the category was set, even for affixes.

* Extract the MSA type rules out of MSAGroupBox into MsaTypeRules and cover them with unit tests, so the logic (including this fix) is verified without a cache, UI, or STA thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/961)
<!-- Reviewable:end -->
