### PR TITLE
Phase-1 follow-up: Avalonia rule-formula editors (Grammar)

### DIFF
--- a/Src/Common/FwAvalonia/FwAvaloniaStrings.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaStrings.cs
@@ -497,5 +497,26 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 
 		public static string FeatureAnalysesName => Text("FwAvalonia.Feature.AnalysesName", "Words Analyses");
 		public static string FeatureAnalysesDescription => Text("FwAvalonia.Feature.AnalysesDescription", "The interlinear morph-bundle editor.");
+
+		/// <summary>Group heading for the avalonia-rule-formula-editor tool surfaces in the feature-manager dialog.</summary>
+		public static string FeatureGroupGrammarRuleEditors => Text("FwAvalonia.FeatureGroup.GrammarRuleEditors", "Grammar rule editors");
+
+		public static string FeaturePhonologicalRuleEditName => Text("FwAvalonia.Feature.PhonologicalRuleEditName", "Phonological Rules");
+		public static string FeaturePhonologicalRuleEditDescription => Text("FwAvalonia.Feature.PhonologicalRuleEditDescription", "The regular and metathesis rule editors.");
+
+		public static string FeatureEnvironmentEditName => Text("FwAvalonia.Feature.EnvironmentEditName", "Phonological Environments");
+		public static string FeatureEnvironmentEditDescription => Text("FwAvalonia.Feature.EnvironmentEditDescription", "The phonological-environment string editor.");
+
+		public static string FeatureCompoundRuleAdvancedEditName => Text("FwAvalonia.Feature.CompoundRuleAdvancedEditName", "Compound Rules");
+		public static string FeatureCompoundRuleAdvancedEditDescription => Text("FwAvalonia.Feature.CompoundRuleAdvancedEditDescription", "The compound-rule editor.");
+
+		public static string FeatureNaturalClassEditName => Text("FwAvalonia.Feature.NaturalClassEditName", "Natural Classes");
+		public static string FeatureNaturalClassEditDescription => Text("FwAvalonia.Feature.NaturalClassEditDescription", "The natural-class editor.");
+
+		public static string FeaturePhonemeEditName => Text("FwAvalonia.Feature.PhonemeEditName", "Phonemes");
+		public static string FeaturePhonemeEditDescription => Text("FwAvalonia.Feature.PhonemeEditDescription", "The Basic IPA symbol editor.");
+
+		public static string FeatureAdhocCoprohibEditName => Text("FwAvalonia.Feature.AdhocCoprohibEditName", "Ad Hoc Co-occurrence Rules");
+		public static string FeatureAdhocCoprohibEditDescription => Text("FwAvalonia.Feature.AdhocCoprohibEditDescription", "The ad hoc co-occurrence-rule editor.");
 	}
 }

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/BasicIPASymbolEditorTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/BasicIPASymbolEditorTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using FwAvaloniaTests.VisualChecks;
+using FwAvaloniaDialogsTests;
+
+namespace FwAvaloniaTests
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — the Basic IPA Symbol editor control: typing a symbol commits
+	/// through the sink; with no sink it is read-only. PNG + AssertNoCrowding.
+	/// </summary>
+	[TestFixture]
+	public class BasicIPASymbolEditorTests
+	{
+		private sealed class FakeSink : IBasicIpaSymbolCommandSink
+		{
+			public string LastCommitted;
+			public bool Commit(string symbol) { LastCommitted = symbol; return true; }
+		}
+
+		private static TextBox Box(Control root) => root.GetVisualDescendants().OfType<TextBox>().First();
+
+		[AvaloniaTest]
+		public void Editable_CommitsTypedSymbol()
+		{
+			var sink = new FakeSink();
+			var editor = new BasicIPASymbolEditor("p", sink);
+			var window = new Window { Content = editor, Width = 240, Height = 70 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			window.UpdateLayout();
+			Dispatcher.UIThread.RunJobs();
+
+			DialogSnapshot.Capture(window, "BasicIPASymbolEditor-01-editable");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+
+			Box(editor).Text = "pʰ";
+			Assert.That(editor.TryCommit(), Is.True);
+			Assert.That(sink.LastCommitted, Is.EqualTo("pʰ"));
+			Assert.That(editor.CommittedText, Is.EqualTo("pʰ"));
+		}
+
+		[AvaloniaTest]
+		public void NoSink_IsReadOnly()
+		{
+			var editor = new BasicIPASymbolEditor("p", null);
+			var window = new Window { Content = editor, Width = 240, Height = 70 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(editor.IsEditable, Is.False);
+			Assert.That(Box(editor).IsReadOnly, Is.True);
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/PhEnvironmentEditorTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/PhEnvironmentEditorTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using FwAvaloniaTests.VisualChecks;
+using FwAvaloniaDialogsTests;
+
+namespace FwAvaloniaTests
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — the environment editor control: commit a valid string,
+	/// reject an invalid one (restore the last committed value + show the error). PNG + AssertNoCrowding.
+	/// </summary>
+	[TestFixture]
+	public class PhEnvironmentEditorTests
+	{
+		private sealed class FakeSink : IPhEnvironmentCommandSink
+		{
+			public string LastCommitted;
+			// "valid" = anything that is non-empty and balanced-ish; the real recognizer is tested in xWorks.
+			public bool Validate(string representation) => !(representation ?? "").Contains("X");
+			public bool Commit(string representation) { LastCommitted = representation; return true; }
+		}
+
+		private static (PhEnvironmentEditor Editor, Window Window, FakeSink Sink) Show(string initial)
+		{
+			var sink = new FakeSink();
+			var editor = new PhEnvironmentEditor(initial, sink);
+			var window = new Window { Content = editor, Width = 360, Height = 120 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			window.UpdateLayout();
+			Dispatcher.UIThread.RunJobs();
+			return (editor, window, sink);
+		}
+
+		private static TextBox Box(Control root) =>
+			root.GetVisualDescendants().OfType<TextBox>().First();
+
+		[AvaloniaTest]
+		public void ValidEdit_Commits()
+		{
+			var (editor, window, sink) = Show("/ _ #");
+			DialogSnapshot.Capture(window, "PhEnvironmentEditor-01-initial");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+
+			Box(editor).Text = "/ a _ #";
+			Assert.That(editor.TryCommit(), Is.True);
+			Assert.That(sink.LastCommitted, Is.EqualTo("/ a _ #"));
+			Assert.That(editor.CommittedText, Is.EqualTo("/ a _ #"));
+		}
+
+		[AvaloniaTest]
+		public void InvalidEdit_IsRejected_AndRestoresLastCommitted()
+		{
+			var (editor, window, sink) = Show("/ _ #");
+
+			Box(editor).Text = "/ X _ #";   // the fake validator rejects anything containing X
+			Assert.That(editor.TryCommit(), Is.False);
+			Assert.That(sink.LastCommitted, Is.Null, "an invalid string is never committed");
+			Assert.That(Box(editor).Text, Is.EqualTo("/ _ #"), "the box restores the last committed value");
+
+			DialogSnapshot.Capture(window, "PhEnvironmentEditor-02-invalid");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+		}
+
+		[AvaloniaTest]
+		public void InsertToolbar_OffersTheLiteralInserts()
+		{
+			var (editor, _, _) = Show(string.Empty);
+			var ids = editor.GetVisualDescendants().OfType<Button>()
+				.Select(b => Avalonia.Automation.AutomationProperties.GetAutomationId(b))
+				.Where(id => id != null && id.StartsWith("PhEnvInsert-"))
+				.ToList();
+			Assert.That(ids, Is.EquivalentTo(new[] { "PhEnvInsert-#", "PhEnvInsert-[", "PhEnvInsert-]", "PhEnvInsert-/", "PhEnvInsert-_" }),
+				"the insert toolbar offers the boundary/optional/slash/underscore literals");
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/RuleCellCommandsTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/RuleCellCommandsTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+
+namespace FwAvaloniaTests
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.2) — the <see cref="RuleCellSpec"/> option-key codec that round-
+	/// trips a chooser selection (the xWorks options projection builds the keys; the view decodes the
+	/// committed key back to a spec the handler applies).
+	/// </summary>
+	[TestFixture]
+	public class RuleCellCommandsTests
+	{
+		[TestCase(RuleCellKind.Phoneme, "P")]
+		[TestCase(RuleCellKind.NaturalClass, "N")]
+		[TestCase(RuleCellKind.Boundary, "B")]
+		public void OptionKey_RoundTrips_ForReferenceKinds(RuleCellKind kind, string prefix)
+		{
+			var guid = Guid.NewGuid();
+			var key = new RuleCellSpec(kind, guid).ToOptionKey();
+			Assert.That(key, Is.EqualTo(prefix + ":" + guid));
+
+			var back = RuleCellSpec.FromOptionKey(key);
+			Assert.That(back, Is.Not.Null);
+			Assert.That(back.Kind, Is.EqualTo(kind));
+			Assert.That(back.TargetGuid, Is.EqualTo(guid));
+		}
+
+		[Test]
+		public void FromOptionKey_RejectsMalformedOrTargetlessKeys()
+		{
+			Assert.That(RuleCellSpec.FromOptionKey(null), Is.Null);
+			Assert.That(RuleCellSpec.FromOptionKey(""), Is.Null);
+			Assert.That(RuleCellSpec.FromOptionKey("P"), Is.Null, "no separator");
+			Assert.That(RuleCellSpec.FromOptionKey("Z:" + Guid.NewGuid()), Is.Null, "unknown kind prefix");
+			Assert.That(RuleCellSpec.FromOptionKey("P:not-a-guid"), Is.Null, "a reference kind needs a parseable GUID");
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/RuleFormulaModelTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/RuleFormulaModelTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+
+namespace FwAvaloniaTests
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.1/1.2) — the LCModel-free rule-formula projection DTO the
+	/// Avalonia editor binds to. Sectioned (LHS/RHS/env) with immutable per-section cell-mutation helpers
+	/// (insert/remove/move) that underpin the editor staging before the Morphology plugin commits the
+	/// change to the rule in one UOW. <see cref="RuleFormulaModel.ToFormulaString"/> is the canonical
+	/// rendering the parity test asserts against.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaModelTests
+	{
+		private static RuleFormulaSection Three(RuleSectionRole role = RuleSectionRole.Lhs) =>
+			new RuleFormulaSection(role, new[]
+			{
+				new RuleCell(RuleCellKind.Phoneme, "p", Guid.NewGuid()),
+				new RuleCell(RuleCellKind.NaturalClass, "V", Guid.NewGuid()),
+				new RuleCell(RuleCellKind.Boundary, "#"),
+			});
+
+		private static string Text(RuleFormulaSection s) => string.Concat(s.Cells.Select(c => c.DisplayText));
+
+		[Test]
+		public void InsertCell_AddsAtIndex_AndIsImmutable()
+		{
+			var s = Three();
+			var n = s.InsertCell(1, new RuleCell(RuleCellKind.Slot, "X"));
+			Assert.That(Text(n), Is.EqualTo("pXV#"));
+			Assert.That(Text(s), Is.EqualTo("pV#"), "the original section is unchanged (immutable)");
+		}
+
+		[Test]
+		public void InsertCell_OutOfRangeIndex_IsClamped()
+		{
+			var s = Three();
+			Assert.That(Text(s.InsertCell(99, new RuleCell(RuleCellKind.Slot, "X"))), Is.EqualTo("pV#X"));
+			Assert.That(Text(s.InsertCell(-5, new RuleCell(RuleCellKind.Slot, "X"))), Is.EqualTo("XpV#"));
+		}
+
+		[Test]
+		public void RemoveCell_DropsCell_OrNoOpsOutOfRange()
+		{
+			var s = Three();
+			Assert.That(Text(s.RemoveCell(1)), Is.EqualTo("p#"));
+			Assert.That(s.RemoveCell(99), Is.SameAs(s), "out-of-range remove is a no-op returning the same section");
+		}
+
+		[Test]
+		public void MoveCell_ReordersCells()
+		{
+			Assert.That(Text(Three().MoveCell(0, 2)), Is.EqualTo("V#p"));
+		}
+
+		[Test]
+		public void Cell_CarriesKindAndTargetGuid()
+		{
+			var g = Guid.NewGuid();
+			var cell = new RuleCell(RuleCellKind.NaturalClass, "V", g);
+			Assert.That(cell.Kind, Is.EqualTo(RuleCellKind.NaturalClass));
+			Assert.That(cell.TargetGuid, Is.EqualTo(g));
+			Assert.That(new RuleCell(RuleCellKind.Slot, "X").TargetGuid, Is.Null, "a pure slot has no target");
+		}
+
+		[Test]
+		public void SectionFor_FindsByRole_AndWithSectionReplaces()
+		{
+			var model = new RuleFormulaModel("PhRegularRule", new[]
+			{
+				new RuleFormulaSection(RuleSectionRole.Lhs, new[] { new RuleCell(RuleCellKind.Phoneme, "p") }),
+				new RuleFormulaSection(RuleSectionRole.Rhs, Enumerable.Empty<RuleCell>()),
+			});
+			Assert.That(model.SectionFor(RuleSectionRole.Lhs).Cells, Has.Count.EqualTo(1));
+			Assert.That(model.SectionFor(RuleSectionRole.RightContext), Is.Null);
+
+			var rhsWithCell = model.SectionFor(RuleSectionRole.Rhs).InsertCell(0, new RuleCell(RuleCellKind.Boundary, "#"));
+			var updated = model.WithSection(1, rhsWithCell);
+			Assert.That(updated.SectionFor(RuleSectionRole.Rhs).Cells, Has.Count.EqualTo(1));
+			Assert.That(model.SectionFor(RuleSectionRole.Rhs).Cells, Is.Empty, "original model unchanged (immutable)");
+		}
+
+		[Test]
+		public void ToFormulaString_RendersBareTokens_NcBracketed_WithRoleSeparators()
+		{
+			// p → [V] / [C] __ #  — the canonical regular-rule formula oracle shape.
+			var model = new RuleFormulaModel("PhRegularRule", new[]
+			{
+				new RuleFormulaSection(RuleSectionRole.Lhs, new[] { new RuleCell(RuleCellKind.Phoneme, "p") }),
+				new RuleFormulaSection(RuleSectionRole.Rhs, new[] { new RuleCell(RuleCellKind.NaturalClass, "V") }),
+				new RuleFormulaSection(RuleSectionRole.LeftContext, new[] { new RuleCell(RuleCellKind.NaturalClass, "C") }),
+				new RuleFormulaSection(RuleSectionRole.RightContext, new[] { new RuleCell(RuleCellKind.Boundary, "#") }),
+			});
+			Assert.That(model.ToFormulaString(), Is.EqualTo("p → [V] / [C] __ #"));
+		}
+
+		[Test]
+		public void ToFormulaString_EmptySectionsContributeNothingButTheirSeparator()
+		{
+			var model = new RuleFormulaModel("PhRegularRule", new[]
+			{
+				new RuleFormulaSection(RuleSectionRole.Lhs, new[] { new RuleCell(RuleCellKind.Phoneme, "p") }),
+				new RuleFormulaSection(RuleSectionRole.Rhs, Enumerable.Empty<RuleCell>()),
+				new RuleFormulaSection(RuleSectionRole.LeftContext, Enumerable.Empty<RuleCell>()),
+				new RuleFormulaSection(RuleSectionRole.RightContext, Enumerable.Empty<RuleCell>()),
+			});
+			Assert.That(model.ToFormulaString(), Is.EqualTo("p →  /  __ "));
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/RuleFormulaRegionEditorTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/RuleFormulaRegionEditorTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using FwAvaloniaTests.VisualChecks; // DialogSnapshot — the PNG harness
+using FwAvaloniaDialogsTests;        // DialogLayoutAssert — the shared geometry tripwire
+
+namespace FwAvaloniaTests
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.3) — T5 visual baseline + render assertions for the read-only
+	/// <see cref="RuleFormulaRegionEditor"/>. Binds the LCModel-free <see cref="RuleFormulaModel"/> DTO and
+	/// renders the cell grid (LHS → RHS / LeftCtx __ RightCtx); these pin the visible states (a populated
+	/// regular rule, and one with empty cell groups) with a PNG per stage and the AssertNoCrowding tripwire.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaRegionEditorTests
+	{
+		private static RuleFormulaModel RegularRule() => new RuleFormulaModel("PhRegularRule", new[]
+		{
+			new RuleFormulaSection(RuleSectionRole.Lhs, new[] { new RuleCell(RuleCellKind.Phoneme, "p") }),
+			new RuleFormulaSection(RuleSectionRole.Rhs, new[] { new RuleCell(RuleCellKind.NaturalClass, "V") }),
+			new RuleFormulaSection(RuleSectionRole.LeftContext, new[] { new RuleCell(RuleCellKind.NaturalClass, "C") }),
+			new RuleFormulaSection(RuleSectionRole.RightContext, new[] { new RuleCell(RuleCellKind.Boundary, "#") }),
+		});
+
+		private static RuleFormulaModel PartlyEmptyRule() => new RuleFormulaModel("PhRegularRule", new[]
+		{
+			new RuleFormulaSection(RuleSectionRole.Lhs, new[] { new RuleCell(RuleCellKind.Phoneme, "p") }),
+			new RuleFormulaSection(RuleSectionRole.Rhs, Enumerable.Empty<RuleCell>()),
+			new RuleFormulaSection(RuleSectionRole.LeftContext, Enumerable.Empty<RuleCell>()),
+			new RuleFormulaSection(RuleSectionRole.RightContext, Enumerable.Empty<RuleCell>()),
+		});
+
+		private static (RuleFormulaRegionEditor Editor, Window Window) Show(RuleFormulaModel model)
+		{
+			var editor = new RuleFormulaRegionEditor(model);
+			var window = new Window { Content = editor, Width = 360, Height = 80 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			window.UpdateLayout();
+			Dispatcher.UIThread.RunJobs();
+			return (editor, window);
+		}
+
+		private static List<string> Texts(Control root) =>
+			root.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
+
+		[AvaloniaTest]
+		public void RegularRule_RendersCellsAndSeparators()
+		{
+			var (editor, window) = Show(RegularRule());
+
+			DialogSnapshot.Capture(window, "RuleFormulaEditor-01-regular");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+
+			Assert.That(AutomationProperties.GetAutomationId(editor), Is.EqualTo(RuleFormulaRegionEditor.RuleFormulaAutomationId));
+			Assert.That(AutomationProperties.GetName(editor), Is.EqualTo("p → [V] / [C] __ #"),
+				"the whole formula reads as the accessibility name");
+
+			var texts = Texts(editor);
+			Assert.That(texts, Does.Contain("p"));
+			Assert.That(texts, Does.Contain("[V]"), "a natural-class cell is bracketed chrome");
+			Assert.That(texts, Does.Contain("[C]"));
+			Assert.That(texts, Does.Contain("#"));
+			Assert.That(texts, Does.Contain("→").And.Contain("/").And.Contain("__"),
+				"the role chrome glyphs render as separators");
+		}
+
+		private sealed class FakeSink : IRuleCellCommandSink
+		{
+			public bool InsertCell(RuleSectionRole role, int index, RuleCellSpec spec) => true;
+			public bool DeleteCell(RuleSectionRole role, int index) => true;
+			public bool MoveCell(RuleSectionRole role, int from, int to) => true;
+			public bool SetCell(RuleSectionRole role, int index, RuleCellSpec spec) => true;
+		}
+
+		[AvaloniaTest]
+		public void EditableGrid_RendersChooserCells_AndInsertButtons_WithoutCrowding()
+		{
+			var editor = new RuleFormulaRegionEditor
+			{
+				Sink = new FakeSink(),
+				Options = new List<RegionChoiceOption>
+				{
+					new RegionChoiceOption("P:" + System.Guid.NewGuid(), "p"),
+					new RegionChoiceOption("N:" + System.Guid.NewGuid(), "V"),
+				}
+			};
+			editor.SetModel(RegularRule());
+			var window = new Window { Content = editor, Width = 420, Height = 90 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			window.UpdateLayout();
+			Dispatcher.UIThread.RunJobs();
+
+			DialogSnapshot.Capture(window, "RuleFormulaEditor-03-editable");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+
+			Assert.That(editor.IsEditable, Is.True);
+			var buttons = editor.GetVisualDescendants().OfType<Button>().ToList();
+			Assert.That(buttons.Count(b => (AutomationProperties.GetAutomationId(b) ?? "").StartsWith("RuleCell-")),
+				Is.EqualTo(4), "one chooser button per cell (p, V, C, #)");
+			Assert.That(buttons.Count(b => (AutomationProperties.GetAutomationId(b) ?? "").StartsWith("RuleInsert-")),
+				Is.EqualTo(4), "one trailing insert button per section");
+		}
+
+		[AvaloniaTest]
+		public void EmptyCellGroups_RenderPlaceholders_WithoutCrowding()
+		{
+			var (editor, window) = Show(PartlyEmptyRule());
+
+			DialogSnapshot.Capture(window, "RuleFormulaEditor-02-empty-groups");
+			DialogLayoutAssert.AssertNoCrowding(editor);
+
+			Assert.That(AutomationProperties.GetName(editor), Is.EqualTo("p →  /  __ "));
+			// The three empty groups (RHS, left, right) each draw a faint placeholder box.
+			var placeholders = editor.GetVisualDescendants().OfType<Border>().Count(b => b != editor);
+			Assert.That(placeholders, Is.EqualTo(3), "each empty cell group shows one placeholder box");
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/LexicalEditFeatureCatalog.cs
+++ b/Src/Common/FwAvalonia/LexicalEditFeatureCatalog.cs
@@ -52,7 +52,25 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 				FwAvaloniaStrings.FeatureGroupOtherRecordTypes),
 			new LexicalEditFeatureDescriptor("Analyses",
 				FwAvaloniaStrings.FeatureAnalysesName, FwAvaloniaStrings.FeatureAnalysesDescription,
-				FwAvaloniaStrings.FeatureGroupOtherRecordTypes)
+				FwAvaloniaStrings.FeatureGroupOtherRecordTypes),
+			new LexicalEditFeatureDescriptor("PhonologicalRuleEdit",
+				FwAvaloniaStrings.FeaturePhonologicalRuleEditName, FwAvaloniaStrings.FeaturePhonologicalRuleEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors),
+			new LexicalEditFeatureDescriptor("EnvironmentEdit",
+				FwAvaloniaStrings.FeatureEnvironmentEditName, FwAvaloniaStrings.FeatureEnvironmentEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors),
+			new LexicalEditFeatureDescriptor("compoundRuleAdvancedEdit",
+				FwAvaloniaStrings.FeatureCompoundRuleAdvancedEditName, FwAvaloniaStrings.FeatureCompoundRuleAdvancedEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors),
+			new LexicalEditFeatureDescriptor("naturalClassedit",
+				FwAvaloniaStrings.FeatureNaturalClassEditName, FwAvaloniaStrings.FeatureNaturalClassEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors),
+			new LexicalEditFeatureDescriptor("phonemeEdit",
+				FwAvaloniaStrings.FeaturePhonemeEditName, FwAvaloniaStrings.FeaturePhonemeEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors),
+			new LexicalEditFeatureDescriptor("AdhocCoprohibEdit",
+				FwAvaloniaStrings.FeatureAdhocCoprohibEditName, FwAvaloniaStrings.FeatureAdhocCoprohibEditDescription,
+				FwAvaloniaStrings.FeatureGroupGrammarRuleEditors)
 		};
 
 		/// <summary>The bare tool-name ids, in catalog order — what <see cref="LexicalEditSurfaceRegistry"/> registers by default.</summary>

--- a/Src/Common/FwAvalonia/LexicalEditSurfaceRegistry.cs
+++ b/Src/Common/FwAvalonia/LexicalEditSurfaceRegistry.cs
@@ -38,18 +38,12 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 			return result;
 		}
 
-		// PHASE-1 FOLLOW-UP surfaces — INERT in the base PR. The view-layer code for these ships (it lives in the
-		// same FwAvalonia/xWorks assemblies) but the tools are deliberately NOT registered, so the resolver returns
-		// "not supported" and they fall back to the legacy WinForms surface even under UIMode=New. Each follow-up PR
-		// ACTIVATES its surface by moving its tool name(s) from this list into DefaultSupportedTools above (the one-line
-		// "flip"). Verified by InertFollowUpSurfacesFallBackToLegacy in the resolver tests.
-		//   avalonia-rule-formula-editor: "PhonologicalRuleEdit","EnvironmentEdit","compoundRuleAdvancedEdit",
-		//                                 "naturalClassedit","phonemeEdit","AdhocCoprohibEdit"
-		// (avalonia-interlinear-editor "Analyses" was flipped into DefaultSupportedTools above by its follow-up PR.)
+		// PHASE-1 FOLLOW-UP edit surfaces — now EMPTY: both follow-up edit surfaces (avalonia-interlinear-editor
+		// "Analyses" and the avalonia-rule-formula-editor family) have been flipped into DefaultSupportedTools above
+		// by their follow-up PRs. The browse/table follow-up is gated separately by
+		// LexicalEditSurfaceResolver.Phase1FollowUpBrowseTools. Verified by InertFollowUpSurfacesFallBackToLegacy.
 		public static readonly string[] Phase1FollowUpSurfaceTools =
 		{
-			"PhonologicalRuleEdit", "EnvironmentEdit", "compoundRuleAdvancedEdit",
-			"naturalClassedit", "phonemeEdit", "AdhocCoprohibEdit"
 		};
 
 		private readonly HashSet<string> _supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/Src/Common/FwAvalonia/Region/BasicIPASymbolEditor.cs
+++ b/Src/Common/FwAvalonia/Region/BasicIPASymbolEditor.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace SIL.FieldWorks.Common.FwAvalonia.Region
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — the Basic IPA Symbol editor (legacy <c>BasicIPASymbolSlice</c>
+	/// parity): an editable single-line entry for a phoneme's <c>BasicIPASymbol</c>. LCModel-free: it binds to
+	/// a string + an <see cref="IBasicIpaSymbolCommandSink"/>; the xWorks plugin owns the read/write.
+	///
+	/// <para>// PARITY: derive-on-commit (auto-filling the phoneme Description + Features from
+	/// <c>BasicIPAInfo.xml</c> when the symbol changes) is DEFERRED — this ships the editable symbol field;
+	/// the derive is an auto-population convenience to be ported by extracting the legacy slice's
+	/// <c>SetDescriptionBasedOnIPA</c>/<c>SetFeaturesBasedOnIPA</c> into a reusable domain helper. Read-only
+	/// when no sink is wired.</para>
+	/// </summary>
+	public sealed class BasicIPASymbolEditor : Border
+	{
+		/// <summary>Stable automation id for the symbol entry.</summary>
+		public const string BasicIpaSymbolAutomationId = "BasicIPASymbolEditor";
+
+		private readonly TextBox m_box;
+		private string m_committed;
+
+		/// <summary>The LCModel-side write seam. Null = read-only.</summary>
+		public IBasicIpaSymbolCommandSink Sink { get; set; }
+
+		/// <summary>True when a sink is wired (the field is editable).</summary>
+		public bool IsEditable => Sink != null;
+
+		/// <summary>The last committed symbol (domain truth after a successful commit).</summary>
+		public string CommittedText => m_committed;
+
+		public BasicIPASymbolEditor() : this(string.Empty, null) { }
+
+		public BasicIPASymbolEditor(string symbol, IBasicIpaSymbolCommandSink sink)
+		{
+			FwSurfaceStyles.Apply(this);
+			Sink = sink;
+			m_committed = symbol ?? string.Empty;
+			Background = Brushes.White;
+			Padding = new Thickness(6, 3, 6, 3);
+
+			m_box = new TextBox
+			{
+				Text = m_committed,
+				MinWidth = 120,
+				IsReadOnly = sink == null,
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			AutomationProperties.SetAutomationId(m_box, BasicIpaSymbolAutomationId);
+			Child = m_box;
+
+			if (sink != null)
+			{
+				m_box.LostFocus += (s, e) => Commit();
+				m_box.KeyDown += (s, e) =>
+				{
+					if (e.Key == Key.Enter) { Commit(); e.Handled = true; }
+					else if (e.Key == Key.Escape) { m_box.Text = m_committed; e.Handled = true; }
+				};
+			}
+		}
+
+		/// <summary>Programmatic commit (used by tests). Writes the symbol through the sink.</summary>
+		public bool TryCommit() => Commit();
+
+		private bool Commit()
+		{
+			var text = m_box.Text ?? string.Empty;
+			if (text == m_committed)
+				return true;
+			if (Sink == null || !Sink.Commit(text))
+			{
+				m_box.Text = m_committed;
+				return false;
+			}
+			m_committed = text;
+			return true;
+		}
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — the LCModel-free write seam for the Basic IPA Symbol editor.
+	/// The xWorks plugin implements <see cref="Commit"/> to write the phoneme's <c>BasicIPASymbol</c> (and,
+	/// in a follow-up, run the derive-on-commit) in one fenced undo step.
+	/// </summary>
+	public interface IBasicIpaSymbolCommandSink
+	{
+		/// <summary>Persist <paramref name="symbol"/> as the phoneme's basic IPA symbol.</summary>
+		bool Commit(string symbol);
+	}
+}

--- a/Src/Common/FwAvalonia/Region/PhEnvironmentEditor.cs
+++ b/Src/Common/FwAvalonia/Region/PhEnvironmentEditor.cs
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace SIL.FieldWorks.Common.FwAvalonia.Region
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — the phonological-environment string editor (legacy
+	/// <c>PhEnvStrRepresentationSlice</c> parity): an editable single-line entry for an
+	/// <c>IPhEnvironment.StringRepresentation</c> (e.g. <c>/ [C] _ #</c>) plus an insert toolbar for the
+	/// boundary/optional/slash/underscore glyphs. On commit the string is validated through the host's
+	/// <c>PhonEnvRecognizer</c> seam; an invalid string is rejected (the box restores the last committed
+	/// value and shows the error) so a malformed environment can never be stored.
+	///
+	/// <para>LCModel-free (design Decision 3 + engine-isolation audit): it binds to a string and an
+	/// <see cref="IPhEnvironmentCommandSink"/>; the xWorks plugin owns the LCModel read/write + validator.
+	/// Read-only when no sink is wired. // PARITY: the natural-class insert chooser is deferred (the literal
+	/// insert toolbar ships; NC insertion reuses the shared chooser kit in a follow-up).</para>
+	/// </summary>
+	public sealed class PhEnvironmentEditor : Border
+	{
+		/// <summary>Stable automation id for the environment editor surface.</summary>
+		public const string EnvironmentAutomationId = "PhEnvironmentEditor";
+
+		private static readonly IBrush ErrorBrush = new SolidColorBrush(Color.FromRgb(0xB2, 0x22, 0x22));
+
+		private readonly TextBox m_box;
+		private readonly TextBlock m_error;
+		private string m_committed;
+
+		/// <summary>The LCModel-side validate/commit seam. Null = read-only.</summary>
+		public IPhEnvironmentCommandSink Sink { get; set; }
+
+		/// <summary>True when a sink is wired (the field is editable).</summary>
+		public bool IsEditable => Sink != null;
+
+		public PhEnvironmentEditor() : this(string.Empty, null) { }
+
+		public PhEnvironmentEditor(string representation, IPhEnvironmentCommandSink sink)
+		{
+			FwSurfaceStyles.Apply(this);
+			Sink = sink;
+			m_committed = representation ?? string.Empty;
+			Background = Brushes.White;
+			Padding = new Thickness(6, 3, 6, 3);
+
+			m_box = new TextBox
+			{
+				Text = m_committed,
+				MinWidth = 220,
+				IsReadOnly = sink == null,
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			AutomationProperties.SetAutomationId(m_box, EnvironmentAutomationId);
+
+			m_error = new TextBlock
+			{
+				Foreground = ErrorBrush,
+				IsVisible = false,
+				FontSize = FwSurfaceStyles.SurfaceFontSize,
+				Margin = new Thickness(0, 2, 0, 0)
+			};
+
+			var root = new StackPanel { Orientation = Orientation.Vertical };
+			if (sink != null)
+				root.Children.Add(BuildInsertToolbar());
+			root.Children.Add(m_box);
+			root.Children.Add(m_error);
+			Child = root;
+
+			if (sink != null)
+			{
+				m_box.LostFocus += (s, e) => CommitOrReject();
+				m_box.KeyDown += (s, e) =>
+				{
+					if (e.Key == Key.Enter)
+					{
+						CommitOrReject();
+						e.Handled = true;
+					}
+					else if (e.Key == Key.Escape)
+					{
+						RestoreCommitted();
+						e.Handled = true;
+					}
+				};
+			}
+		}
+
+		/// <summary>The last committed string representation (domain truth after a successful commit).</summary>
+		public string CommittedText => m_committed;
+
+		/// <summary>Programmatic commit (used by the toolbar and tests); validates then stages, or rejects.</summary>
+		public bool TryCommit() => CommitOrReject();
+
+		private bool CommitOrReject()
+		{
+			var text = m_box.Text ?? string.Empty;
+			if (text == m_committed)
+			{
+				ClearError();
+				return true;
+			}
+			if (Sink == null || !Sink.Validate(text))
+			{
+				ShowError(text);
+				RestoreCommitted();
+				return false;
+			}
+			if (!Sink.Commit(text))
+			{
+				ShowError(text);
+				RestoreCommitted();
+				return false;
+			}
+			m_committed = text;
+			ClearError();
+			return true;
+		}
+
+		private void RestoreCommitted() => m_box.Text = m_committed;
+
+		private void ShowError(string attempted)
+		{
+			// TODO localization: prototype hard-coded string — route through the LocalizationManager catalog
+			// (reuse a Morphology environment-error id) before product use.
+			m_error.Text = $"'{attempted}' is not a valid environment.";
+			m_error.IsVisible = true;
+		}
+
+		private void ClearError()
+		{
+			m_error.IsVisible = false;
+			m_error.Text = string.Empty;
+		}
+
+		// The literal-insert toolbar: word boundary, optional brackets, the segment slash, the environment bar.
+		private Control BuildInsertToolbar()
+		{
+			var bar = new StackPanel
+			{
+				Orientation = Orientation.Horizontal,
+				Margin = new Thickness(0, 0, 0, 3)
+			};
+			foreach (var glyph in new[] { "#", "[", "]", "/", "_" })
+				bar.Children.Add(InsertButton(glyph));
+			return bar;
+		}
+
+		private Control InsertButton(string glyph)
+		{
+			var button = new Button
+			{
+				Content = glyph,
+				Padding = new Thickness(6, 1, 6, 1),
+				Margin = new Thickness(0, 0, 3, 0),
+				MinWidth = 22
+			};
+			AutomationProperties.SetAutomationId(button, "PhEnvInsert-" + glyph);
+			button.Click += (s, e) =>
+			{
+				var caret = Math.Max(0, Math.Min(m_box.CaretIndex, (m_box.Text ?? string.Empty).Length));
+				m_box.Text = (m_box.Text ?? string.Empty).Insert(caret, glyph);
+				m_box.CaretIndex = caret + glyph.Length;
+				m_box.Focus();
+			};
+			return button;
+		}
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — the LCModel-free validate/commit seam for the environment
+	/// editor. The xWorks plugin implements it: <see cref="Validate"/> runs the phonological-environment
+	/// recognizer; <see cref="Commit"/> writes the string representation in one fenced undo step.
+	/// </summary>
+	public interface IPhEnvironmentCommandSink
+	{
+		/// <summary>True when <paramref name="representation"/> is a well-formed environment.</summary>
+		bool Validate(string representation);
+
+		/// <summary>Persist <paramref name="representation"/> as the environment's string representation.</summary>
+		bool Commit(string representation);
+	}
+}

--- a/Src/Common/FwAvalonia/Region/RuleCellCommands.cs
+++ b/Src/Common/FwAvalonia/Region/RuleCellCommands.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+
+namespace SIL.FieldWorks.Common.FwAvalonia.Region
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.1) — an LCModel-free description of a cell to insert/replace in a
+	/// rule formula: its <see cref="RuleCellKind"/> plus the GUID of the target object (phoneme / natural
+	/// class / boundary) the cell references. The view supplies this (its per-cell chooser, task 2.2, picks
+	/// the GUID); the xWorks/Morphology handler resolves the GUID to the real LCModel object and builds the
+	/// matching <c>IPhSimpleContext</c> (design Decision 1: the view never touches LCModel).
+	/// </summary>
+	public sealed class RuleCellSpec
+	{
+		public RuleCellSpec(RuleCellKind kind, Guid? targetGuid)
+		{
+			Kind = kind;
+			TargetGuid = targetGuid;
+		}
+
+		/// <summary>What kind of cell to create.</summary>
+		public RuleCellKind Kind { get; }
+
+		/// <summary>The referenced object's GUID (phoneme/natural-class/boundary). Required for the reference
+		/// kinds; a pure slot/variable carries none.</summary>
+		public Guid? TargetGuid { get; }
+
+		/// <summary>
+		/// Encode this spec as an <c>FwOptionPicker</c> option key — a kind prefix + the target GUID
+		/// (<c>"P:&lt;guid&gt;"</c> phoneme, <c>"N:"</c> natural class, <c>"B:"</c> boundary) — so the picked
+		/// option round-trips back to a spec the handler can apply. The xWorks options projection builds the
+		/// same keys; the view decodes the committed key with <see cref="FromOptionKey"/>.
+		/// </summary>
+		public string ToOptionKey() => Prefix(Kind) + ":" + (TargetGuid?.ToString() ?? string.Empty);
+
+		/// <summary>Decode an option key built by <see cref="ToOptionKey"/> back into a spec, or null if the
+		/// key is malformed / an unknown kind / (for a reference kind) carries no parseable GUID.</summary>
+		public static RuleCellSpec FromOptionKey(string key)
+		{
+			if (string.IsNullOrEmpty(key) || key.Length < 2 || key[1] != ':')
+				return null;
+			var rest = key.Substring(2);
+			Guid? guid = Guid.TryParse(rest, out var g) ? g : (Guid?)null;
+			switch (key[0])
+			{
+				case 'P': return guid == null ? null : new RuleCellSpec(RuleCellKind.Phoneme, guid);
+				case 'N': return guid == null ? null : new RuleCellSpec(RuleCellKind.NaturalClass, guid);
+				case 'B': return guid == null ? null : new RuleCellSpec(RuleCellKind.Boundary, guid);
+				default: return null;
+			}
+		}
+
+		private static string Prefix(RuleCellKind kind)
+		{
+			switch (kind)
+			{
+				case RuleCellKind.Phoneme: return "P";
+				case RuleCellKind.NaturalClass: return "N";
+				case RuleCellKind.Boundary: return "B";
+				default: return "S";
+			}
+		}
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.1) — the editor's cell-mutation seam. The Avalonia
+	/// <see cref="RuleFormulaRegionEditor"/> raises these intents (insert at / delete / reorder / replace a
+	/// cell in a named section); the xWorks/Morphology handler applies them to the rule inside the region's
+	/// fenced edit session as ONE undoable step per gesture, then re-projects so the grid re-renders from
+	/// domain truth. This interface is LCModel-free so the view stays engine-isolated; each method returns
+	/// false (and stages nothing) when the gesture is invalid or unsupported for the section.
+	/// </summary>
+	public interface IRuleCellCommandSink
+	{
+		/// <summary>Insert a new cell built from <paramref name="spec"/> at <paramref name="index"/> in the
+		/// section playing <paramref name="role"/>.</summary>
+		bool InsertCell(RuleSectionRole role, int index, RuleCellSpec spec);
+
+		/// <summary>Delete the cell at <paramref name="index"/> in the section playing <paramref name="role"/>.</summary>
+		bool DeleteCell(RuleSectionRole role, int index);
+
+		/// <summary>Move the cell at <paramref name="from"/> to <paramref name="to"/> within the section.</summary>
+		bool MoveCell(RuleSectionRole role, int from, int to);
+
+		/// <summary>Replace the cell at <paramref name="index"/> with one built from <paramref name="spec"/>.</summary>
+		bool SetCell(RuleSectionRole role, int index, RuleCellSpec spec);
+	}
+}

--- a/Src/Common/FwAvalonia/Region/RuleFormulaModel.cs
+++ b/Src/Common/FwAvalonia/Region/RuleFormulaModel.cs
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SIL.FieldWorks.Common.FwAvalonia.Region
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.1/1.2) — the kind of a single cell in a phonological/morphological
+	/// rule formula. Mirrors the cell kinds the legacy RuleFormulaControl grid renders.
+	/// </summary>
+	public enum RuleCellKind
+	{
+		/// <summary>A single phoneme (PhPhoneme), via PhSimpleContextSeg.</summary>
+		Phoneme,
+
+		/// <summary>A natural class (PhNaturalClass), via PhSimpleContextNC. Rendered bracketed [..].</summary>
+		NaturalClass,
+
+		/// <summary>A boundary marker (PhBdryMarker), e.g. a morpheme/word boundary, via PhSimpleContextBdry.</summary>
+		Boundary,
+
+		/// <summary>A structural slot / variable (PhVariable "X"), or a placeholder for an unset context.</summary>
+		Slot,
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor — the role a <see cref="RuleFormulaSection"/> plays in a rule formula.
+	/// Each role owns a distinct LCModel collection (so write-back can target the right home) and a fixed
+	/// chrome separator the view/formatter emits before it. Regular-rule roles ship in task 1.2; metathesis
+	/// (2.3) and compound (2.5) add their own roles without reshaping the model.
+	/// </summary>
+	public enum RuleSectionRole
+	{
+		/// <summary>Left-hand side — the input/structural-description cells (PhSegmentRule.StrucDescOS).</summary>
+		Lhs,
+
+		/// <summary>Right-hand side — the structural-change cells (PhSegRuleRHS.StrucChangeOS).</summary>
+		Rhs,
+
+		/// <summary>Left environment/context (PhSegRuleRHS.LeftContextOA).</summary>
+		LeftContext,
+
+		/// <summary>Right environment/context (PhSegRuleRHS.RightContextOA).</summary>
+		RightContext,
+
+		// Metathesis roles (PhMetathesisRule.StrucDescOS partitioned by GetStrucChangeIndex). The two
+		// switch groups are the swapped pair; the env groups frame them.
+		/// <summary>Metathesis left environment (kidxLeftEnv).</summary>
+		LeftEnv,
+
+		/// <summary>Metathesis left switch group, incl. any middle contexts when IsMiddleWithLeftSwitch (kidxLeftSwitch).</summary>
+		LeftSwitch,
+
+		/// <summary>Metathesis right switch group, incl. any middle contexts otherwise (kidxRightSwitch).</summary>
+		RightSwitch,
+
+		/// <summary>Metathesis right environment (kidxRightEnv).</summary>
+		RightEnv,
+
+		// Compound / affix-process roles (MoAffixProcess.InputOS / OutputOS).
+		/// <summary>Compound-rule input columns (MoAffixProcess.InputOS).</summary>
+		Input,
+
+		/// <summary>Compound-rule output mappings (MoAffixProcess.OutputOS).</summary>
+		Output,
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.1) — one cell of a rule formula, as an LCModel-free DTO the
+	/// Avalonia editor binds to (the xWorks/Morphology adapter projects the rule into these and maps edits
+	/// back; the view never touches LCModel — design Decision 1/3). Immutable: edits produce a new model.
+	/// <para><see cref="DisplayText"/> is the BARE token (e.g. "p", "V", "#") — brackets/parentheses are
+	/// chrome the view/formatter derives from <see cref="Kind"/>, so the token maps cleanly to its target
+	/// object on write-back.</para>
+	/// </summary>
+	public sealed class RuleCell
+	{
+		public RuleCell(RuleCellKind kind, string displayText, Guid? targetGuid = null)
+		{
+			Kind = kind;
+			DisplayText = displayText ?? string.Empty;
+			TargetGuid = targetGuid;
+		}
+
+		/// <summary>What this cell represents.</summary>
+		public RuleCellKind Kind { get; }
+
+		/// <summary>The bare token shown in the cell (phoneme/boundary glyph, class abbreviation, slot label);
+		/// brackets are NOT included — the view adds them for <see cref="RuleCellKind.NaturalClass"/>.</summary>
+		public string DisplayText { get; }
+
+		/// <summary>The referenced LCModel object's GUID (phoneme/natural-class/boundary), or null for a
+		/// pure structural slot/variable. Carried so the adapter can map a cell back to its target on commit.</summary>
+		public Guid? TargetGuid { get; }
+
+		public RuleCell WithDisplayText(string displayText) => new RuleCell(Kind, displayText, TargetGuid);
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.2) — one editable cell group of a rule formula (the LHS, RHS,
+	/// left or right context). Each section maps to a distinct LCModel collection, so cell mutations stage
+	/// against the right home on commit. Immutable; Insert/Remove/Move return a new section.
+	/// </summary>
+	public sealed class RuleFormulaSection
+	{
+		public RuleFormulaSection(RuleSectionRole role, IEnumerable<RuleCell> cells)
+		{
+			Role = role;
+			Cells = (cells ?? Enumerable.Empty<RuleCell>()).ToList();
+		}
+
+		/// <summary>The role this group plays in the formula (drives ordering + chrome separators).</summary>
+		public RuleSectionRole Role { get; }
+
+		/// <summary>The cells in document order (left-to-right within the group). May be empty — an empty
+		/// group still renders (the legacy Vc draws an empty bracket pile).</summary>
+		public IReadOnlyList<RuleCell> Cells { get; }
+
+		/// <summary>Insert <paramref name="cell"/> at <paramref name="index"/> (clamped), returning a new section.</summary>
+		public RuleFormulaSection InsertCell(int index, RuleCell cell)
+		{
+			if (cell == null) throw new ArgumentNullException(nameof(cell));
+			var list = Cells.ToList();
+			list.Insert(Clamp(index, 0, list.Count), cell);
+			return new RuleFormulaSection(Role, list);
+		}
+
+		/// <summary>Remove the cell at <paramref name="index"/>, returning a new section (no-op if out of range).</summary>
+		public RuleFormulaSection RemoveCell(int index)
+		{
+			if (index < 0 || index >= Cells.Count) return this;
+			var list = Cells.ToList();
+			list.RemoveAt(index);
+			return new RuleFormulaSection(Role, list);
+		}
+
+		/// <summary>Move the cell at <paramref name="from"/> to <paramref name="to"/> (both clamped), returning a new section.</summary>
+		public RuleFormulaSection MoveCell(int from, int to)
+		{
+			if (from < 0 || from >= Cells.Count) return this;
+			var list = Cells.ToList();
+			var cell = list[from];
+			list.RemoveAt(from);
+			list.Insert(Clamp(to, 0, list.Count), cell);
+			return new RuleFormulaSection(Role, list);
+		}
+
+		internal static int Clamp(int value, int min, int max) => value < min ? min : (value > max ? max : value);
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.2) — the LCModel-free projection of a phonological/morphological
+	/// rule the Avalonia <c>RuleFormulaRegionEditor</c> renders: an ordered list of cell-group
+	/// <see cref="Sections"/> (LHS/RHS/env) plus the rule kind. The Morphology projector builds this from a
+	/// <c>PhSegRuleRHS</c>/<c>MoCompoundRule</c> (read) and applies cell edits back to it inside one fenced
+	/// UOW (write). Immutable; mutation helpers return a new instance so the editor can stage without
+	/// touching LCModel.
+	/// </summary>
+	public sealed class RuleFormulaModel
+	{
+		public RuleFormulaModel(string ruleKind, IEnumerable<RuleFormulaSection> sections)
+		{
+			RuleKind = ruleKind ?? string.Empty;
+			Sections = (sections ?? Enumerable.Empty<RuleFormulaSection>()).ToList();
+		}
+
+		/// <summary>The rule's class/kind tag (e.g. "PhRegularRule", "PhMetathesisRule", "MoCompoundRule").</summary>
+		public string RuleKind { get; }
+
+		/// <summary>The cell groups in document order.</summary>
+		public IReadOnlyList<RuleFormulaSection> Sections { get; }
+
+		/// <summary>The section playing <paramref name="role"/>, or null if the model has none.</summary>
+		public RuleFormulaSection SectionFor(RuleSectionRole role) => Sections.FirstOrDefault(s => s.Role == role);
+
+		/// <summary>Replace the section at <paramref name="index"/> with <paramref name="section"/>, returning a new model.</summary>
+		public RuleFormulaModel WithSection(int index, RuleFormulaSection section)
+		{
+			if (section == null) throw new ArgumentNullException(nameof(section));
+			if (index < 0 || index >= Sections.Count) return this;
+			var list = Sections.ToList();
+			list[index] = section;
+			return new RuleFormulaModel(RuleKind, list);
+		}
+
+		/// <summary>
+		/// Render the formula as a single deterministic string (bare tokens, NC bracketed, with the chrome
+		/// separator each role carries). This is the canonical text the parity test asserts against a
+		/// hand-written oracle, and the accessibility text the view exposes. Empty sections contribute "".
+		/// </summary>
+		public string ToFormulaString()
+		{
+			var sb = new StringBuilder();
+			foreach (var section in Sections)
+			{
+				sb.Append(SeparatorBefore(section.Role));
+				foreach (var cell in section.Cells)
+					sb.Append(Token(cell));
+			}
+			return sb.ToString();
+		}
+
+		/// <summary>The bare token for a cell: natural classes are bracketed [..]; everything else is the
+		/// raw <see cref="RuleCell.DisplayText"/>. The view and the formula string share this so they never drift.</summary>
+		public static string Token(RuleCell cell)
+			=> cell != null && cell.Kind == RuleCellKind.NaturalClass ? "[" + cell.DisplayText + "]" : cell?.DisplayText ?? string.Empty;
+
+		/// <summary>The bare chrome glyph that precedes a section of the given role (no surrounding spaces):
+		/// "" for LHS, "→" before RHS, "/" before the left context, "__" before the right context. The view
+		/// renders these as muted separator labels; <see cref="ToFormulaString"/> wraps them in spaces.</summary>
+		public static string RoleSeparatorGlyph(RuleSectionRole role)
+		{
+			switch (role)
+			{
+				case RuleSectionRole.Rhs: return "→";
+				case RuleSectionRole.LeftContext: return "/";
+				case RuleSectionRole.RightContext: return "__";
+				// Metathesis: delimit the four cells; "↔" marks the swapped switch pair.
+				case RuleSectionRole.LeftSwitch: return "|";
+				case RuleSectionRole.RightSwitch: return "↔";
+				case RuleSectionRole.RightEnv: return "|";
+				// Compound: input columns ⇒ output mappings.
+				case RuleSectionRole.Output: return "⇒";
+				default: return string.Empty;   // Lhs, LeftEnv, Input (and any not-yet-mapped role)
+			}
+		}
+
+		/// <summary>The fixed chrome separator the formula string emits before a section of the given role.</summary>
+		private static string SeparatorBefore(RuleSectionRole role)
+		{
+			var glyph = RoleSeparatorGlyph(role);
+			return glyph.Length == 0 ? string.Empty : " " + glyph + " ";
+		}
+	}
+}

--- a/Src/Common/FwAvalonia/Region/RuleFormulaRegionEditor.cs
+++ b/Src/Common/FwAvalonia/Region/RuleFormulaRegionEditor.cs
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace SIL.FieldWorks.Common.FwAvalonia.Region
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.3/2.1/2.2) — the Avalonia rule-formula grid, the cross-platform
+	/// parity of the legacy <c>RegRuleFormulaControl</c>/<c>RegRuleFormulaVc</c> root-site grid. It renders a
+	/// <see cref="RuleFormulaModel"/> as a horizontal run of cell groups (LHS → RHS / LeftCtx __ RightCtx),
+	/// each group a sequence of phoneme/natural-class/boundary/slot cells, with the role chrome glyphs
+	/// (arrow/slash/underscore) drawn as muted separators between groups.
+	///
+	/// <para>The view stays LCModel-free (design Decision 3 + the engine-isolation audit): it binds to the
+	/// DTO the xWorks/Morphology projector produces. When a <see cref="Sink"/> and <see cref="Options"/> are
+	/// wired (task 2.1/2.2) the grid is EDITABLE: each cell is a chooser button (click = replace; context
+	/// menu = delete / insert-before) and each group gets a trailing "+" insert button. A committed option's
+	/// codec key (<see cref="RuleCellSpec.FromOptionKey"/>) becomes the spec the sink applies in one undo
+	/// step; the sink re-projects and calls <see cref="SetModel"/> to refresh. With no sink it is read-only.</para>
+	/// </summary>
+	public sealed class RuleFormulaRegionEditor : Border
+	{
+		/// <summary>Stable automation id for the whole rule-formula surface.</summary>
+		public const string RuleFormulaAutomationId = "RuleFormulaEditor";
+
+		/// <summary>Muted color for the role separator glyphs (legacy Vc draws them gray).</summary>
+		private static readonly IBrush SeparatorBrush = new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x80));
+
+		/// <summary>Faint placeholder/cell border for empty groups and editable cells.</summary>
+		private static readonly IBrush PlaceholderBrush = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xB0));
+
+		private readonly StackPanel m_row;
+		private RuleFormulaModel m_model;
+
+		/// <summary>
+		/// avalonia-rule-formula-editor (task 2.1) — the cell-mutation seam. When non-null the grid is
+		/// editable: cell gestures route here, the xWorks handler applies them to the rule in one undoable
+		/// step and re-projects, calling <see cref="SetModel"/> to refresh. Null = read-only (task 1.3).
+		/// </summary>
+		public IRuleCellCommandSink Sink { get; set; }
+
+		/// <summary>avalonia-rule-formula-editor (task 2.2) — the insertable-cell options (phonemes / natural
+		/// classes / boundaries) the chooser flyouts list; their keys decode to <see cref="RuleCellSpec"/>.
+		/// The grid only offers editing affordances when BOTH this and <see cref="Sink"/> are set.</summary>
+		public IReadOnlyList<RegionChoiceOption> Options { get; set; }
+
+		/// <summary>True when an edit sink + options are wired (the grid accepts cell gestures).</summary>
+		public bool IsEditable => Sink != null && Options != null;
+
+		public RuleFormulaRegionEditor()
+		{
+			FwSurfaceStyles.Apply(this);
+			Background = Brushes.White;
+			Padding = new Thickness(6, 3, 6, 3);
+			m_row = new StackPanel
+			{
+				Orientation = Orientation.Horizontal,
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			Child = m_row;
+			AutomationProperties.SetAutomationId(this, RuleFormulaAutomationId);
+		}
+
+		public RuleFormulaRegionEditor(RuleFormulaModel model) : this()
+		{
+			SetModel(model);
+		}
+
+		/// <summary>The model the grid renders. Setting it rebuilds the cell run.</summary>
+		public RuleFormulaModel Model
+		{
+			get => m_model;
+			set => SetModel(value);
+		}
+
+		/// <summary>Rebuild the cell run from <paramref name="model"/> (null clears the grid).</summary>
+		public void SetModel(RuleFormulaModel model)
+		{
+			m_model = model;
+			m_row.Children.Clear();
+			if (model == null)
+			{
+				AutomationProperties.SetName(this, string.Empty);
+				return;
+			}
+
+			var editable = IsEditable;
+			foreach (var section in model.Sections)
+			{
+				var glyph = RuleFormulaModel.RoleSeparatorGlyph(section.Role);
+				if (glyph.Length > 0)
+					m_row.Children.Add(BuildSeparator(glyph));
+
+				for (var i = 0; i < section.Cells.Count; i++)
+					m_row.Children.Add(editable
+						? BuildEditableCell(section.Role, i, section.Cells[i])
+						: BuildCell(section.Cells[i]));
+
+				if (section.Cells.Count == 0 && !editable)
+					m_row.Children.Add(BuildPlaceholder());
+
+				if (editable)
+					m_row.Children.Add(BuildInsertButton(section.Role, section.Cells.Count));
+			}
+
+			// Accessibility text: the whole formula reads as one string (matches the parity oracle).
+			AutomationProperties.SetName(this, model.ToFormulaString());
+		}
+
+		// ----- read-only cell rendering (task 1.3) -----
+
+		private static Control BuildCell(RuleCell cell)
+			=> new TextBlock
+			{
+				Text = RuleFormulaModel.Token(cell),
+				VerticalAlignment = VerticalAlignment.Center,
+				Margin = new Thickness(2, 0, 2, 0)
+			};
+
+		private static Control BuildSeparator(string glyph)
+			=> new TextBlock
+			{
+				Text = glyph,
+				Foreground = SeparatorBrush,
+				VerticalAlignment = VerticalAlignment.Center,
+				Margin = new Thickness(4, 0, 4, 0)
+			};
+
+		// A thin faint box so an empty group still shows the formula's structure (the legacy empty bracket pile).
+		private static Control BuildPlaceholder()
+			=> new Border
+			{
+				MinWidth = 12,
+				MinHeight = 12,
+				Margin = new Thickness(2, 0, 2, 0),
+				BorderThickness = new Thickness(1),
+				BorderBrush = PlaceholderBrush,
+				VerticalAlignment = VerticalAlignment.Center
+			};
+
+		// ----- editable cell rendering (task 2.2) -----
+
+		// A cell is a chooser button: click opens the replace picker; the context menu offers delete and
+		// insert-before. The bare/bracketed token reads exactly as the read-only render.
+		private Control BuildEditableCell(RuleSectionRole role, int index, RuleCell cell)
+		{
+			var button = new Button
+			{
+				Content = RuleFormulaModel.Token(cell),
+				Padding = new Thickness(4, 1, 4, 1),
+				Margin = new Thickness(2, 0, 2, 0),
+				MinWidth = 16,
+				Background = Brushes.White,
+				BorderBrush = PlaceholderBrush,
+				BorderThickness = new Thickness(1),
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			AutomationProperties.SetAutomationId(button, $"RuleCell-{role}-{index}");
+			button.Flyout = BuildChooserFlyout(role, index, replace: true);
+
+			// Context menu: Delete this cell, and Insert-before (opens the chooser at this index). The
+			// insert-before item carries the picker as its OWN sub-flyout target via a click that shows it.
+			var deleteItem = new MenuItem { Header = FwAvaloniaStrings.RuleCellDelete };
+			deleteItem.Click += (s, e) => Sink?.DeleteCell(role, index);
+			var insertItem = new MenuItem { Header = FwAvaloniaStrings.RuleCellInsertBefore };
+			insertItem.Click += (s, e) => ShowChooser(button, role, index, replace: false);
+			button.ContextFlyout = new MenuFlyout { Items = { deleteItem, insertItem } };
+			return button;
+		}
+
+		// The trailing "+" appends a new cell at the end of a group.
+		private Control BuildInsertButton(RuleSectionRole role, int endIndex)
+		{
+			var add = new Button
+			{
+				Content = "+",
+				Padding = new Thickness(4, 1, 4, 1),
+				Margin = new Thickness(2, 0, 2, 0),
+				MinWidth = 16,
+				Foreground = SeparatorBrush,
+				Background = Brushes.Transparent,
+				BorderThickness = new Thickness(0),
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			AutomationProperties.SetAutomationId(add, $"RuleInsert-{role}");
+			add.Flyout = BuildChooserFlyout(role, endIndex, replace: false);
+			return add;
+		}
+
+		// One option picker, hosted in a flyout, that applies the committed cell to (role, index): replace
+		// the cell or insert before it. Decoding the option key to a spec is the shared codec; the sink
+		// re-projects + refreshes the grid on success.
+		private FlyoutBase BuildChooserFlyout(RuleSectionRole role, int index, bool replace)
+		{
+			var picker = new FwOptionPicker(Options, null, "RuleCellPicker");
+			var flyout = FwOptionPicker.CreateOptionFlyout(picker, PlacementMode.Bottom);
+
+			Action<RegionChoiceOption> committed = option =>
+			{
+				flyout.Hide();
+				var spec = RuleCellSpec.FromOptionKey(option?.Key);
+				if (spec == null || Sink == null)
+					return;
+				if (replace)
+					Sink.SetCell(role, index, spec);
+				else
+					Sink.InsertCell(role, index, spec);
+			};
+			EventHandler dismissed = (s, e) => flyout.Hide();
+			picker.OptionCommitted += committed;
+			picker.Dismissed += dismissed;
+			return flyout;
+		}
+
+		// Show a one-shot chooser anchored at a control (used by the context-menu "Insert before").
+		private void ShowChooser(Control anchor, RuleSectionRole role, int index, bool replace)
+			=> BuildChooserFlyout(role, index, replace).ShowAt(anchor);
+	}
+}

--- a/Src/xWorks/AffixRuleFormulaRegionEditorPlugin.cs
+++ b/Src/xWorks/AffixRuleFormulaRegionEditorPlugin.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia.Controls;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.Reporting;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.5, read-only) — the Avalonia compound / affix-process rule
+	/// editor: claims the legacy <c>SIL.FieldWorks.XWorks.MorphologyEditor.AffixRuleFormulaSlice</c> layout
+	/// identity and renders the <c>IMoAffixProcess</c>'s input columns ⇒ output mappings via
+	/// <see cref="RuleFormulaProjector.ProjectCompoundRule"/>.
+	///
+	/// <para>READ-ONLY this increment (the input/output editing — copy-from-input index references, modify
+	/// features, phoneme inserts — is a follow-up); the slice's object is the affix process itself (legacy
+	/// <c>AffixRuleFormulaControl</c> edits the <c>IMoAffixProcess</c>). LCModel reads live here.</para>
+	/// </summary>
+	public sealed class AffixRuleFormulaRegionEditorPlugin : IRegionEditorPlugin
+	{
+		/// <summary>The legacy slice class this plugin claims (MorphologyParts.xml MoAffixProcess-Detail-RuleFormula).</summary>
+		public const string AffixRuleFormulaSliceClassName =
+			"SIL.FieldWorks.XWorks.MorphologyEditor.AffixRuleFormulaSlice";
+
+		public string LegacyClassName => AffixRuleFormulaSliceClassName;
+
+		public Control BuildControl(RegionEditorBuildContext context)
+		{
+			var rule = context?.Target as IMoAffixProcess;
+			if (rule == null)
+				return null;
+			try
+			{
+				return new RuleFormulaRegionEditor(RuleFormulaProjector.ProjectCompoundRule(rule));
+			}
+			catch (Exception e)
+			{
+				Logger.WriteEvent($"AffixRuleFormulaRegionEditorPlugin: compound editor unavailable for '{rule.Guid}': {e}");
+				return null;
+			}
+		}
+	}
+}

--- a/Src/xWorks/BasicIpaSymbolDeriver.cs
+++ b/Src/xWorks/BasicIpaSymbolDeriver.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.IO;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using SIL.FieldWorks.Common.FwUtils;
+using SIL.LCModel;
+using SIL.LCModel.Core.WritingSystems;
+using SIL.Utils;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1, derive-on-commit) — the reusable port of the legacy
+	/// <c>BasicIPASymbolSlice</c> derive logic: when a phoneme's <c>BasicIPASymbol</c> is set, fill its
+	/// Description (per analysis writing system) and phonological Features from <c>BasicIPAInfo.xml</c>;
+	/// clearing the symbol clears them. Fills only EMPTY Description/Features (never overwrites a user's
+	/// own edits), exactly like the legacy guard. LCModel writes happen inside the caller's fenced UOW.
+	/// </summary>
+	public static class BasicIpaSymbolDeriver
+	{
+		private static readonly XDocument s_ipaInfo = LoadIpaInfo();
+
+		private static XDocument LoadIpaInfo()
+		{
+			try
+			{
+				return XDocument.Load(Path.Combine(FwDirectoryFinder.TemplateDirectory, PhPhonemeTags.ksBasicIPAInfoFile));
+			}
+			catch
+			{
+				return null; // missing template: derive becomes a no-op, the symbol still saves
+			}
+		}
+
+		/// <summary>Derive Description + Features for <paramref name="phoneme"/> from its current BasicIPASymbol.</summary>
+		public static void Derive(IPhPhoneme phoneme, LcmCache cache)
+		{
+			if (phoneme == null || cache == null)
+				return;
+			var symbol = phoneme.BasicIPASymbol?.Text ?? string.Empty;
+			DeriveDescription(phoneme, cache, symbol);
+			DeriveFeatures(phoneme, cache, symbol);
+		}
+
+		private static void DeriveDescription(IPhPhoneme phoneme, LcmCache cache, string symbol)
+		{
+			foreach (CoreWritingSystemDefinition ws in cache.ServiceLocator.WritingSystems.AnalysisWritingSystems)
+			{
+				var handle = ws.Handle;
+				var existing = phoneme.Description.get_String(handle).Text;
+				if (symbol.Length == 0)
+				{
+					// Clearing the symbol clears a previously-derived description.
+					if (!string.IsNullOrEmpty(existing))
+						phoneme.Description.set_String(handle, string.Empty);
+					continue;
+				}
+				if (!string.IsNullOrEmpty(existing))
+					continue; // never overwrite the user's own description (legacy guard)
+				var description = s_ipaInfo?.XPathSelectElement(
+					"/SegmentDefinitions/SegmentDefinition[Representations/Representation[.='" +
+					XmlUtils.MakeSafeXmlAttribute(symbol) + "']]/Descriptions/Description[@lang='" + ws.Id + "']");
+				if (description != null)
+					phoneme.Description.set_String(handle, (string)description);
+			}
+		}
+
+		private static void DeriveFeatures(IPhPhoneme phoneme, LcmCache cache, string symbol)
+		{
+			if (symbol.Length == 0)
+			{
+				phoneme.FeaturesOA?.FeatureSpecsOC.Clear();
+				return;
+			}
+			// Only populate when there are no features yet (never clobber the user's own feature edits).
+			if (phoneme.FeaturesOA != null && phoneme.FeaturesOA.FeatureSpecsOC.Count > 0)
+				return;
+
+			var features = s_ipaInfo?.XPathSelectElement(
+				"/SegmentDefinitions/SegmentDefinition[Representations/Representation[.='" +
+				XmlUtils.MakeSafeXmlAttribute(symbol) + "']]/Features");
+			if (features == null)
+				return;
+
+			var featSystem = cache.LangProject.PhFeatureSystemOA;
+			foreach (var pair in features.Elements("FeatureValuePair"))
+			{
+				var featDefn = featSystem.GetFeature((string)pair.Attribute("feature"));
+				var symVal = featSystem.GetSymbolicValue((string)pair.Attribute("value"));
+				if (featDefn == null || symVal == null)
+					continue;
+				if (phoneme.FeaturesOA == null)
+					phoneme.FeaturesOA = cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
+				var value = cache.ServiceLocator.GetInstance<IFsClosedValueFactory>().Create();
+				phoneme.FeaturesOA.FeatureSpecsOC.Add(value);
+				value.FeatureRA = featDefn;
+				value.ValueRA = symVal;
+			}
+		}
+	}
+}

--- a/Src/xWorks/BasicIpaSymbolRegionEditorPlugin.cs
+++ b/Src/xWorks/BasicIpaSymbolRegionEditorPlugin.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia.Controls;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Core.Text;
+using SIL.Reporting;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — the Basic IPA Symbol editor plugin: claims the legacy
+	/// <c>SIL.FieldWorks.XWorks.MorphologyEditor.BasicIPASymbolSlice</c> and renders a phoneme's
+	/// <c>BasicIPASymbol</c> as an editable entry (<see cref="BasicIPASymbolEditor"/>). LCModel read/write
+	/// lives here (design Decision 1), including derive-on-commit (<see cref="BasicIpaSymbolDeriver"/> fills
+	/// empty Description/Features from BasicIPAInfo.xml — legacy parity).
+	/// </summary>
+	public sealed class BasicIpaSymbolRegionEditorPlugin : IRegionEditorPlugin
+	{
+		public const string BasicIPASymbolSliceClassName =
+			"SIL.FieldWorks.XWorks.MorphologyEditor.BasicIPASymbolSlice";
+
+		public string LegacyClassName => BasicIPASymbolSliceClassName;
+
+		public Control BuildControl(RegionEditorBuildContext context)
+		{
+			var phoneme = context?.Target as IPhPhoneme;
+			var cache = context?.Cache;
+			if (phoneme == null || cache == null)
+				return null;
+			try
+			{
+				var symbol = phoneme.BasicIPASymbol?.Text ?? string.Empty;
+				var host = context.EditContext;
+				var sink = host == null ? null : new BasicIpaSymbolEditSink(phoneme, cache, host);
+				return new BasicIPASymbolEditor(symbol, sink);
+			}
+			catch (Exception e)
+			{
+				Logger.WriteEvent($"BasicIpaSymbolRegionEditorPlugin: IPA symbol editor unavailable for '{phoneme.Guid}': {e}");
+				return null;
+			}
+		}
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — writes the phoneme's <c>BasicIPASymbol</c> (pronunciation
+	/// writing system) through the region's shared fenced session as one undo step, then runs the
+	/// derive-on-commit (<see cref="BasicIpaSymbolDeriver"/>) in the same UOW.
+	/// </summary>
+	internal sealed class BasicIpaSymbolEditSink : IBasicIpaSymbolCommandSink
+	{
+		private readonly IPhPhoneme _phoneme;
+		private readonly LcmCache _cache;
+		private readonly IRegionEditContext _host;
+
+		public BasicIpaSymbolEditSink(IPhPhoneme phoneme, LcmCache cache, IRegionEditContext host)
+		{
+			_phoneme = phoneme;
+			_cache = cache;
+			_host = host;
+		}
+
+		public bool Commit(string symbol)
+		{
+			var ws = _cache.DefaultPronunciationWs > 0 ? _cache.DefaultPronunciationWs : _cache.DefaultVernWs;
+			bool Write()
+			{
+				_phoneme.BasicIPASymbol = TsStringUtils.MakeString(symbol ?? string.Empty, ws);
+				// Derive-on-commit: fill empty Description + Features from BasicIPAInfo.xml (legacy parity).
+				BasicIpaSymbolDeriver.Derive(_phoneme, _cache);
+				return true;
+			}
+
+			if (_host is RegionEditContextBase fenced)
+			{
+				var ok = fenced.Stage(Write, "Basic IPA Symbol");
+				if (ok)
+					fenced.Commit();
+				return ok;
+			}
+			return Write();
+		}
+	}
+}

--- a/Src/xWorks/MetaRuleFormulaEditSink.cs
+++ b/Src/xWorks/MetaRuleFormulaEditSink.cs
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.3 editing) — the LCModel-side handler for METATHESIS cell
+	/// gestures. A metathesis rule keeps one <c>StrucDescOS</c> partitioned into four cells by index ranges
+	/// (LeftEnv / LeftSwitch / RightSwitch / RightEnv); a gesture maps a cell-local index to the absolute
+	/// <c>StrucDescOS</c> position, mutates it, and maintains the partition metadata exactly as the legacy
+	/// <c>MetaRuleFormulaControl</c>: insert calls <c>UpdateStrucChange(kidx, index, true)</c> after
+	/// inserting; delete relies on <c>PhSimpleContext.DeleteObjectSideEffects</c> to re-derive the partition.
+	/// Staged through the region's shared fenced session, one undo step per gesture, then re-projects.
+	///
+	/// <para>// PARITY: scoped to rules WITHOUT a "middle" context (the common case — middle is an advanced
+	/// option that folds into a switch cell). When <c>MiddleIndex != -1</c>, switch-cell edits reject; the
+	/// environment cells stay editable (they are outside the switch pair). Move/reorder is deferred.</para>
+	/// </summary>
+	public sealed class MetaRuleFormulaEditSink : IRuleCellCommandSink
+	{
+		private readonly IPhMetathesisRule _rule;
+		private readonly LcmCache _cache;
+		private readonly IRegionEditContext _host;
+		private readonly Action<RuleFormulaModel> _onModelChanged;
+
+		public MetaRuleFormulaEditSink(IPhMetathesisRule rule, LcmCache cache, IRegionEditContext host,
+			Action<RuleFormulaModel> onModelChanged)
+		{
+			_rule = rule ?? throw new ArgumentNullException(nameof(rule));
+			_cache = cache ?? throw new ArgumentNullException(nameof(cache));
+			_host = host;
+			_onModelChanged = onModelChanged;
+		}
+
+		public bool InsertCell(RuleSectionRole role, int index, RuleCellSpec spec)
+		{
+			if (spec == null || !TryKidx(role, out var kidx) || BlockedByMiddle(role) || !TryResolveTarget(spec, out var target))
+				return false;
+			int count = CellCount(role);
+			if (index < 0 || index > count)
+				return false;
+			int absolute = InsertionIndex(role, index);
+			return Apply(() =>
+			{
+				var ctx = CreateBareContext(spec.Kind);
+				if (ctx == null)
+					return false;
+				_rule.StrucDescOS.Insert(absolute, ctx);     // own it first
+				_rule.UpdateStrucChange(kidx, absolute, true); // maintain the partition metadata
+				SetTarget(ctx, target);
+				return true;
+			});
+		}
+
+		public bool DeleteCell(RuleSectionRole role, int index)
+		{
+			if (!TryKidx(role, out _) || BlockedByMiddle(role))
+				return false;
+			int count = CellCount(role);
+			if (index < 0 || index >= count)
+				return false;
+			int absolute = CellStart(role) + index;
+			return Apply(() =>
+			{
+				var ctx = _rule.StrucDescOS[absolute];
+				ctx.PreRemovalSideEffects();
+				_rule.StrucDescOS.Remove(ctx);   // DeleteObjectSideEffects re-derives the partition indices
+				return true;
+			});
+		}
+
+		// Reordering within a metathesis cell (MoveOwnSeq + partition re-derivation) is deferred. // PARITY
+		public bool MoveCell(RuleSectionRole role, int from, int to) => false;
+
+		public bool SetCell(RuleSectionRole role, int index, RuleCellSpec spec)
+		{
+			if (spec == null || !TryKidx(role, out var kidx) || BlockedByMiddle(role) || !TryResolveTarget(spec, out var target))
+				return false;
+			int count = CellCount(role);
+			if (index < 0 || index >= count)
+				return false;
+			int absolute = CellStart(role) + index;
+			return Apply(() =>
+			{
+				var old = _rule.StrucDescOS[absolute];
+				old.PreRemovalSideEffects();
+				_rule.StrucDescOS.Remove(old);
+				var fresh = CreateBareContext(spec.Kind);
+				if (fresh == null)
+					return false;
+				_rule.StrucDescOS.Insert(absolute, fresh);
+				_rule.UpdateStrucChange(kidx, absolute, true);
+				SetTarget(fresh, target);
+				return true;
+			});
+		}
+
+		// ----- metathesis partition math (legacy MetaRuleFormulaControl parity, non-middle) -----
+
+		private bool BlockedByMiddle(RuleSectionRole role)
+			=> _rule.MiddleIndex != -1
+				&& (role == RuleSectionRole.LeftSwitch || role == RuleSectionRole.RightSwitch);
+
+		private int CellCount(RuleSectionRole role)
+		{
+			switch (role)
+			{
+				case RuleSectionRole.LeftEnv: return _rule.LeftEnvIndex == -1 ? 0 : _rule.LeftEnvLimit;
+				case RuleSectionRole.LeftSwitch: return _rule.LeftSwitchIndex == -1 ? 0 : _rule.LeftSwitchLimit - _rule.LeftSwitchIndex;
+				case RuleSectionRole.RightSwitch: return _rule.RightSwitchIndex == -1 ? 0 : _rule.RightSwitchLimit - _rule.RightSwitchIndex;
+				case RuleSectionRole.RightEnv: return _rule.RightEnvIndex == -1 ? 0 : _rule.RightEnvLimit - _rule.RightEnvIndex;
+				default: return 0;
+			}
+		}
+
+		// The absolute StrucDescOS index where this cell's contexts start (only meaningful for a non-empty cell).
+		private int CellStart(RuleSectionRole role)
+		{
+			switch (role)
+			{
+				case RuleSectionRole.LeftEnv: return 0;
+				case RuleSectionRole.LeftSwitch: return _rule.LeftSwitchIndex;
+				case RuleSectionRole.RightSwitch: return _rule.RightSwitchIndex;
+				case RuleSectionRole.RightEnv: return _rule.RightEnvIndex;
+				default: return _rule.StrucDescOS.Count;
+			}
+		}
+
+		// Where to insert a cell at cell-local position `index`. For a non-empty cell this is CellStart+index;
+		// for an empty cell it is the legacy GetInsertionIndex fallback (the start of the next non-empty cell,
+		// else the end). Middle is excluded by BlockedByMiddle for the switch cells.
+		private int InsertionIndex(RuleSectionRole role, int index)
+		{
+			if (CellCount(role) > 0)
+				return CellStart(role) + index;
+
+			switch (role)
+			{
+				case RuleSectionRole.LeftEnv:
+					return 0;
+				case RuleSectionRole.LeftSwitch:
+					if (_rule.RightSwitchIndex != -1) return _rule.RightSwitchIndex;
+					if (_rule.RightEnvIndex != -1) return _rule.RightEnvIndex;
+					break;
+				case RuleSectionRole.RightSwitch:
+					if (_rule.RightEnvIndex != -1) return _rule.RightEnvIndex;
+					break;
+			}
+			return _rule.StrucDescOS.Count;
+		}
+
+		private static bool TryKidx(RuleSectionRole role, out int kidx)
+		{
+			switch (role)
+			{
+				case RuleSectionRole.LeftEnv: kidx = PhMetathesisRuleTags.kidxLeftEnv; return true;
+				case RuleSectionRole.LeftSwitch: kidx = PhMetathesisRuleTags.kidxLeftSwitch; return true;
+				case RuleSectionRole.RightSwitch: kidx = PhMetathesisRuleTags.kidxRightSwitch; return true;
+				case RuleSectionRole.RightEnv: kidx = PhMetathesisRuleTags.kidxRightEnv; return true;
+				default: kidx = -1; return false;
+			}
+		}
+
+		// ----- shared staging + context build (kept local for metathesis isolation) -----
+
+		private IPhSimpleContext CreateBareContext(RuleCellKind kind)
+		{
+			switch (kind)
+			{
+				case RuleCellKind.Phoneme: return _cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+				case RuleCellKind.Boundary: return _cache.ServiceLocator.GetInstance<IPhSimpleContextBdryFactory>().Create();
+				case RuleCellKind.NaturalClass: return _cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				default: return null;
+			}
+		}
+
+		private static void SetTarget(IPhSimpleContext ctx, ICmObject target)
+		{
+			switch (ctx)
+			{
+				case IPhSimpleContextSeg seg: seg.FeatureStructureRA = (IPhPhoneme)target; break;
+				case IPhSimpleContextBdry bdry: bdry.FeatureStructureRA = (IPhBdryMarker)target; break;
+				case IPhSimpleContextNC nc: nc.FeatureStructureRA = (IPhNaturalClass)target; break;
+			}
+		}
+
+		private bool TryResolveTarget(RuleCellSpec spec, out ICmObject target)
+		{
+			target = null;
+			if (spec.TargetGuid == null
+				|| !_cache.ServiceLocator.GetInstance<ICmObjectRepository>().TryGetObject(spec.TargetGuid.Value, out var obj)
+				|| obj == null)
+				return false;
+			switch (spec.Kind)
+			{
+				case RuleCellKind.Phoneme: if (!(obj is IPhPhoneme)) return false; break;
+				case RuleCellKind.Boundary: if (!(obj is IPhBdryMarker)) return false; break;
+				case RuleCellKind.NaturalClass: if (!(obj is IPhNaturalClass)) return false; break;
+				default: return false;
+			}
+			target = obj;
+			return true;
+		}
+
+		private bool Apply(Func<bool> mutate)
+		{
+			bool ok;
+			if (_host is RegionEditContextBase fenced)
+			{
+				ok = fenced.Stage(mutate, "Rule Formula");
+				if (ok)
+					fenced.Commit();
+			}
+			else
+			{
+				ok = mutate();
+			}
+			if (ok)
+				_onModelChanged?.Invoke(RuleFormulaProjector.ProjectMetathesisRule(_rule));
+			return ok;
+		}
+	}
+}

--- a/Src/xWorks/MetaRuleFormulaRegionEditorPlugin.cs
+++ b/Src/xWorks/MetaRuleFormulaRegionEditorPlugin.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia.Controls;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.Reporting;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.3) — the Avalonia metathesis-rule formula editor: claims the
+	/// legacy <c>SIL.FieldWorks.XWorks.MorphologyEditor.MetaRuleFormulaSlice</c> layout identity and renders
+	/// the <c>IPhMetathesisRule</c>'s four index-partitioned cell groups (left env | left switch ↔ right
+	/// switch | right env) via <see cref="RuleFormulaProjector.ProjectMetathesisRule"/>.
+	///
+	/// <para>Editable when the region supplies its fenced context (via <see cref="MetaRuleFormulaEditSink"/>,
+	/// non-middle cells); the slice's object is the rule itself (legacy <c>MetaRuleFormulaControl</c> casts
+	/// its object to <c>IPhMetathesisRule</c>). LCModel reads/writes live here (design Decision 1). // PARITY:
+	/// the result/swap-row display echo and middle-context editing are deferred.</para>
+	/// </summary>
+	public sealed class MetaRuleFormulaRegionEditorPlugin : IRegionEditorPlugin
+	{
+		/// <summary>The legacy slice class this plugin claims (MorphologyParts.xml PhMetathesisRule-Detail-RuleFormula).</summary>
+		public const string MetaRuleFormulaSliceClassName =
+			"SIL.FieldWorks.XWorks.MorphologyEditor.MetaRuleFormulaSlice";
+
+		public string LegacyClassName => MetaRuleFormulaSliceClassName;
+
+		public Control BuildControl(RegionEditorBuildContext context)
+		{
+			var rule = context?.Target as IPhMetathesisRule;
+			if (rule == null)
+				return null;
+			try
+			{
+				var editor = new RuleFormulaRegionEditor(RuleFormulaProjector.ProjectMetathesisRule(rule));
+				var host = context.EditContext;
+				if (host != null)
+				{
+					editor.Sink = new MetaRuleFormulaEditSink(rule, context.Cache, host, editor.SetModel);
+					editor.Options = RuleFormulaOptions.BuildCellOptions(context.Cache);
+				}
+				return editor;
+			}
+			catch (Exception e)
+			{
+				Logger.WriteEvent($"MetaRuleFormulaRegionEditorPlugin: metathesis editor unavailable for '{rule.Guid}': {e}");
+				return null;
+			}
+		}
+	}
+}

