### PR TITLE
Phase-1 follow-up: activate the Avalonia browse table

### DIFF
--- a/Src/Common/FwAvalonia/FwAvaloniaTests/LexicalEditSurfaceResolverTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/LexicalEditSurfaceResolverTests.cs
@@ -163,12 +163,12 @@ namespace FwAvaloniaTests
 		// Phase1FollowUpBrowseTools) and restores the SelectsAvalonia expectations.
 
 		[Test]
-		public void ResolveBrowse_LexiconBrowse_NewMode_InertInBase_FallsBackToLegacy()
+		public void ResolveBrowse_LexiconBrowse_NewMode_YieldsAvalonia()
 		{
 			var surface = LexicalEditSurfaceResolver.ResolveBrowse(
 				uiMode: LexicalEditSurfaceResolver.NewUIMode, currentToolName: "lexiconBrowse");
-			Assert.That(surface, Is.EqualTo(LexicalEditSurface.WinForms),
-				"the browse table is a follow-up surface, inert in the base PR (even under New)");
+			Assert.That(surface, Is.EqualTo(LexicalEditSurface.Avalonia),
+				"the browse table is activated by the table follow-up PR (under New)");
 		}
 
 		[Test]
@@ -180,14 +180,14 @@ namespace FwAvaloniaTests
 		}
 
 		[Test]
-		public void ResolveBrowse_LexiconEdit_NewMode_InertInBase_FallsBackToLegacy()
+		public void ResolveBrowse_LexiconEdit_NewMode_YieldsAvalonia()
 		{
 			// The Lexicon Edit tool's left Entries pane reports currentContentControl = "lexiconEdit".
-			// Inert in the base PR; the browse follow-up re-registers it.
+			// Activated by the table follow-up PR.
 			var surface = LexicalEditSurfaceResolver.ResolveBrowse(
 				uiMode: LexicalEditSurfaceResolver.NewUIMode, currentToolName: "lexiconEdit");
-			Assert.That(surface, Is.EqualTo(LexicalEditSurface.WinForms),
-				"the browse table is a follow-up surface, inert in the base PR (even under New)");
+			Assert.That(surface, Is.EqualTo(LexicalEditSurface.Avalonia),
+				"the browse table is activated by the table follow-up PR (under New)");
 		}
 
 		[TestCase("concordance")]
@@ -209,24 +209,24 @@ namespace FwAvaloniaTests
 		[TestCase("toolBulkEditWordforms")]   // §20.2.4 Words bulk-edit
 		[TestCase("featureTypesAdvancedEdit")]      // §20.2.7 Grammar/Lists flat feature-types table
 		[TestCase("reversalToolReversalIndexPOS")]  // §20.2.7 reversal-index POS flat table
-		// Phase-1: the browse TABLE is a follow-up surface, INERT in the base PR, so these tools stay on the
-		// legacy BrowseViewer even under New. The browse follow-up re-registers them and restores Avalonia.
-		public void ResolveBrowse_RegisteredNonLexiconTool_NewMode_InertInBase(string toolName)
+		// §20.2: activated by the table follow-up PR — these flat-list tools' browse pane renders on the
+		// Avalonia owned table under New (their EDIT detail stays WinForms until separately registered).
+		public void ResolveBrowse_RegisteredNonLexiconTool_NewMode_YieldsAvalonia(string toolName)
 		{
 			Assert.That(LexicalEditSurfaceResolver.ResolveBrowse(
 				uiMode: LexicalEditSurfaceResolver.NewUIMode, currentToolName: toolName),
-				Is.EqualTo(LexicalEditSurface.WinForms),
-				$"{toolName} browse is inert in the base PR (table is a follow-up); stays legacy even under New");
+				Is.EqualTo(LexicalEditSurface.Avalonia),
+				$"{toolName} browse is activated by the table follow-up PR; selects the Avalonia table under New");
 		}
 
 		[Test]
-		public void ResolveBrowse_ExplicitOverride_InertInBase()
+		public void ResolveBrowse_ExplicitOverride_YieldsAvalonia()
 		{
-			// With the browse table inert (no tool registered), even an explicit override cannot select the
-			// Avalonia table — the tool gate is checked first. The follow-up re-registers the browse tools.
+			// With the browse table activated (tool registered), an explicit override selects the Avalonia
+			// table: the tool gate is open, so the override wins over the persisted preference.
 			Assert.That(LexicalEditSurfaceResolver.ResolveBrowse(
 				overrideEnabled: true, uiMode: LexicalEditSurfaceResolver.LegacyUIMode,
-				currentToolName: "lexiconBrowse"), Is.EqualTo(LexicalEditSurface.WinForms));
+				currentToolName: "lexiconBrowse"), Is.EqualTo(LexicalEditSurface.Avalonia));
 		}
 
 		// --- Disabled-tools CSV round-trip (the "Manage Individual Features" persistence format). No prior

