### PR TITLE
LT-22069: Speed up cross-project link navigation

### DIFF
--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -3484,8 +3484,12 @@ namespace SIL.FieldWorks
 		/// ------------------------------------------------------------------------------------
 		private static RemoteRequest CreateRequestor(int port, string requestType)
 		{
+			// LT-22069: connect via the IPv4 loopback literal rather than "localhost". Resolving
+			// "localhost" can try IPv6 (::1) first and wait ~2s for it to fail before falling back
+			// to IPv4, and that cost is paid on every first-contact to another FieldWorks process's
+			// remoting port. Using 127.0.0.1 avoids the name-resolution/IPv6 stall.
 			RemoteRequest requestor = (RemoteRequest)Activator.GetObject(typeof(RemoteRequest),
-				"tcp://localhost:" + port + "/" + requestType);
+				"tcp://127.0.0.1:" + port + "/" + requestType);
 			Func<bool> invoker = requestor.IsAlive;
 			IAsyncResult ar = invoker.BeginInvoke(null, null);
 			if (!ar.AsyncWaitHandle.WaitOne(1000, false))


### PR DESCRIPTION
## Summary

Clicking a cross-project hyperlink (e.g. FLExTrans links between two FLEx projects) took several seconds to bring the target project to the fore, with most of the time spent in .NET Remoting setup rather than the actual jump.

**Root cause:** `CreateRequestor` connected to other FieldWorks processes via `tcp://localhost:<port>/...`. Resolving `localhost` tries IPv6 (`::1`) first and waits ~2s for it to fail before falling back to IPv4. That stall is paid once per first-contact to each other FieldWorks process's remoting port. A link relay scans those ports three times during startup (the update check, the single-process-mode check, and the actual handoff), so the cost grows by ~2s for every additional FieldWorks instance running.

**Fix:** connect to the IPv4 loopback literal `127.0.0.1` instead of `localhost`.

## Measurements

Measured with the German/Swedish FLExTrans sample projects (Debug x64), varying the number of FieldWorks instances open. Diagnosed with temporary cross-process timing markers (since removed); SLDR init (3 ms) and the jump itself (25 ms) were not the bottleneck.

**Case 2 — target project already open (end-to-end click cost):**

| FieldWorks instances open | Before | After |
|---|---|---|
| 2 | 4,953 ms | 1,448 ms |
| 3 | 6,967 ms | 1,426 ms |
| 4 | 9,056 ms | 1,432 ms |
| 5 | 11,269 ms | 1,405 ms |

**Case 1 — target project not yet open (time to target window):**

| FieldWorks instances open | Before | After |
|---|---|---|
| 1 | 5,702 ms | 3,654 ms |
| 3 | 9,637 ms | 3,765 ms |
| 5 | 14,219 ms | 3,444 ms |

Before the fix the cost scaled linearly at ~2.1 s per running instance; after the fix it is flat regardless of how many instances are open. This also speeds up normal multi-instance startup and cold cross-project opens, which run the same probes. The remaining Case 1 time is project loading, which this change does not affect.

## Relationship to the reported times

The original report cited ~21 s (Case 1) and ~10 s (Case 2). **We could not confirm how many FieldWorks sessions the reporter had open at the time**, so this is our best guess — but it is the most likely explanation, because we were only able to reproduce times of that magnitude with several (~4–5) FieldWorks sessions running simultaneously. With the fix, those times become flat/low regardless of session count.

## Testing

- Built Debug x64 (`build.ps1 -SkipNative`).
- Reproduced the cross-project link scenario by replaying the stored `silfw:` link against the target project; confirmed the timings above and that target windows / jump behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/969)
<!-- Reviewable:end -->