--- a/Src/xWorks/PhEnvironmentRegionEditorPlugin.cs
+++ b/Src/xWorks/PhEnvironmentRegionEditorPlugin.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Linq;
+using Avalonia.Controls;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Core.Phonology;
+using SIL.LCModel.Core.Text;
+using SIL.Reporting;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — the phonological-environment editor plugin: claims the
+	/// legacy <c>SIL.FieldWorks.XWorks.MorphologyEditor.PhEnvStrRepresentationSlice</c> and renders the
+	/// <c>IPhEnvironment.StringRepresentation</c> as a validated editable field (<see cref="PhEnvironmentEditor"/>).
+	/// The LCModel read/write + the <c>PhonEnvRecognizer</c> validator live here (design Decision 1).
+	/// </summary>
+	public sealed class PhEnvironmentRegionEditorPlugin : IRegionEditorPlugin
+	{
+		public const string PhEnvStrRepresentationSliceClassName =
+			"SIL.FieldWorks.XWorks.MorphologyEditor.PhEnvStrRepresentationSlice";
+
+		public string LegacyClassName => PhEnvStrRepresentationSliceClassName;
+
+		public Control BuildControl(RegionEditorBuildContext context)
+		{
+			var env = context?.Target as IPhEnvironment;
+			var cache = context?.Cache;
+			if (env == null || cache == null)
+				return null;
+			try
+			{
+				var representation = env.StringRepresentation?.Text ?? string.Empty;
+				var host = context.EditContext;
+				var sink = host == null ? null : new PhEnvironmentEditSink(env, cache, host);
+				return new PhEnvironmentEditor(representation, sink);
+			}
+			catch (Exception e)
+			{
+				Logger.WriteEvent($"PhEnvironmentRegionEditorPlugin: environment editor unavailable for '{env.Guid}': {e}");
+				return null;
+			}
+		}
+	}
+
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — validates an environment string through the same
+	/// <see cref="PhonEnvRecognizer"/> the legacy slice used, and writes the validated
+	/// <c>StringRepresentation</c> (vernacular) through the region's shared fenced session as one undo step.
+	/// </summary>
+	internal sealed class PhEnvironmentEditSink : IPhEnvironmentCommandSink
+	{
+		private readonly IPhEnvironment _env;
+		private readonly LcmCache _cache;
+		private readonly IRegionEditContext _host;
+		private readonly PhonEnvRecognizer _validator;
+
+		public PhEnvironmentEditSink(IPhEnvironment env, LcmCache cache, IRegionEditContext host)
+		{
+			_env = env;
+			_cache = cache;
+			_host = host;
+			var phonData = cache.LangProject.PhonologicalDataOA;
+			_validator = new PhonEnvRecognizer(
+				phonData.AllPhonemes().ToArray(),
+				phonData.AllNaturalClassAbbrs().ToArray());
+		}
+
+		public bool Validate(string representation)
+			=> _validator.Recognize(representation ?? string.Empty);
+
+		public bool Commit(string representation)
+		{
+			bool Write()
+			{
+				_env.StringRepresentation = TsStringUtils.MakeString(representation ?? string.Empty, _cache.DefaultVernWs);
+				return true;
+			}
+
+			if (_host is RegionEditContextBase fenced)
+			{
+				var ok = fenced.Stage(Write, "Environment");
+				if (ok)
+					fenced.Commit();
+				return ok;
+			}
+			return Write();
+		}
+	}
+}