--- a/Src/Common/FwAvalonia/LexicalEditSurfaceResolver.cs
+++ b/Src/Common/FwAvalonia/LexicalEditSurfaceResolver.cs
@@ -46,25 +46,23 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 		// flat-list non-lexicon tools opt their LIST pane into the Avalonia table here. (Their EDIT detail
 		// stays WinForms until registered in the separate LexicalEditSurfaceRegistry — §20.3.) Lists tools are
 		// NOT here: they navigate via a hierarchical tree bar, which needs the §20.2.6 owned tree first.
-		// PHASE-1: the Avalonia browse TABLE is a FOLLOW-UP surface and is INERT in the base PR — no tool is
-		// registered, so every list pane falls back to the legacy WinForms BrowseViewer even under UIMode=New.
-		// The table's view-layer code (LexicalBrowseView etc.) ships in base but stays dormant. The
-		// phase1-followup-table branch/PR (stacked on phase1-followup-rule, per PR #964's description) ACTIVATES
-		// it by moving its tool name(s) from Phase1FollowUpBrowseTools into this list.
-		// Verified by InertFollowUpSurfacesFallBackToLegacy in the resolver tests. The gate this array feeds is
-		// consulted at Src/xWorks/RecordBrowseView.cs:TryActivateAvaloniaBrowse (via ResolveBrowse below).
+		// PHASE-1 TABLE FOLLOW-UP (this branch): the Avalonia owned browse table is ACTIVATED here by listing
+		// the tools whose list pane renders on it under UIMode=New. The table's view-layer code (LexicalBrowseView
+		// etc.) and its RecordBrowseView product wiring already shipped (dormant) in the base PR; this flip turns
+		// them on. The browse gate is separate from the edit-surface registry (LexicalEditSurfaceRegistry) because
+		// the table is a distinct surface; both are gated by the same `UIMode = New` preference.
 		private static readonly string[] SupportedAvaloniaBrowseToolNames =
 		{
-		};
-
-		// The browse tools the phase1-followup-table branch/PR will re-activate (the one-line "flip" — move
-		// into the array above).
-		public static readonly string[] Phase1FollowUpBrowseTools =
-		{
-			"lexiconEdit", "lexiconBrowse",
+			"lexiconEdit",   // the Lexicon Edit tool's left Entries pane (currentContentControl = "lexiconEdit")
+			"lexiconBrowse", // the standalone Lexicon > Browse tool
 			"notebookEdit", "notebookBrowse",       // §20.2.1 Notebook (RnGenericRec flat record list)
 			"Analyses", "toolBulkEditWordforms",    // §20.2.4 Words (wordform analyses + bulk edit)
 			"featureTypesAdvancedEdit", "reversalToolReversalIndexPOS" // §20.2.7 Grammar flat-table editors
+		};
+
+		// Now EMPTY: the browse/table follow-up has been flipped into SupportedAvaloniaBrowseToolNames above.
+		public static readonly string[] Phase1FollowUpBrowseTools =
+		{
 		};
 
 		/// <summary>Property/app-setting key storing the preferred lexical-edit UI mode.</summary>


### PR DESCRIPTION
## Phase-1 follow-up: activate the Avalonia browse table

**Stacked on the rule-formula follow-up.** Pure activation flip — the table view code (`LexicalBrowseView`, `LexicalBrowseHostControl`, `BulkEditBarView`, `ClerkBrowse*`) and its `RecordBrowseView` wiring already shipped (dormant) in the base PR, because they are fused to base wiring and could not be carved into a separate code PR.

- **Flip:** moves the 8 browse tool names (`lexiconEdit`, `lexiconBrowse`, `notebookEdit`, `notebookBrowse`, `Analyses`, `toolBulkEditWordforms`, `featureTypesAdvancedEdit`, `reversalToolReversalIndexPOS`) from `Phase1FollowUpBrowseTools` into `SupportedAvaloniaBrowseToolNames`.
- Flips the 4 base inert-browse resolver tests back to asserting Avalonia under New.

2-file change. Verification: build green; resolver/browse suites 142/142.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/967)
<!-- Reviewable:end -->