--- a/Src/xWorks/RegionEditorPlugins.cs
+++ b/Src/xWorks/RegionEditorPlugins.cs
@@ -159,16 +159,20 @@ namespace SIL.FieldWorks.XWorks
 		internal static void RegisterBuiltins(RegionEditorPluginRegistry registry)
 		{
 			registry.Register(new ReversalIndexEntryPlugin());
-			// PHASE-1 FOLLOW-UP PRs: ChorusNotesPlugin (the Chorus/FLExBridge notes bar, see above) and
-			// the avalonia-rule-formula-editor family (RuleFormulaRegionEditorPlugin,
-			// MetaRuleFormulaRegionEditorPlugin, AffixRuleFormulaRegionEditorPlugin, PhEnvironmentRegionEditorPlugin,
-			// BasicIpaSymbolRegionEditorPlugin) ship in their own follow-up PRs. Each follow-up adds its plugin
-			// file(s) back and restores the registration here, alongside the registry flip in
-			// LexicalEditSurfaceRegistry.Phase1FollowUpSurfaceTools.
+			// PHASE-1 FOLLOW-UP PR: ChorusNotesPlugin (the Chorus/FLExBridge notes bar, see above) ships
+			// in its own follow-up PR, which restores the registration here.
 			// avalonia-interlinear-editor (W-4): the native Avalonia interlinear editor for the Words
 			// Analyses detail pane, claiming the legacy InterlinearSlice. Read-only this wave; the
 			// editable write-back + MSA prune (W-5) layer onto the same plugin.
 			registry.Register(new InterlinearSlicePlugin());
+			// avalonia-rule-formula-editor (1.4 / 2.3 / 2.5): the Grammar regular + metathesis + compound rule editors.
+			registry.Register(new RuleFormulaRegionEditorPlugin());
+			registry.Register(new MetaRuleFormulaRegionEditorPlugin());
+			registry.Register(new AffixRuleFormulaRegionEditorPlugin());
+			// avalonia-rule-formula-editor (3.2): the phonological-environment string editor.
+			registry.Register(new PhEnvironmentRegionEditorPlugin());
+			// avalonia-rule-formula-editor (3.1): the Basic IPA Symbol editor (derive-on-commit deferred).
+			registry.Register(new BasicIpaSymbolRegionEditorPlugin());
 			registry.Register(DialogLauncherPlugins.CreateMsaInflectionFeatures());
 			registry.Register(DialogLauncherPlugins.CreatePhonologicalFeatures());
 			registry.Register(DialogLauncherPlugins.CreateAudioVisual());

--- a/Src/xWorks/RuleFormulaEditSink.cs
+++ b/Src/xWorks/RuleFormulaEditSink.cs
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.1) — the LCModel-side handler for the rule grid's cell gestures
+	/// (design Decision 1: ALL rule reads/writes live here, never in the FwAvalonia view). It applies each
+	/// gesture to the regular rule inside the region's SHARED fenced edit session (<see cref="Apply"/> stages
+	/// through <c>RegionEditContextBase.Stage</c> and commits as ONE undoable step — the structural-gesture
+	/// "commit immediately + re-show" cadence the StText paragraph CRUD uses), then re-projects so the grid
+	/// re-renders from domain truth.
+	///
+	/// <para>Covers all four regular-rule sections: the plain owning-sequence LHS (<c>StrucDescOS</c>) /
+	/// RHS (<c>StrucChangeOS</c>), and the left/right CONTEXT atomic slots with their
+	/// atomic↔<c>PhSequenceContext</c> transition (0→1→2 promotes a single context into a sequence; deleting
+	/// back removes members — legacy <c>RegRuleFormulaControl.CreateSeqCtxt</c>/<c>InsertContextInto</c>/
+	/// <c>RemoveContextsFrom</c> parity). One simple context maps to one projected cell, so (role, index)
+	/// aligns with the projector's flatten order. // PARITY: context members are assumed simple contexts
+	/// (the projector defers iteration / nested sequences).</para>
+	/// </summary>
+	public sealed class RuleFormulaEditSink : IRuleCellCommandSink
+	{
+		private readonly IPhSegRuleRHS _rhs;
+		private readonly LcmCache _cache;
+		private readonly IRegionEditContext _host;
+		private readonly Action<RuleFormulaModel> _onModelChanged;
+
+		public RuleFormulaEditSink(IPhSegRuleRHS rhs, LcmCache cache, IRegionEditContext host,
+			Action<RuleFormulaModel> onModelChanged)
+		{
+			_rhs = rhs ?? throw new ArgumentNullException(nameof(rhs));
+			_cache = cache ?? throw new ArgumentNullException(nameof(cache));
+			_host = host;
+			_onModelChanged = onModelChanged;
+		}
+
+		public bool InsertCell(RuleSectionRole role, int index, RuleCellSpec spec)
+		{
+			if (spec == null || !TryResolveTarget(spec, out var target))   // resolve BEFORE mutating
+				return false;
+
+			var seq = OwningSequenceFor(role);
+			if (seq != null)   // LHS / RHS — plain owning sequence
+			{
+				if (index < 0 || index > seq.Count)
+					return false;
+				return Apply(() =>
+				{
+					var ctx = CreateBareContext(spec.Kind);
+					if (ctx == null)
+						return false;
+					seq.Insert(index, ctx);     // own it FIRST, then set the reference (legacy order)
+					SetTarget(ctx, target);
+					return true;
+				});
+			}
+
+			if (!IsContextSection(role))
+				return false;
+			return Apply(() => InsertIntoContext(role, index, spec.Kind, target));
+		}
+
+		public bool DeleteCell(RuleSectionRole role, int index)
+		{
+			var seq = OwningSequenceFor(role);
+			if (seq != null)   // LHS / RHS
+			{
+				if (index < 0 || index >= seq.Count)
+					return false;
+				return Apply(() =>
+				{
+					var ctx = seq[index];
+					ctx.PreRemovalSideEffects();
+					seq.Remove(ctx);   // owning sequence: Remove deletes the owned context (legacy parity)
+					return true;
+				});
+			}
+
+			if (!IsContextSection(role) || GetContextOA(role) == null)
+				return false;
+			return Apply(() => DeleteFromContext(role, index));
+		}
+
+		public bool MoveCell(RuleSectionRole role, int from, int to)
+		{
+			var seq = OwningSequenceFor(role);
+			if (seq != null)   // LHS / RHS
+			{
+				int n = seq.Count;
+				if (from < 0 || from >= n || to < 0 || to >= n || from == to)
+					return false;
+				return Apply(() =>
+				{
+					// MoveOwnSeq inserts the moved item BEFORE the object at the destination index in the
+					// ORIGINAL ordering: moving later (to>from) targets to+1; moving earlier targets to.
+					int dest = to > from ? to + 1 : to;
+					_cache.DomainDataByFlid.MoveOwnSeq(OwnerHvoFor(role), FlidFor(role), from, from,
+						OwnerHvoFor(role), FlidFor(role), dest);
+					return true;
+				});
+			}
+
+			// A context section only reorders when it is a multi-member sequence.
+			if (!IsContextSection(role) || !(GetContextOA(role) is IPhSequenceContext members))
+				return false;
+			int count = members.MembersRS.Count;
+			if (from < 0 || from >= count || to < 0 || to >= count || from == to)
+				return false;
+			return Apply(() =>
+			{
+				var m = members.MembersRS[from];
+				members.MembersRS.Remove(m);     // reference sequence: Remove does NOT delete the owned ctx
+				members.MembersRS.Insert(to, m); // post-removal insert at the final index
+				return true;
+			});
+		}
+
+		public bool SetCell(RuleSectionRole role, int index, RuleCellSpec spec)
+		{
+			if (spec == null || !TryResolveTarget(spec, out var target))   // resolve BEFORE mutating
+				return false;
+
+			var seq = OwningSequenceFor(role);
+			if (seq != null)   // LHS / RHS
+			{
+				if (index < 0 || index >= seq.Count)
+					return false;
+				return Apply(() =>
+				{
+					var fresh = CreateBareContext(spec.Kind);
+					if (fresh == null)
+						return false;
+					var old = seq[index];
+					old.PreRemovalSideEffects();
+					seq.Remove(old);
+					seq.Insert(index, fresh);   // own it FIRST, then set the reference (legacy order)
+					SetTarget(fresh, target);
+					return true;
+				});
+			}
+
+			if (!IsContextSection(role) || GetContextOA(role) == null)
+				return false;
+			return Apply(() => SetInContext(role, index, spec.Kind, target));
+		}
+
+		// ----- context-section (Left/Right) mutations: atomic ↔ PhSequenceContext (legacy
+		// RegRuleFormulaControl.CreateSeqCtxt / InsertContextInto / RemoveContextsFrom parity). A null OA = 0
+		// cells, a simple context = 1 cell (index 0), a PhSequenceContext = its MembersRS (index per member).
+		// The projector flattens these the same way, so (role,index) aligns. // PARITY: members are assumed
+		// simple contexts (the projector defers iteration/nested-sequence), which is the rule-editor norm. -----
+
+		private bool InsertIntoContext(RuleSectionRole role, int index, RuleCellKind kind, ICmObject target)
+		{
+			var ctx = GetContextOA(role);
+			if (ctx == null)
+			{
+				if (index != 0)
+					return false;
+				var only = CreateBareContext(kind);
+				if (only == null)
+					return false;
+				SetContextOA(role, only);   // atomic single — own it first
+				SetTarget(only, target);
+				return true;
+			}
+
+			var seq = ctx as IPhSequenceContext;
+			if (seq == null)
+			{
+				// Promote the existing single context into a 2+ sequence (CreateSeqCtxt parity).
+				_cache.LangProject.PhonologicalDataOA.ContextsOS.Add(ctx);   // move out of the atomic slot
+				seq = _cache.ServiceLocator.GetInstance<IPhSequenceContextFactory>().Create();
+				SetContextOA(role, seq);
+				seq.MembersRS.Add(ctx);
+			}
+			if (index < 0 || index > seq.MembersRS.Count)
+				return false;
+			var fresh = CreateBareContext(kind);
+			if (fresh == null)
+				return false;
+			_cache.LangProject.PhonologicalDataOA.ContextsOS.Add(fresh);   // own it, then reference + target
+			seq.MembersRS.Insert(index, fresh);
+			SetTarget(fresh, target);
+			return true;
+		}
+
+		private bool DeleteFromContext(RuleSectionRole role, int index)
+		{
+			var ctx = GetContextOA(role);
+			if (ctx is IPhSequenceContext seq)
+			{
+				if (index < 0 || index >= seq.MembersRS.Count)
+					return false;
+				var member = seq.MembersRS[index];
+				member.PreRemovalSideEffects();
+				_cache.LangProject.PhonologicalDataOA.ContextsOS.Remove(member);   // also drops the reference
+				return true;
+			}
+			if (index != 0)
+				return false;
+			ctx.PreRemovalSideEffects();
+			SetContextOA(role, null);   // owning-atomic clear deletes the single context
+			return true;
+		}
+
+		private bool SetInContext(RuleSectionRole role, int index, RuleCellKind kind, ICmObject target)
+		{
+			var ctx = GetContextOA(role);
+			if (ctx is IPhSequenceContext seq)
+			{
+				if (index < 0 || index >= seq.MembersRS.Count)
+					return false;
+				var old = seq.MembersRS[index];
+				old.PreRemovalSideEffects();
+				_cache.LangProject.PhonologicalDataOA.ContextsOS.Remove(old);
+				var fresh = CreateBareContext(kind);
+				if (fresh == null)
+					return false;
+				_cache.LangProject.PhonologicalDataOA.ContextsOS.Add(fresh);
+				seq.MembersRS.Insert(index, fresh);
+				SetTarget(fresh, target);
+				return true;
+			}
+			if (index != 0)
+				return false;
+			var replacement = CreateBareContext(kind);
+			if (replacement == null)
+				return false;
+			ctx.PreRemovalSideEffects();
+			SetContextOA(role, replacement);   // owning-atomic replace deletes the old single context
+			SetTarget(replacement, target);
+			return true;
+		}
+
+		// ----- helpers -----
+
+		private static bool IsContextSection(RuleSectionRole role)
+			=> role == RuleSectionRole.LeftContext || role == RuleSectionRole.RightContext;
+
+		private IPhPhonContext GetContextOA(RuleSectionRole role)
+			=> role == RuleSectionRole.LeftContext ? _rhs.LeftContextOA : _rhs.RightContextOA;
+
+		private void SetContextOA(RuleSectionRole role, IPhPhonContext value)
+		{
+			if (role == RuleSectionRole.LeftContext)
+				_rhs.LeftContextOA = value;
+			else
+				_rhs.RightContextOA = value;
+		}
+
+		private ILcmOwningSequence<IPhSimpleContext> OwningSequenceFor(RuleSectionRole role)
+		{
+			switch (role)
+			{
+				case RuleSectionRole.Lhs: return _rhs.OwningRule?.StrucDescOS;
+				case RuleSectionRole.Rhs: return _rhs.StrucChangeOS;
+				default: return null;   // PARITY: context sections deferred to the next increment
+			}
+		}
+
+		private int OwnerHvoFor(RuleSectionRole role)
+			=> role == RuleSectionRole.Lhs ? _rhs.OwningRule.Hvo : _rhs.Hvo;
+
+		private static int FlidFor(RuleSectionRole role)
+			=> role == RuleSectionRole.Lhs ? PhSegmentRuleTags.kflidStrucDesc : PhSegRuleRHSTags.kflidStrucChange;
+
+		// Create the bare simple context (no target yet). The reference is set by SetTarget AFTER the
+		// context is owned by its sequence — setting a reference on an unowned object NREs (legacy order).
+		private IPhSimpleContext CreateBareContext(RuleCellKind kind)
+		{
+			switch (kind)
+			{
+				case RuleCellKind.Phoneme:
+					return _cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+				case RuleCellKind.Boundary:
+					return _cache.ServiceLocator.GetInstance<IPhSimpleContextBdryFactory>().Create();
+				case RuleCellKind.NaturalClass:
+					return _cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				default:
+					return null;   // Slot/variable is not a simple context (not valid in StrucDesc/StrucChange)
+			}
+		}
+
+		// Point an owned context at its (already-resolved + type-checked) target object.
+		private static void SetTarget(IPhSimpleContext ctx, ICmObject target)
+		{
+			switch (ctx)
+			{
+				case IPhSimpleContextSeg seg: seg.FeatureStructureRA = (IPhPhoneme)target; break;
+				case IPhSimpleContextBdry bdry: bdry.FeatureStructureRA = (IPhBdryMarker)target; break;
+				case IPhSimpleContextNC nc: nc.FeatureStructureRA = (IPhNaturalClass)target; break;
+			}
+		}
+
+		// Resolve + type-check the spec's target object before any mutation, so a bad spec rejects cleanly.
+		private bool TryResolveTarget(RuleCellSpec spec, out ICmObject target)
+		{
+			target = null;
+			if (spec.TargetGuid == null)
+				return false;
+			if (!_cache.ServiceLocator.GetInstance<ICmObjectRepository>()
+					.TryGetObject(spec.TargetGuid.Value, out var obj) || obj == null)
+				return false;
+			switch (spec.Kind)
+			{
+				case RuleCellKind.Phoneme:
+					if (!(obj is IPhPhoneme)) return false;
+					break;
+				case RuleCellKind.Boundary:
+					if (!(obj is IPhBdryMarker)) return false;
+					break;
+				case RuleCellKind.NaturalClass:
+					if (!(obj is IPhNaturalClass)) return false;
+					break;
+				default:
+					return false;
+			}
+			target = obj;
+			return true;
+		}
+
+		// Stage the mutation on the host's shared fenced session and commit it as ONE undo step, then
+		// re-project so the grid refreshes from domain truth. A non-fenced host (a test fake) runs the
+		// mutation directly (the caller supplies the UOW).
+		private bool Apply(Func<bool> mutate)
+		{
+			bool ok;
+			if (_host is RegionEditContextBase fenced)
+			{
+				ok = fenced.Stage(mutate, "Rule Formula");
+				if (ok)
+					fenced.Commit();   // commit-immediately: one undoable step per gesture (task 2.6)
+			}
+			else
+			{
+				ok = mutate();
+			}
+			if (ok)
+				_onModelChanged?.Invoke(RuleFormulaProjector.ProjectRegularRule(_rhs));
+			return ok;
+		}
+	}
+}

--- a/Src/xWorks/RuleFormulaOptions.cs
+++ b/Src/xWorks/RuleFormulaOptions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.2) — projects the phonological inventory a rule cell can
+	/// reference (phonemes, natural classes, boundary markers) into the <see cref="RegionChoiceOption"/>
+	/// list the shared <c>FwOptionPicker</c> renders. Each option's <see cref="RegionChoiceOption.Key"/> is a
+	/// <see cref="RuleCellSpec"/> codec key (kind prefix + GUID), so the picked option decodes straight back
+	/// to the spec the <see cref="RuleFormulaEditSink"/> inserts. LCModel reads live here (design Decision 1);
+	/// the view only sees the LCModel-free option list. Display text mirrors the projector/legacy Vc.
+	/// </summary>
+	public static class RuleFormulaOptions
+	{
+		/// <summary>
+		/// Build the insertable-cell options for a rule, in the legacy chooser order: phonemes (vernacular
+		/// name), then natural classes (analysis abbreviation), then boundary markers. Each carries a codec
+		/// key (<see cref="RuleCellSpec.ToOptionKey"/>) the view decodes on commit.
+		/// </summary>
+		public static IReadOnlyList<RegionChoiceOption> BuildCellOptions(LcmCache cache)
+		{
+			var options = new List<RegionChoiceOption>();
+			if (cache == null)
+				return options;
+			var phonData = cache.LangProject?.PhonologicalDataOA;
+			if (phonData == null)
+				return options;
+
+			foreach (var phonemeSet in phonData.PhonemeSetsOS)
+				foreach (var phoneme in phonemeSet.PhonemesOC)
+					options.Add(Option(RuleCellKind.Phoneme, phoneme.Guid, Vernacular(phoneme)));
+
+			foreach (var nc in phonData.NaturalClassesOS)
+				options.Add(Option(RuleCellKind.NaturalClass, nc.Guid, NaturalClassText(nc)));
+
+			foreach (var phonemeSet in phonData.PhonemeSetsOS)
+				foreach (var bdry in phonemeSet.BoundaryMarkersOC)
+					options.Add(Option(RuleCellKind.Boundary, bdry.Guid, Vernacular(bdry)));
+
+			return options;
+		}
+
+		private static RegionChoiceOption Option(RuleCellKind kind, System.Guid guid, string name)
+			=> new RegionChoiceOption(new RuleCellSpec(kind, guid).ToOptionKey(),
+				string.IsNullOrEmpty(name) ? "?" : name, 0);
+
+		private static string Vernacular(IPhTerminalUnit tu)
+			=> tu?.Name?.BestVernacularAlternative?.Text;
+
+		private static string NaturalClassText(IPhNaturalClass nc)
+		{
+			var abbr = nc?.Abbreviation?.BestAnalysisAlternative?.Text;
+			if (!string.IsNullOrEmpty(abbr))
+				return abbr;
+			return nc?.Name?.BestAnalysisAlternative?.Text;
+		}
+	}
+}

--- a/Src/xWorks/RuleFormulaProjector.cs
+++ b/Src/xWorks/RuleFormulaProjector.cs
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.2) — projects an LCModel phonological rule into the LCModel-free
+	/// <see cref="RuleFormulaModel"/> the Avalonia <c>RuleFormulaRegionEditor</c> renders (design Decision 1/3:
+	/// ALL LCModel reads live here in the xWorks/Morphology plugin layer, never in the FwAvalonia view).
+	///
+	/// <para>Cell display text mirrors the legacy <c>RuleFormulaVcBase</c>/<c>RegRuleFormulaVc</c>: terminal
+	/// units (phoneme/boundary) show <c>Name.BestVernacularAlternative</c>; natural classes show
+	/// <c>Abbreviation.BestAnalysisAlternative</c> (then <c>Name</c>); a variable shows "X". Brackets around a
+	/// natural class are chrome the view derives from the cell kind, so the token here is bare.</para>
+	///
+	/// <para>// PARITY (task 1.2 read-only scope): feature-based natural classes (PhNCFeatures: multiline
+	/// feature stack + α/β feature-constraint variables) render as their abbreviation/name only, and
+	/// iteration contexts (PhIterationContext min/max sub/superscript) render their member only. Both are
+	/// deferred to the editable phase per design (advisor-confirmed scope call).</para>
+	/// </summary>
+	public static class RuleFormulaProjector
+	{
+		/// <summary>Rule-kind tag for a regular phonological rule (PhRegularRule via PhSegmentRule).</summary>
+		public const string RegularRuleKind = "PhRegularRule";
+
+		/// <summary>Rule-kind tag for a metathesis phonological rule (PhMetathesisRule).</summary>
+		public const string MetathesisRuleKind = "PhMetathesisRule";
+
+		/// <summary>Rule-kind tag for a compound / affix-process rule (MoAffixProcess).</summary>
+		public const string CompoundRuleKind = "MoAffixProcess";
+
+		/// <summary>
+		/// Project the regular-rule right-hand-side (the slice's root object) into a four-section formula
+		/// model: LHS (the owning rule's StrucDesc), RHS (this RHS's StrucChange), left context, right context.
+		/// Empty sections are kept — the formula always shows all four (and their chrome separators).
+		/// </summary>
+		public static RuleFormulaModel ProjectRegularRule(IPhSegRuleRHS rhs)
+		{
+			if (rhs == null) throw new ArgumentNullException(nameof(rhs));
+			var rule = rhs.OwningRule;
+			var sections = new List<RuleFormulaSection>
+			{
+				new RuleFormulaSection(RuleSectionRole.Lhs, ProjectSimpleContexts(rule?.StrucDescOS)),
+				new RuleFormulaSection(RuleSectionRole.Rhs, ProjectSimpleContexts(rhs.StrucChangeOS)),
+				new RuleFormulaSection(RuleSectionRole.LeftContext, ProjectContext(rhs.LeftContextOA)),
+				new RuleFormulaSection(RuleSectionRole.RightContext, ProjectContext(rhs.RightContextOA)),
+			};
+			return new RuleFormulaModel(RegularRuleKind, sections);
+		}
+
+		/// <summary>
+		/// Project a metathesis rule into four cell groups (left env / left switch / right switch / right
+		/// env). The single <c>StrucDescOS</c> is partitioned by <c>GetStrucChangeIndex</c> per context (which
+		/// already folds the optional "middle" contexts into whichever switch owns them), so we bucket each
+		/// context in document order into its role — matching the legacy <c>MetaRuleFormulaControl</c> input
+		/// row. // PARITY (task 2.3 read-only): the legacy result/swap row is a display echo of the input
+		/// switch pair; the editor shows the input row and notes the swap via the "↔" chrome.
+		/// </summary>
+		public static RuleFormulaModel ProjectMetathesisRule(IPhMetathesisRule rule)
+		{
+			if (rule == null) throw new ArgumentNullException(nameof(rule));
+			var left = new List<RuleCell>();
+			var leftSwitch = new List<RuleCell>();
+			var rightSwitch = new List<RuleCell>();
+			var right = new List<RuleCell>();
+
+			foreach (var ctx in rule.StrucDescOS)
+			{
+				var bucket = BucketFor(rule.GetStrucChangeIndex(ctx), left, leftSwitch, rightSwitch, right);
+				bucket?.AddRange(ProjectContext(ctx));
+			}
+
+			return new RuleFormulaModel(MetathesisRuleKind, new List<RuleFormulaSection>
+			{
+				new RuleFormulaSection(RuleSectionRole.LeftEnv, left),
+				new RuleFormulaSection(RuleSectionRole.LeftSwitch, leftSwitch),
+				new RuleFormulaSection(RuleSectionRole.RightSwitch, rightSwitch),
+				new RuleFormulaSection(RuleSectionRole.RightEnv, right),
+			});
+		}
+
+		/// <summary>
+		/// Project a compound / affix-process rule (MoAffixProcess) into an Input section (the
+		/// input columns, each an IPhContextOrVar flattened like a context) and an Output section (the rule
+		/// mappings). A copy-from-input maps to the 1-based index of its referenced input column; an
+		/// insert-phones maps to its phoneme/boundary tokens; a modify-from-input maps to "n[class]".
+		/// // PARITY (task 2.5 read-only): editing the input/output and the modify feature detail are deferred.
+		/// </summary>
+		public static RuleFormulaModel ProjectCompoundRule(IMoAffixProcess rule)
+		{
+			if (rule == null) throw new ArgumentNullException(nameof(rule));
+			var inputs = new List<RuleCell>();
+			foreach (var input in rule.InputOS)
+				inputs.AddRange(ProjectContext(input));
+
+			var outputs = new List<RuleCell>();
+			foreach (var mapping in rule.OutputOS)
+				outputs.AddRange(ProjectMapping(mapping));
+
+			return new RuleFormulaModel(CompoundRuleKind, new List<RuleFormulaSection>
+			{
+				new RuleFormulaSection(RuleSectionRole.Input, inputs),
+				new RuleFormulaSection(RuleSectionRole.Output, outputs),
+			});
+		}
+
+		private static IEnumerable<RuleCell> ProjectMapping(IMoRuleMapping mapping)
+		{
+			var cells = new List<RuleCell>();
+			if (mapping == null)
+				return cells;
+			switch (mapping.ClassID)
+			{
+				case MoCopyFromInputTags.kClassId:
+					var copy = (IMoCopyFromInput)mapping;
+					cells.Add(new RuleCell(RuleCellKind.Slot, IndexLabel(copy.ContentRA)));
+					break;
+				case MoInsertPhonesTags.kClassId:
+					foreach (var tu in ((IMoInsertPhones)mapping).ContentRS)
+						cells.Add(new RuleCell(tu is IPhBdryMarker ? RuleCellKind.Boundary : RuleCellKind.Phoneme,
+							TermUnitText(tu), tu?.Guid));
+					break;
+				case MoModifyFromInputTags.kClassId:
+					var modify = (IMoModifyFromInput)mapping;
+					cells.Add(new RuleCell(RuleCellKind.Slot,
+						IndexLabel(modify.ContentRA) + "[" + NaturalClassText(modify.ModificationRA) + "]"));
+					break;
+				case MoInsertNCTags.kClassId:
+					var insNc = (IMoInsertNC)mapping;
+					cells.Add(new RuleCell(RuleCellKind.NaturalClass, NaturalClassText(insNc.ContentRA),
+						insNc.ContentRA?.Guid));
+					break;
+			}
+			return cells;
+		}
+
+		// The 1-based column number of a referenced input (legacy ContentRA.IndexInOwner + 1), or "0" when unset.
+		private static string IndexLabel(IPhContextOrVar input)
+			=> input == null ? "0" : (input.IndexInOwner + 1).ToString();
+
+		private static List<RuleCell> BucketFor(int kidx, List<RuleCell> left, List<RuleCell> leftSwitch,
+			List<RuleCell> rightSwitch, List<RuleCell> right)
+		{
+			if (kidx == PhMetathesisRuleTags.kidxLeftEnv) return left;
+			if (kidx == PhMetathesisRuleTags.kidxLeftSwitch) return leftSwitch;
+			if (kidx == PhMetathesisRuleTags.kidxRightSwitch) return rightSwitch;
+			if (kidx == PhMetathesisRuleTags.kidxRightEnv) return right;
+			return null;
+		}
+
+		private static IEnumerable<RuleCell> ProjectSimpleContexts(IEnumerable<IPhSimpleContext> seq)
+		{
+			var cells = new List<RuleCell>();
+			if (seq == null)
+				return cells;
+			foreach (var ctx in seq)
+				cells.AddRange(ProjectContext(ctx));
+			return cells;
+		}
+
+		/// <summary>
+		/// Flatten a context-or-variable into bare cells. A sequence flattens its members; simple contexts
+		/// (seg/bdry/NC) map to one cell each; a variable is "X". Mirrors <c>RuleFormulaVcBase.Display</c>'s
+		/// dispatch on <c>ClassID</c>.
+		/// </summary>
+		private static IEnumerable<RuleCell> ProjectContext(IPhContextOrVar ctxtOrVar)
+		{
+			var cells = new List<RuleCell>();
+			if (ctxtOrVar == null)
+				return cells;
+
+			switch (ctxtOrVar.ClassID)
+			{
+				case PhSequenceContextTags.kClassId:
+					foreach (var member in ((IPhSequenceContext)ctxtOrVar).MembersRS)
+						cells.AddRange(ProjectContext(member));
+					break;
+
+				case PhSimpleContextSegTags.kClassId:
+					var seg = (IPhSimpleContextSeg)ctxtOrVar;
+					cells.Add(new RuleCell(RuleCellKind.Phoneme, TermUnitText(seg.FeatureStructureRA),
+						seg.FeatureStructureRA?.Guid));
+					break;
+
+				case PhSimpleContextBdryTags.kClassId:
+					var bdry = (IPhSimpleContextBdry)ctxtOrVar;
+					cells.Add(new RuleCell(RuleCellKind.Boundary, TermUnitText(bdry.FeatureStructureRA),
+						bdry.FeatureStructureRA?.Guid));
+					break;
+
+				case PhSimpleContextNCTags.kClassId:
+					var nc = (IPhSimpleContextNC)ctxtOrVar;
+					cells.Add(new RuleCell(RuleCellKind.NaturalClass, NaturalClassText(nc.FeatureStructureRA),
+						nc.FeatureStructureRA?.Guid));
+					break;
+
+				case PhVariableTags.kClassId:
+					cells.Add(new RuleCell(RuleCellKind.Slot, "X"));
+					break;
+
+				case PhIterationContextTags.kClassId:
+					// PARITY: min/max sub/superscript deferred (1.2 scope) — project the member only.
+					cells.AddRange(ProjectContext(((IPhIterationContext)ctxtOrVar).MemberRA));
+					break;
+			}
+			return cells;
+		}
+
+		private static string TermUnitText(IPhTerminalUnit tu)
+		{
+			if (tu == null)
+				return "?";
+			var text = tu.Name.BestVernacularAlternative?.Text;
+			return string.IsNullOrEmpty(text) ? "?" : text;
+		}
+
+		private static string NaturalClassText(IPhNaturalClass nc)
+		{
+			if (nc == null)
+				return "?";
+			var abbr = nc.Abbreviation.BestAnalysisAlternative?.Text;
+			if (!string.IsNullOrEmpty(abbr))
+				return abbr;
+			var name = nc.Name.BestAnalysisAlternative?.Text;
+			return string.IsNullOrEmpty(name) ? "?" : name;
+		}
+	}
+}

--- a/Src/xWorks/RuleFormulaRegionEditorPlugin.cs
+++ b/Src/xWorks/RuleFormulaRegionEditorPlugin.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using Avalonia.Controls;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.Reporting;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.4) — the native Avalonia regular-rule formula editor: claims the
+	/// legacy <c>SIL.FieldWorks.XWorks.MorphologyEditor.RegRuleFormulaSlice</c> layout identity through the D1
+	/// plugin contract and renders the rule's formula grid (<see cref="RuleFormulaRegionEditor"/>) at the
+	/// slice's real in-tree position, retiring the §20.1.3 "unsupported" row the rule tools showed under New UI.
+	///
+	/// <para>The slice's object is the rule's <c>IPhSegRuleRHS</c> (legacy <c>RegRuleFormulaControl.Rhs</c>);
+	/// this plugin projects it LCModel-side via <see cref="RuleFormulaProjector"/> and hands the LCModel-free
+	/// model to the view (design Decision 1/3). This phase is READ-ONLY — the editable phase (task 2.1+) wires
+	/// cell-intent events through the region's fenced edit session.</para>
+	/// </summary>
+	public sealed class RuleFormulaRegionEditorPlugin : IRegionEditorPlugin
+	{
+		/// <summary>The legacy slice class this plugin claims (MorphologyParts.xml PhSegRuleRHS-Detail-RuleFormula).</summary>
+		public const string RegRuleFormulaSliceClassName =
+			"SIL.FieldWorks.XWorks.MorphologyEditor.RegRuleFormulaSlice";
+
+		public string LegacyClassName => RegRuleFormulaSliceClassName;
+
+		public Control BuildControl(RegionEditorBuildContext context)
+		{
+			var rhs = context?.Target as IPhSegRuleRHS;
+			if (rhs == null)
+				return null;
+
+			try
+			{
+				var model = RuleFormulaProjector.ProjectRegularRule(rhs);
+				var editor = new RuleFormulaRegionEditor(model);
+
+				// task 2.1: when the region supplies its fenced edit context, make the grid editable —
+				// cell gestures route to the LCModel handler, which commits one undo step and re-projects.
+				var host = context.EditContext;
+				if (host != null)
+				{
+					editor.Sink = new RuleFormulaEditSink(rhs, context.Cache, host, editor.SetModel);
+					editor.Options = RuleFormulaOptions.BuildCellOptions(context.Cache);
+				}
+
+				return editor;
+			}
+			catch (Exception e)
+			{
+				// Graceful degradation (same policy as the other plugins): a broken rule read degrades to the
+				// view's null-factory unsupported row, never the whole pane.
+				Logger.WriteEvent($"RuleFormulaRegionEditorPlugin: rule editor unavailable for '{rhs.Guid}': {e}");
+				return null;
+			}
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/BasicIpaSymbolEditWorkflowTests.cs
+++ b/Src/xWorks/xWorksTests/BasicIpaSymbolEditWorkflowTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.1) — T4 commit round-trip for the Basic IPA Symbol editor: the
+	/// sink writes the phoneme's BasicIPASymbol through the region's fenced session (one undo step) and the
+	/// value round-trips from domain truth. // PARITY: derive-on-commit (Description/Features) deferred.
+	/// </summary>
+	[TestFixture]
+	public class BasicIpaSymbolEditWorkflowTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhPhoneme m_phoneme;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				m_phoneme = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(m_phoneme);
+				m_phoneme.Name.SetVernacularDefaultWritingSystem("p");
+			});
+		}
+
+		[Test]
+		public void Commit_WritesBasicIPASymbol_AndUndoRestores()
+		{
+			var host = new ComposedRegionEditContext(Cache, m_phoneme,
+				new Dictionary<string, Func<string, string, bool>>(),
+				new Dictionary<string, Func<string, bool>>());
+			var sink = new BasicIpaSymbolEditSink(m_phoneme, Cache, host);
+
+			Assert.That(sink.Commit("pʰ"), Is.True);
+			Assert.That(m_phoneme.BasicIPASymbol.Text, Is.EqualTo("pʰ"),
+				"the committed IPA symbol persisted to the phoneme");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(m_phoneme.BasicIPASymbol?.Text ?? string.Empty, Is.Not.EqualTo("pʰ"),
+				"one Undo reverts the IPA symbol edit");
+		}
+
+		[Test]
+		public void Derive_FillsDescriptionForAKnownSymbol_AndClearsOnEmpty()
+		{
+			// "a" is a standard low vowel present in BasicIPAInfo.xml with an English description; the
+			// test cache's default analysis WS is English. Derive-on-commit fills the empty Description.
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				m_phoneme.BasicIPASymbol = SIL.LCModel.Core.Text.TsStringUtils.MakeString("a", Cache.DefaultVernWs);
+				BasicIpaSymbolDeriver.Derive(m_phoneme, Cache);
+			});
+			var derived = m_phoneme.Description.AnalysisDefaultWritingSystem.Text;
+			Assert.That(derived, Is.Not.Null.And.Not.Empty,
+				"committing a known IPA symbol derives its description from BasicIPAInfo.xml");
+
+			// Clearing the symbol clears the derived description.
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				m_phoneme.BasicIPASymbol = SIL.LCModel.Core.Text.TsStringUtils.MakeString(string.Empty, Cache.DefaultVernWs);
+				BasicIpaSymbolDeriver.Derive(m_phoneme, Cache);
+			});
+			Assert.That(m_phoneme.Description.AnalysisDefaultWritingSystem.Text ?? string.Empty, Is.Empty,
+				"clearing the symbol clears the derived description");
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/LexemeEditorBurnDownTests.cs
+++ b/Src/xWorks/xWorksTests/LexemeEditorBurnDownTests.cs
@@ -253,11 +253,12 @@ namespace SIL.FieldWorks.XWorks
 			// avalonia-interlinear-editor (W-4): the InterlinearSlicePlugin claims the Words Analyses
 			// InterlinearSlice (a WfiAnalysis class, beyond the LexEntry/LexSense census above) — the
 			// native Avalonia interlinear editor, shipped read-only first.
-			// PHASE-1 FOLLOW-UP PRs: ChorusNotesPlugin (see above) and the avalonia-rule-formula-editor
-			// family (five plugins: the three rule-formula grids plus the environment-string and Basic
-			// IPA symbol editors) ship in their own follow-up PRs. Each follow-up restores its plugin
-			// registration in RegionEditorPlugins.RegisterBuiltins and adds its class name(s) back to
-			// this census.
+			// PHASE-1 FOLLOW-UP PR: ChorusNotesPlugin (see above) ships in its own follow-up PR, which
+			// restores its plugin registration in RegionEditorPlugins.RegisterBuiltins and adds its class
+			// name back to this census.
+			// avalonia-rule-formula-editor: the Grammar rule-editor family adds five plugins — the three
+			// rule-formula grids (regular/metathesis/compound) plus the two supporting bespoke editors
+			// (environment string, Basic IPA symbol). Each claims its legacy Morphology slice class.
 			Assert.That(RegionEditorPluginRegistry.Default.RegisteredClassNames,
 				Is.EquivalentTo(new[]
 				{
@@ -265,7 +266,12 @@ namespace SIL.FieldWorks.XWorks
 					InterlinearSlicePlugin.InterlinearSliceClassName,
 					DialogLauncherPlugins.MsaFeatureSliceClassName,
 					DialogLauncherPlugins.PhonologicalFeatureSliceClassName,
-					DialogLauncherPlugins.AudioVisualSliceClassName
+					DialogLauncherPlugins.AudioVisualSliceClassName,
+					RuleFormulaRegionEditorPlugin.RegRuleFormulaSliceClassName,
+					MetaRuleFormulaRegionEditorPlugin.MetaRuleFormulaSliceClassName,
+					AffixRuleFormulaRegionEditorPlugin.AffixRuleFormulaSliceClassName,
+					PhEnvironmentRegionEditorPlugin.PhEnvStrRepresentationSliceClassName,
+					BasicIpaSymbolRegionEditorPlugin.BasicIPASymbolSliceClassName
 				}));
 			Assert.That(RegionEditorPluginRegistry.Default.Resolve(AvaloniaCompanionSlices.MessageSliceClassName),
 				Is.Null, "ChorusNotesPlugin is a Phase-1 follow-up surface and must not be registered in the base PR");

--- a/Src/xWorks/xWorksTests/PhEnvironmentEditWorkflowTests.cs
+++ b/Src/xWorks/xWorksTests/PhEnvironmentEditWorkflowTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using System;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 3.2) — T1 validate + T4 commit round-trip for the phonological
+	/// environment editor. The sink validates through the same <c>PhonEnvRecognizer</c> the legacy slice
+	/// used and writes <c>StringRepresentation</c> through the region's fenced session (one undo step).
+	/// </summary>
+	[TestFixture]
+	public class PhEnvironmentEditWorkflowTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhEnvironment m_env;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				var a = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(a);
+				a.Name.SetVernacularDefaultWritingSystem("a");
+				var code = a.CodesOS.Count > 0 ? a.CodesOS[0]
+					: Cache.ServiceLocator.GetInstance<IPhCodeFactory>().Create();
+				if (a.CodesOS.Count == 0) a.CodesOS.Add(code);
+				code.Representation.SetVernacularDefaultWritingSystem("a");
+
+				m_env = Cache.ServiceLocator.GetInstance<IPhEnvironmentFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.EnvironmentsOS.Add(m_env);
+			});
+		}
+
+		private PhEnvironmentEditSink NewSink()
+		{
+			var host = new ComposedRegionEditContext(Cache, m_env,
+				new Dictionary<string, Func<string, string, bool>>(),
+				new Dictionary<string, Func<string, bool>>());
+			return new PhEnvironmentEditSink(m_env, Cache, host);
+		}
+
+		[Test]
+		public void Validate_RejectsMalformedEnvironment()
+		{
+			var sink = NewSink();
+			Assert.That(sink.Validate("[[[ bogus"), Is.False, "a malformed environment is rejected by the recognizer");
+		}
+
+		[Test]
+		public void Commit_WritesStringRepresentation_AndUndoRestores()
+		{
+			var sink = NewSink();
+			Assert.That(sink.Commit("/ _ a"), Is.True);
+			Assert.That(m_env.StringRepresentation.Text, Is.EqualTo("/ _ a"),
+				"the committed environment string persisted to the domain");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(m_env.StringRepresentation?.Text ?? string.Empty, Is.Not.EqualTo("/ _ a"),
+				"one Undo reverts the environment edit");
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/RecordEditViewSwitchTests.cs
+++ b/Src/xWorks/xWorksTests/RecordEditViewSwitchTests.cs
@@ -166,13 +166,17 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		// §20.3 / §20.5.2: the detail-editor tools registered for the Avalonia surface. They resolve to
-		// Avalonia under New mode. "Analyses" was flipped on by the avalonia-interlinear-editor follow-up PR
-		// (this branch). The rule-formula tools (PhonologicalRuleEdit, EnvironmentEdit, compoundRuleAdvancedEdit,
-		// naturalClassedit, phonemeEdit, AdhocCoprohibEdit) remain INERT until their own follow-up PR (see
-		// LexicalEditSurfaceRegistry.Phase1FollowUpSurfaceTools), which adds their TestCase rows back here.
+		// Avalonia under New mode. "Analyses" was flipped on by the avalonia-interlinear-editor follow-up PR;
+		// the rule-formula tools were flipped on by the avalonia-rule-formula-editor follow-up PR (this branch).
 		[TestCase("notebookEdit")]
 		[TestCase("posEdit")]
-		[TestCase("Analyses")]   // avalonia-interlinear-editor follow-up: flipped into DefaultSupportedTools
+		[TestCase("Analyses")]                  // avalonia-interlinear-editor follow-up
+		[TestCase("PhonologicalRuleEdit")]      // avalonia-rule-formula-editor follow-up (regular + metathesis)
+		[TestCase("EnvironmentEdit")]           // §3.2 phonological-environment editor
+		[TestCase("compoundRuleAdvancedEdit")]  // §2.5 compound rule editor
+		[TestCase("naturalClassedit")]          // §3.3 natural-class editor
+		[TestCase("phonemeEdit")]               // §3.1 Basic IPA symbol editor
+		[TestCase("AdhocCoprohibEdit")]         // §3.4 ad-hoc co-prohibition editor
 		public void RegisteredRecordEditTools_ResolveToAvalonia_WhenUIModeIsNew(string toolValue)
 		{
 			m_propertyTable.SetProperty("UIMode", "New", true);

--- a/Src/xWorks/xWorksTests/RuleFormulaCompoundTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaCompoundTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.5, read-only) — T1 parity + T2 compose for the compound /
+	/// affix-process rule editor. A compound rule is input columns ⇒ output mappings; the projector renders
+	/// each input column and maps a copy-from-input to its 1-based column number and an insert-phones to its
+	/// phoneme tokens. Hand-written oracle "[C][V] ⇒ 1a" is independent of the projector reads.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaCompoundTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IMoAffixProcess m_rule;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				var a = AddPhoneme("a");
+				var cons = AddNc("C");
+				var vowel = AddNc("V");
+
+				var entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();
+				m_rule = Cache.ServiceLocator.GetInstance<IMoAffixProcessFactory>().Create();
+				entry.LexemeFormOA = m_rule;
+				m_rule.InputOS.Clear();
+
+				// Two input columns: [C] [V].
+				var cInput = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				m_rule.InputOS.Add(cInput);
+				cInput.FeatureStructureRA = cons;
+				var vInput = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				m_rule.InputOS.Add(vInput);
+				vInput.FeatureStructureRA = vowel;
+
+				// Output: copy input column 1, then insert phoneme "a".
+				var copy = Cache.ServiceLocator.GetInstance<IMoCopyFromInputFactory>().Create();
+				m_rule.OutputOS.Add(copy);
+				copy.ContentRA = m_rule.InputOS[0];
+				var insert = Cache.ServiceLocator.GetInstance<IMoInsertPhonesFactory>().Create();
+				m_rule.OutputOS.Add(insert);
+				insert.ContentRS.Add(a);
+			});
+		}
+
+		[Test]
+		public void ProjectCompoundRule_RendersInputColumnsAndOutputMappings()
+		{
+			var model = RuleFormulaProjector.ProjectCompoundRule(m_rule);
+
+			Assert.That(model.RuleKind, Is.EqualTo(RuleFormulaProjector.CompoundRuleKind));
+			Assert.That(model.ToFormulaString(), Is.EqualTo("[C][V] ⇒ 1a"));
+
+			var input = model.SectionFor(RuleSectionRole.Input);
+			Assert.That(input.Cells.Select(c => c.DisplayText), Is.EqualTo(new[] { "C", "V" }));
+			var output = model.SectionFor(RuleSectionRole.Output);
+			Assert.That(output.Cells[0].DisplayText, Is.EqualTo("1"), "copy-from-input shows its 1-based column number");
+			Assert.That(output.Cells[1].DisplayText, Is.EqualTo("a"), "insert-phones shows the inserted phoneme");
+		}
+
+		[Test]
+		public void Compose_MoAffixProcess_ResolvesTheRuleEditor_NotUnsupported()
+		{
+			var composed = FullEntryRegionComposer.Compose(m_rule, Cache, layoutName: "Normal",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var editors = composed.Model.Fields
+				.Where(f => f.Kind == RegionFieldKind.Custom)
+				.Select(f => f.ControlFactory?.Invoke())
+				.OfType<RuleFormulaRegionEditor>()
+				.ToList();
+			Assert.That(editors, Is.Not.Empty,
+				"the AffixRuleFormulaSlice resolves to the Avalonia rule editor (no Unsupported row)");
+		}
+
+		private IPhPhoneme AddPhoneme(string name)
+		{
+			var ph = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(ph);
+			ph.Name.SetVernacularDefaultWritingSystem(name);
+			return ph;
+		}
+
+		private IPhNCSegments AddNc(string abbr)
+		{
+			var nc = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(nc);
+			nc.Abbreviation.SetAnalysisDefaultWritingSystem(abbr);
+			return nc;
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/RuleFormulaEditWorkflowTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaEditWorkflowTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.1/2.6) — T4 editable workflow over a real in-memory cache: a
+	/// cell gesture on the LHS/RHS owning sequences routes through <see cref="RuleFormulaEditSink"/> into the
+	/// region's fenced edit session, commits as ONE undoable step, re-projects (the handler's onModelChanged
+	/// fires), and round-trips when re-projected fresh from domain truth — and a single Undo reverts the
+	/// whole gesture. Proves the editing seam end-to-end, not merely that a setter returned true.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaEditWorkflowTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhRegularRule m_rule;
+		private IPhSegRuleRHS m_rhs;
+		private IPhPhoneme m_p;
+		private IPhPhoneme m_t;
+		private IPhPhoneme m_k;
+		private IPhNCSegments m_vowel;
+		private IPhBdryMarker m_wordBdry;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				m_p = AddPhoneme("p");
+				m_t = AddPhoneme("t");
+				m_k = AddPhoneme("k");
+				m_vowel = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(m_vowel);
+				m_vowel.Abbreviation.SetAnalysisDefaultWritingSystem("V");
+				m_wordBdry = Cache.ServiceLocator.GetInstance<IPhBdryMarkerFactory>()
+					.Create(LangProjectTags.kguidPhRuleWordBdry, Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0]);
+				m_wordBdry.Name.SetVernacularDefaultWritingSystem("#");
+
+				m_rule = Cache.ServiceLocator.GetInstance<IPhRegularRuleFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonRulesOS.Add(m_rule);
+				AddSeg(m_rule.StrucDescOS, m_p);   // LHS = [p, t]
+				AddSeg(m_rule.StrucDescOS, m_t);
+				m_rhs = m_rule.RightHandSidesOS[0];
+				AddNc(m_rhs.StrucChangeOS, m_vowel); // RHS = [V]
+			});
+		}
+
+		private RuleFormulaEditSink NewSink(out List<RuleFormulaModel> reshows)
+		{
+			var captured = new List<RuleFormulaModel>();
+			reshows = captured;
+			// A real fenced host context (RegionEditContextBase) over the rule — empty setter dicts: the
+			// sink stages through Stage()/Commit() directly, not the typed setters.
+			var host = new ComposedRegionEditContext(Cache, m_rule,
+				new Dictionary<string, Func<string, string, bool>>(),
+				new Dictionary<string, Func<string, bool>>());
+			return new RuleFormulaEditSink(m_rhs, Cache, host, m => captured.Add(m));
+		}
+
+		private string Lhs() => RuleFormulaProjector.ProjectRegularRule(m_rhs)
+			.SectionFor(RuleSectionRole.Lhs).Cells.Aggregate("", (s, c) => s + c.DisplayText);
+
+		[Test]
+		public void DeleteCell_RemovesIt_CommitsOneUndoStep_AndUndoRestores()
+		{
+			var before = Cache.ActionHandlerAccessor.UndoableSequenceCount;
+			var sink = NewSink(out var reshows);
+
+			Assert.That(sink.DeleteCell(RuleSectionRole.Lhs, 0), Is.True);
+
+			Assert.That(Lhs(), Is.EqualTo("t"), "the first LHS cell is gone (re-projected from domain truth)");
+			Assert.That(reshows, Has.Count.EqualTo(1), "the gesture re-shows once");
+			Assert.That(reshows[0].SectionFor(RuleSectionRole.Lhs).Cells.Single().DisplayText, Is.EqualTo("t"));
+			Assert.That(Cache.ActionHandlerAccessor.UndoableSequenceCount, Is.EqualTo(before + 1),
+				"the gesture is exactly one undoable step");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(Lhs(), Is.EqualTo("pt"), "one Undo restores the deleted cell");
+		}
+
+		[Test]
+		public void InsertCell_AddsIt_AndRoundTrips()
+		{
+			var sink = NewSink(out _);
+
+			Assert.That(sink.InsertCell(RuleSectionRole.Lhs, 1, new RuleCellSpec(RuleCellKind.Phoneme, m_k.Guid)),
+				Is.True);
+
+			Assert.That(Lhs(), Is.EqualTo("pkt"), "the inserted phoneme lands at index 1, re-projected from domain");
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(Lhs(), Is.EqualTo("pt"), "Undo removes the inserted cell");
+		}
+
+		[Test]
+		public void InsertCell_RejectsUnresolvableTarget_StagesNothing()
+		{
+			var sink = NewSink(out var reshows);
+			var before = Cache.ActionHandlerAccessor.UndoableSequenceCount;
+
+			Assert.That(sink.InsertCell(RuleSectionRole.Lhs, 0, new RuleCellSpec(RuleCellKind.Phoneme, Guid.NewGuid())),
+				Is.False, "an unknown target GUID is rejected");
+			Assert.That(reshows, Is.Empty, "a rejected gesture re-shows nothing");
+			Assert.That(Cache.ActionHandlerAccessor.UndoableSequenceCount, Is.EqualTo(before),
+				"a rejected gesture opens no undo step");
+			Assert.That(Lhs(), Is.EqualTo("pt"));
+		}
+
+		[Test]
+		public void MoveCell_ReordersWithinTheSection_AndUndoRestores()
+		{
+			var sink = NewSink(out _);
+
+			Assert.That(sink.MoveCell(RuleSectionRole.Lhs, 0, 1), Is.True);
+			Assert.That(Lhs(), Is.EqualTo("tp"), "p moves after t");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(Lhs(), Is.EqualTo("pt"), "one Undo restores the original order");
+		}
+
+		private string Section(RuleSectionRole role) => RuleFormulaProjector.ProjectRegularRule(m_rhs)
+			.SectionFor(role).Cells.Aggregate("", (s, c) => s + c.DisplayText);
+
+		[Test]
+		public void LeftContext_AtomicToSequenceAndBack_RoundTrips()
+		{
+			var sink = NewSink(out _);
+			// 0 → 1: empty context accepts a single cell (stored as the atomic OA).
+			Assert.That(sink.InsertCell(RuleSectionRole.LeftContext, 0, new RuleCellSpec(RuleCellKind.Phoneme, m_p.Guid)), Is.True);
+			Assert.That(Section(RuleSectionRole.LeftContext), Is.EqualTo("p"));
+			Assert.That(m_rhs.LeftContextOA, Is.InstanceOf<IPhSimpleContextSeg>(), "one cell is the atomic single context");
+
+			// 1 → 2: the second cell promotes the atomic into a PhSequenceContext.
+			Assert.That(sink.InsertCell(RuleSectionRole.LeftContext, 1, new RuleCellSpec(RuleCellKind.Phoneme, m_t.Guid)), Is.True);
+			Assert.That(Section(RuleSectionRole.LeftContext), Is.EqualTo("pt"));
+			Assert.That(m_rhs.LeftContextOA, Is.InstanceOf<IPhSequenceContext>(), "two cells promote to a sequence");
+
+			// 2 → 1: deleting a member leaves the (1-member) sequence — projector still flattens to one cell.
+			Assert.That(sink.DeleteCell(RuleSectionRole.LeftContext, 0), Is.True);
+			Assert.That(Section(RuleSectionRole.LeftContext), Is.EqualTo("t"));
+
+			// 1 → 0: deleting the last cell clears the context.
+			Assert.That(sink.DeleteCell(RuleSectionRole.LeftContext, 0), Is.True);
+			Assert.That(Section(RuleSectionRole.LeftContext), Is.Empty);
+		}
+
+		[Test]
+		public void RightContext_Insert_ThenUndo_Restores()
+		{
+			var sink = NewSink(out _);
+			Assert.That(sink.InsertCell(RuleSectionRole.RightContext, 0, new RuleCellSpec(RuleCellKind.Boundary, m_wordBdry.Guid)), Is.True);
+			Assert.That(Section(RuleSectionRole.RightContext), Is.EqualTo("#"));
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(Section(RuleSectionRole.RightContext), Is.Empty, "one Undo clears the inserted context cell");
+		}
+
+		// ----- construction helpers -----
+
+		private IPhPhoneme AddPhoneme(string name)
+		{
+			var ph = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(ph);
+			ph.Name.SetVernacularDefaultWritingSystem(name);
+			return ph;
+		}
+
+		private void AddSeg(ILcmOwningSequence<IPhSimpleContext> seq, IPhPhoneme phoneme)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+			seq.Add(ctx);
+			ctx.FeatureStructureRA = phoneme;
+		}
+
+		private void AddNc(ILcmOwningSequence<IPhSimpleContext> seq, IPhNaturalClass nc)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+			seq.Add(ctx);
+			ctx.FeatureStructureRA = nc;
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/RuleFormulaMetathesisTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaMetathesisTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.3) — T1 parity + T2 compose for the metathesis rule editor.
+	/// A metathesis rule partitions one <c>StrucDescOS</c> into four cells (left env | left switch ↔ right
+	/// switch | right env); the projector buckets by <c>GetStrucChangeIndex</c>. The hand-written oracle
+	/// "[V] | a ↔ t | [C]" is independent of the projector's reads (anti-circular).
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaMetathesisTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhMetathesisRule m_rule;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				var a = AddPhoneme("a");
+				var t = AddPhoneme("t");
+				var vowel = AddNc("V");
+				var cons = AddNc("C");
+
+				m_rule = Cache.ServiceLocator.GetInstance<IPhMetathesisRuleFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonRulesOS.Add(m_rule);
+				m_rule.Name.SetAnalysisDefaultWritingSystem("meta");
+
+				// Four cells, one context each (HCLoaderTests.MetathesisRule pattern).
+				AddNcAt(vowel, PhMetathesisRuleTags.kidxLeftEnv, 0);
+				AddSegAt(a, PhMetathesisRuleTags.kidxLeftSwitch, 1);
+				AddSegAt(t, PhMetathesisRuleTags.kidxRightSwitch, 2);
+				AddNcAt(cons, PhMetathesisRuleTags.kidxRightEnv, 3);
+			});
+		}
+
+		[Test]
+		public void ProjectMetathesisRule_BucketsTheFourCells()
+		{
+			var model = RuleFormulaProjector.ProjectMetathesisRule(m_rule);
+
+			Assert.That(model.RuleKind, Is.EqualTo(RuleFormulaProjector.MetathesisRuleKind));
+			Assert.That(model.ToFormulaString(), Is.EqualTo("[V] | a ↔ t | [C]"));
+			Assert.That(model.SectionFor(RuleSectionRole.LeftEnv).Cells.Single().DisplayText, Is.EqualTo("V"));
+			Assert.That(model.SectionFor(RuleSectionRole.LeftSwitch).Cells.Single().DisplayText, Is.EqualTo("a"));
+			Assert.That(model.SectionFor(RuleSectionRole.RightSwitch).Cells.Single().DisplayText, Is.EqualTo("t"));
+			Assert.That(model.SectionFor(RuleSectionRole.RightEnv).Cells.Single().DisplayText, Is.EqualTo("C"));
+		}
+
+		[Test]
+		public void Compose_PhMetathesisRule_ResolvesTheRuleEditor_NotUnsupported()
+		{
+			var composed = FullEntryRegionComposer.Compose(m_rule, Cache, layoutName: "Edit",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var editors = composed.Model.Fields
+				.Where(f => f.Kind == RegionFieldKind.Custom)
+				.Select(f => f.ControlFactory?.Invoke())
+				.OfType<RuleFormulaRegionEditor>()
+				.ToList();
+			Assert.That(editors, Is.Not.Empty,
+				"the MetaRuleFormulaSlice resolves to the Avalonia rule editor (no Unsupported row)");
+		}
+
+		private string Section(RuleSectionRole role) => RuleFormulaProjector.ProjectMetathesisRule(m_rule)
+			.SectionFor(role).Cells.Aggregate("", (s, c) => s + c.DisplayText);
+
+		private MetaRuleFormulaEditSink NewSink()
+		{
+			var host = new ComposedRegionEditContext(Cache, m_rule,
+				new System.Collections.Generic.Dictionary<string, System.Func<string, string, bool>>(),
+				new System.Collections.Generic.Dictionary<string, System.Func<string, bool>>());
+			return new MetaRuleFormulaEditSink(m_rule, Cache, host, m => { });
+		}
+
+		[Test]
+		public void EditLeftEnv_Insert_Delete_RoundTripsAndMaintainsPartitions()
+		{
+			var sink = NewSink();
+			var p = Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.First(ph =>
+				ph.Name.BestVernacularAlternative.Text == "a");
+
+			// Insert a phoneme into the (1-cell) left env at index 1 → "Va" ... wait LeftEnv started as [V].
+			Assert.That(sink.InsertCell(RuleSectionRole.LeftEnv, 1, new RuleCellSpec(RuleCellKind.Phoneme, p.Guid)), Is.True);
+			Assert.That(Section(RuleSectionRole.LeftEnv), Is.EqualTo("Va"), "inserted phoneme appends to the left env");
+			// The switch cells are untouched by the env edit (partitions shifted correctly).
+			Assert.That(Section(RuleSectionRole.LeftSwitch), Is.EqualTo("a"));
+			Assert.That(Section(RuleSectionRole.RightSwitch), Is.EqualTo("t"));
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(Section(RuleSectionRole.LeftEnv), Is.EqualTo("V"), "one Undo restores the env");
+		}
+
+		[Test]
+		public void EditRightSwitch_SetCell_ReplacesTarget()
+		{
+			var sink = NewSink();
+			var a = Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.First(ph =>
+				ph.Name.BestVernacularAlternative.Text == "a");
+
+			// Replace the right-switch cell (t) with phoneme a.
+			Assert.That(sink.SetCell(RuleSectionRole.RightSwitch, 0, new RuleCellSpec(RuleCellKind.Phoneme, a.Guid)), Is.True);
+			Assert.That(Section(RuleSectionRole.RightSwitch), Is.EqualTo("a"));
+			Assert.That(Section(RuleSectionRole.LeftSwitch), Is.EqualTo("a"), "the left switch is unchanged");
+			Assert.That(Section(RuleSectionRole.RightEnv), Is.EqualTo("C"), "the right env is unchanged");
+		}
+
+		private IPhPhoneme AddPhoneme(string name)
+		{
+			var ph = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(ph);
+			ph.Name.SetVernacularDefaultWritingSystem(name);
+			return ph;
+		}
+
+		private IPhNCSegments AddNc(string abbr)
+		{
+			var nc = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(nc);
+			nc.Abbreviation.SetAnalysisDefaultWritingSystem(abbr);
+			return nc;
+		}
+
+		private void AddSegAt(IPhPhoneme phoneme, int kidx, int index)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+			m_rule.StrucDescOS.Add(ctx);
+			ctx.FeatureStructureRA = phoneme;
+			m_rule.UpdateStrucChange(kidx, index, true);
+		}
+
+		private void AddNcAt(IPhNaturalClass nc, int kidx, int index)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+			m_rule.StrucDescOS.Add(ctx);
+			ctx.FeatureStructureRA = nc;
+			m_rule.UpdateStrucChange(kidx, index, true);
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/RuleFormulaOptionsTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaOptionsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 2.2) — T1 for the chooser options projection: the phonological
+	/// inventory (phonemes, natural classes, boundary markers) becomes <see cref="RegionChoiceOption"/>s
+	/// whose keys decode back to <see cref="RuleCellSpec"/> via the shared codec.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaOptionsTests : MemoryOnlyBackendProviderTestBase
+	{
+		[Test]
+		public void BuildCellOptions_ProjectsPhonemesNaturalClassesAndBoundaries_WithDecodableKeys()
+		{
+			IPhPhoneme p = null;
+			IPhNCSegments vowel = null;
+			IPhBdryMarker bdry = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				p = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(p);
+				p.Name.SetVernacularDefaultWritingSystem("p");
+				vowel = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(vowel);
+				vowel.Abbreviation.SetAnalysisDefaultWritingSystem("V");
+				bdry = Cache.ServiceLocator.GetInstance<IPhBdryMarkerFactory>()
+					.Create(LangProjectTags.kguidPhRuleWordBdry, Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0]);
+				bdry.Name.SetVernacularDefaultWritingSystem("#");
+			});
+
+			var options = RuleFormulaOptions.BuildCellOptions(Cache);
+
+			var byKey = options.ToDictionary(o => o.Key, o => o);
+			Assert.That(byKey.ContainsKey("P:" + p.Guid), "phoneme option present with codec key");
+			Assert.That(byKey["P:" + p.Guid].Name, Is.EqualTo("p"));
+			Assert.That(byKey.ContainsKey("N:" + vowel.Guid), "natural-class option present");
+			Assert.That(byKey["N:" + vowel.Guid].Name, Is.EqualTo("V"));
+			Assert.That(byKey.ContainsKey("B:" + bdry.Guid), "boundary option present");
+
+			// Every key decodes back to a spec the handler can apply.
+			foreach (var option in options)
+				Assert.That(RuleCellSpec.FromOptionKey(option.Key), Is.Not.Null, $"key '{option.Key}' decodes");
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/RuleFormulaProjectorTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaProjectorTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.2) — T1 parity test for <see cref="RuleFormulaProjector"/>.
+	/// Builds known regular rules in an in-memory cache and asserts the projected formula equals a
+	/// HAND-WRITTEN oracle string derived from the legacy <c>RegRuleFormulaVc</c>/<c>RuleFormulaVcBase</c>
+	/// layout (LHS → RHS / LeftCtx __ RightCtx; phonemes/boundaries bare, natural classes bracketed). The
+	/// oracle is independent of the properties the projector reads, so a green test means the projector
+	/// genuinely walks the rule structure correctly (advisor-confirmed anti-circular design).
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaProjectorTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhPhoneme m_p;
+		private IPhPhoneme m_t;
+		private IPhNCSegments m_vowel;
+		private IPhNCSegments m_cons;
+		private IPhBdryMarker m_wordBdry;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				m_p = AddPhoneme("p");
+				m_t = AddPhoneme("t");
+				m_vowel = AddNaturalClass("V");
+				m_cons = AddNaturalClass("C");
+				m_wordBdry = AddBoundary(LangProjectTags.kguidPhRuleWordBdry, "#");
+			});
+		}
+
+		[Test]
+		public void ProjectRegularRule_RendersCanonicalFormula()
+		{
+			IPhSegRuleRHS rhs = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				var rule = NewRegularRule();             // p → [V] / [C] __ #
+				AddSeg(rule.StrucDescOS, m_p);           // LHS
+				rhs = rule.RightHandSidesOS[0];
+				AddNc(rhs.StrucChangeOS, m_vowel);       // RHS
+
+				// Owning-atomic contexts: assign the property FIRST, then set the reference (HCLoaderTests pattern).
+				var leftNc = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				rhs.LeftContextOA = leftNc;
+				leftNc.FeatureStructureRA = m_cons;
+				var rightBdry = Cache.ServiceLocator.GetInstance<IPhSimpleContextBdryFactory>().Create();
+				rhs.RightContextOA = rightBdry;
+				rightBdry.FeatureStructureRA = m_wordBdry;
+			});
+
+			var model = RuleFormulaProjector.ProjectRegularRule(rhs);
+
+			Assert.That(model.RuleKind, Is.EqualTo(RuleFormulaProjector.RegularRuleKind));
+			Assert.That(model.ToFormulaString(), Is.EqualTo("p → [V] / [C] __ #"));
+
+			// Structural assertions (kind + carried target), independent of the formula string.
+			var lhs = model.SectionFor(RuleSectionRole.Lhs);
+			Assert.That(lhs.Cells, Has.Count.EqualTo(1));
+			Assert.That(lhs.Cells[0].Kind, Is.EqualTo(RuleCellKind.Phoneme));
+			Assert.That(lhs.Cells[0].TargetGuid, Is.EqualTo(m_p.Guid));
+			Assert.That(model.SectionFor(RuleSectionRole.Rhs).Cells[0].Kind, Is.EqualTo(RuleCellKind.NaturalClass));
+			Assert.That(model.SectionFor(RuleSectionRole.Rhs).Cells[0].TargetGuid, Is.EqualTo(m_vowel.Guid));
+			Assert.That(model.SectionFor(RuleSectionRole.RightContext).Cells[0].Kind, Is.EqualTo(RuleCellKind.Boundary));
+		}
+
+		[Test]
+		public void ProjectRegularRule_FlattensSequenceContext_AndKeepsEmptySections()
+		{
+			IPhSegRuleRHS rhs = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				var rule = NewRegularRule();             // p →  / #t __  (empty RHS + empty right context)
+				AddSeg(rule.StrucDescOS, m_p);
+				rhs = rule.RightHandSidesOS[0];
+
+				var seq = Cache.ServiceLocator.GetInstance<IPhSequenceContextFactory>().Create();
+				rhs.LeftContextOA = seq;
+				AddBdry(seq.MembersRS, m_wordBdry);
+				AddSeg(seq.MembersRS, m_t);
+				// RHS StrucChange + RightContext intentionally left empty.
+			});
+
+			var model = RuleFormulaProjector.ProjectRegularRule(rhs);
+
+			Assert.That(model.ToFormulaString(), Is.EqualTo("p →  / #t __ "));
+			Assert.That(model.SectionFor(RuleSectionRole.Rhs).Cells, Is.Empty);
+			Assert.That(model.SectionFor(RuleSectionRole.RightContext).Cells, Is.Empty);
+
+			var left = model.SectionFor(RuleSectionRole.LeftContext);
+			Assert.That(left.Cells, Has.Count.EqualTo(2), "the sequence context flattens into its members");
+			Assert.That(left.Cells[0].Kind, Is.EqualTo(RuleCellKind.Boundary));
+			Assert.That(left.Cells[1].Kind, Is.EqualTo(RuleCellKind.Phoneme));
+		}
+
+		#region construction helpers (mirrors HCLoaderTests)
+
+		private IPhRegularRule NewRegularRule()
+		{
+			var rule = Cache.ServiceLocator.GetInstance<IPhRegularRuleFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.PhonRulesOS.Add(rule);   // factory seeds RightHandSidesOS[0]
+			return rule;
+		}
+
+		private IPhPhoneme AddPhoneme(string name)
+		{
+			var ph = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(ph);
+			ph.Name.SetVernacularDefaultWritingSystem(name);
+			return ph;
+		}
+
+		private IPhNCSegments AddNaturalClass(string abbr)
+		{
+			var nc = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(nc);
+			nc.Abbreviation.SetAnalysisDefaultWritingSystem(abbr);
+			nc.Name.SetAnalysisDefaultWritingSystem(abbr);
+			return nc;
+		}
+
+		private IPhBdryMarker AddBoundary(Guid guid, string rep)
+		{
+			var bdry = Cache.ServiceLocator.GetInstance<IPhBdryMarkerFactory>()
+				.Create(guid, Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0]);
+			bdry.Name.SetVernacularDefaultWritingSystem(rep);
+			return bdry;
+		}
+
+		private void AddSeg(ILcmOwningSequence<IPhSimpleContext> seq, IPhPhoneme phoneme)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+			seq.Add(ctx);
+			ctx.FeatureStructureRA = phoneme;
+		}
+
+		private void AddSeg(ILcmReferenceSequence<IPhPhonContext> seq, IPhPhoneme phoneme)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.ContextsOS.Add(ctx);
+			ctx.FeatureStructureRA = phoneme;
+			seq.Add(ctx);
+		}
+
+		private void AddNc(ILcmOwningSequence<IPhSimpleContext> seq, IPhNaturalClass nc)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+			seq.Add(ctx);
+			ctx.FeatureStructureRA = nc;
+		}
+
+		private void AddBdry(ILcmReferenceSequence<IPhPhonContext> seq, IPhBdryMarker bdry)
+		{
+			var ctx = Cache.ServiceLocator.GetInstance<IPhSimpleContextBdryFactory>().Create();
+			Cache.LangProject.PhonologicalDataOA.ContextsOS.Add(ctx);
+			ctx.FeatureStructureRA = bdry;
+			seq.Add(ctx);
+		}
+
+		#endregion
+	}
+}

--- a/Src/xWorks/xWorksTests/RuleFormulaRegionEditorPluginTests.cs
+++ b/Src/xWorks/xWorksTests/RuleFormulaRegionEditorPluginTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (task 1.4) — the regular-rule formula plugin lands on the Avalonia
+	/// surface. T1: the plugin builds a <see cref="RuleFormulaRegionEditor"/> from a rule's
+	/// <c>IPhSegRuleRHS</c>. T2: composing the <c>PhSegRuleRHS</c> "Edit" layout through the real
+	/// <see cref="FullEntryRegionComposer"/> + the DEFAULT plugin registry resolves the RegRuleFormulaSlice
+	/// to the rule editor — no §20.1.3 "Unsupported" row.
+	/// </summary>
+	[TestFixture]
+	public class RuleFormulaRegionEditorPluginTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhRegularRule m_rule;
+		private IPhSegRuleRHS m_rhs;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				var p = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(p);
+				p.Name.SetVernacularDefaultWritingSystem("p");
+				var vowel = Cache.ServiceLocator.GetInstance<IPhNCSegmentsFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.NaturalClassesOS.Add(vowel);
+				vowel.Abbreviation.SetAnalysisDefaultWritingSystem("V");
+
+				m_rule = Cache.ServiceLocator.GetInstance<IPhRegularRuleFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonRulesOS.Add(m_rule);    // factory seeds RightHandSidesOS[0]
+				m_rule.Name.SetAnalysisDefaultWritingSystem("prule");
+				var lhs = Cache.ServiceLocator.GetInstance<IPhSimpleContextSegFactory>().Create();
+				m_rule.StrucDescOS.Add(lhs);
+				lhs.FeatureStructureRA = p;
+				m_rhs = m_rule.RightHandSidesOS[0];
+				var rhsNc = Cache.ServiceLocator.GetInstance<IPhSimpleContextNCFactory>().Create();
+				m_rhs.StrucChangeOS.Add(rhsNc);
+				rhsNc.FeatureStructureRA = vowel;
+			});
+		}
+
+		[Test]
+		public void Plugin_BuildsRuleFormulaEditor_FromTheRhs()
+		{
+			var node = new ViewNode("PhSegRuleRHS/RuleFormula/#0", ViewNodeKind.Field, "Rule Formula", null,
+				"RuleFormula", "custom", EditorClassification.Dynamic, null, ViewVisibility.Always,
+				ViewExpansion.NotApplicable, false, null, Array.Empty<ViewNode>(),
+				customEditorClass: RuleFormulaRegionEditorPlugin.RegRuleFormulaSliceClassName,
+				customEditorAssembly: "MorphologyEditorDll.dll");
+
+			var control = new RuleFormulaRegionEditorPlugin()
+				.BuildControl(new RegionEditorBuildContext(m_rhs, node, () => null, Cache));
+
+			Assert.That(control, Is.InstanceOf<RuleFormulaRegionEditor>());
+			var editor = (RuleFormulaRegionEditor)control;
+			Assert.That(editor.Model.ToFormulaString(), Is.EqualTo("p → [V] /  __ "),
+				"the projected formula renders LHS phoneme, RHS natural class, and empty contexts");
+		}
+
+		[Test]
+		public void Plugin_IsRegisteredInTheDefaultRegistry()
+		{
+			Assert.That(
+				RegionEditorPluginRegistry.Default.Resolve(RuleFormulaRegionEditorPlugin.RegRuleFormulaSliceClassName),
+				Is.InstanceOf<RuleFormulaRegionEditorPlugin>(),
+				"the rule editor is wired into the product plugin registry");
+		}
+
+		[Test]
+		public void Compose_PhSegRuleRHS_ResolvesTheRuleEditor_NotUnsupported()
+		{
+			var composed = FullEntryRegionComposer.Compose(m_rhs, Cache, layoutName: "Edit",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var custom = composed.Model.Fields.SingleOrDefault(f => f.Kind == RegionFieldKind.Custom);
+			Assert.That(custom, Is.Not.Null, "the RHS 'Edit' layout composes the custom RuleFormula slice");
+
+			var control = custom.ControlFactory();
+			Assert.That(control, Is.InstanceOf<RuleFormulaRegionEditor>(),
+				"the RegRuleFormulaSlice resolves to the Avalonia rule editor (no Unsupported row)");
+		}
+
+		[Test]
+		public void Compose_PhRegularRule_RecordPath_ResolvesTheRuleEditor()
+		{
+			// The REAL RecordEditView composes the PhRegularRule (the record), which reaches the formula
+			// slice only through <seq field="RightHandSides" layout="Edit"/> + the RuleFormulaSection
+			// summary/indent wrapper. Proving the rule-level path here de-risks Block 4 (advisor-flagged).
+			var composed = FullEntryRegionComposer.Compose(m_rule, Cache, layoutName: "Edit",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var ruleEditors = composed.Model.Fields
+				.Where(f => f.Kind == RegionFieldKind.Custom)
+				.Select(f => f.ControlFactory?.Invoke())
+				.OfType<RuleFormulaRegionEditor>()
+				.ToList();
+			Assert.That(ruleEditors, Is.Not.Empty,
+				"composing the rule record reaches the RuleFormula slice through the RightHandSides seq and "
+				+ "resolves the Avalonia rule editor (no Unsupported row)");
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/SupportingEditorComposeTests.cs
+++ b/Src/xWorks/xWorksTests/SupportingEditorComposeTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia.Region;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// avalonia-rule-formula-editor (Block 3/4) — verifies the supporting-editor record details compose
+	/// END TO END on the Avalonia surface after the multi-child-part importer fix: the bespoke custom field
+	/// resolves to its Avalonia editor AND the surrounding standard Name/Description fields compose editably.
+	/// These gate the tool flips (EnvironmentEdit / phonemeEdit).
+	/// </summary>
+	[TestFixture]
+	public class SupportingEditorComposeTests : MemoryOnlyBackendProviderTestBase
+	{
+		[Test]
+		public void Compose_PhEnvironment_HasEnvironmentEditorAndEditableNameDescription()
+		{
+			IPhEnvironment env = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				env = Cache.ServiceLocator.GetInstance<IPhEnvironmentFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.EnvironmentsOS.Add(env);
+				env.Name.SetAnalysisDefaultWritingSystem("intervocalic");
+				env.Description.SetAnalysisDefaultWritingSystem("between vowels");
+			});
+
+			var composed = FullEntryRegionComposer.Compose(env, Cache, layoutName: "Edit",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var editors = composed.Model.Fields.Where(f => f.Kind == RegionFieldKind.Custom)
+				.Select(f => f.ControlFactory?.Invoke()).OfType<PhEnvironmentEditor>().ToList();
+			Assert.That(editors, Is.Not.Empty, "the StringRepresentation slice resolves to the Avalonia environment editor");
+			Assert.That(composed.Model.Fields.Any(f => f.Kind == RegionFieldKind.Text),
+				"Name/Description compose as editable text (multi-child <if> import fix)");
+		}
+
+		[Test]
+		public void Compose_PhPhoneme_HasIpaSymbolEditor()
+		{
+			IPhPhoneme phoneme = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS.Add(
+					Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create());
+				phoneme = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				Cache.LangProject.PhonologicalDataOA.PhonemeSetsOS[0].PhonemesOC.Add(phoneme);
+				phoneme.Name.SetVernacularDefaultWritingSystem("p");
+			});
+
+			var composed = FullEntryRegionComposer.Compose(phoneme, Cache, layoutName: "Edit",
+				plugins: RegionEditorPluginRegistry.Default);
+
+			var editors = composed.Model.Fields.Where(f => f.Kind == RegionFieldKind.Custom)
+				.Select(f => f.ControlFactory?.Invoke()).OfType<BasicIPASymbolEditor>().ToList();
+			Assert.That(editors, Is.Not.Empty, "the BasicIPASymbol slice resolves to the Avalonia IPA symbol editor");
+		}
+	}
+}


### PR DESCRIPTION
## Phase-1 follow-up: Avalonia rule-formula editors (Grammar)

**Stacked on the interlinear follow-up.** Restores and activates the Grammar rule-editor family.

- Adds 29 files: the 5 plugins (regular/metathesis/compound rule grids + phonological-environment + Basic IPA symbol editors), `RuleFormulaModel`/`RegionEditor`/`RuleCellCommands`, projector/sinks/options/deriver, and all their tests.
- Restores the 5 plugin registrations + census entries.
- **Flip:** registers the 6 rule tools (`PhonologicalRuleEdit`, `EnvironmentEdit`, `compoundRuleAdvancedEdit`, `naturalClassedit`, `phonemeEdit`, `AdhocCoprohibEdit`) in `LexicalEditFeatureCatalog` under a new "Grammar rule editors" group (restoring the canonical pre-split active set + parity notes). `Phase1FollowUpSurfaceTools` is now empty.

Note: since this branch was rebased onto the squashed base PR, "flip" now means catalog entries rather than a hardcoded array edit — as a side effect, this also adds a new "Grammar rule editors" group (6 rows: Phonological Rules, Phonological Environments, Compound Rules, Natural Classes, Phonemes, Ad Hoc Co-occurrence Rules) to the Tools→Options "Manage Individual Features" dialog, visible under `UIMode=New`.

Verification: build green; census + 6 rule `RegisteredRecordEditTools` cases + RuleFormula/SupportingEditorCompose suites all passing (`FwAvaloniaTests` 866/866, `xWorksTests` 1695/1697, 2 pre-existing skips).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/966)
<!-- Reviewable:end -->

