### PR TITLE
Fix LT-22577: Word Gloss and Category show as stars when out of focus

### DIFF
--- a/Src/LexText/Interlinear/SandboxBase.SandboxVc.cs
+++ b/Src/LexText/Interlinear/SandboxBase.SandboxVc.cs
@@ -550,6 +550,14 @@ namespace SIL.FieldWorks.IText
 				vwenv.set_IntProperty((int)FwTextPropType.ktptEditable,
 					(int)FwTextPropVar.ktpvEnum,
 					(int)TptEditable.ktptNotEditable);
+				int wordPosHvo = vwenv.DataAccess.get_ObjectProp(hvo, ktagSbWordPos);
+				if (vwenv.DataAccess.get_IntProp(wordPosHvo, ktagSbNamedObjGuess) == 1)
+				{
+					// Show that the word category is guessed.
+					vwenv.set_IntProperty((int)FwTextPropType.ktptBackColor,
+						(int)FwTextPropVar.ktpvDefault,
+						InterlinVc.MachineGuessColor);
+				}
 				AddOptionalNamedObj(vwenv, hvo, ktagSbWordPos, ktagMissingWordPos,
 					kfragMissingWordPos, ktagWordPosIcon, ws, choiceIndex);
 			}

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -562,6 +562,11 @@ namespace SIL.FieldWorks.IText
 			get; set;
 		}
 
+		public bool UsingWordCatGuess
+		{
+			get; set;
+		}
+
 		/// <summary>
 		/// Indicates the direction of flow of baseline that Sandbox is in.
 		/// (Only available after MakeRoot)
@@ -1581,6 +1586,7 @@ namespace SIL.FieldWorks.IText
 				int hvoSbWordPos = m_caches.DataAccess.get_ObjectProp(RootWordHvo, ktagSbWordPos);
 				m_caches.DataAccess.SetObjProp(RootWordHvo, ktagSbWordPos, hvoPos);
 				m_caches.DataAccess.SetInt(hvoPos, ktagSbNamedObjGuess, 1);
+				UsingWordCatGuess = true;
 				m_caches.DataAccess.PropChanged(RootBox, (int)PropChangeType.kpctNotifyAll, RootWordHvo,
 					ktagSbWordPos, 0, 1, (hvoSbWordPos == 0 ? 0 : 1));
 			}
@@ -4045,7 +4051,7 @@ namespace SIL.FieldWorks.IText
 		/// <returns></returns>
 		public bool ShouldSave(bool fSaveGuess)
 		{
-			return m_caches.DataAccess.IsDirty() || (fSaveGuess && UsingGuess);
+			return m_caches.DataAccess.IsDirty() || (fSaveGuess && (UsingGuess || UsingWordCatGuess));
 		}
 
 		/// <summary>
@@ -4064,6 +4070,7 @@ namespace SIL.FieldWorks.IText
 				CurrentAnalysisTree.Analysis = analMethod.Run();
 				obsoleteAna = analMethod.ObsoleteAnalysis;
 				UsingGuess = false;
+				UsingWordCatGuess = false;
 				MarkAsInitialState();
 			}
 			return CurrentAnalysisTree;


### PR DESCRIPTION
 This fixes https://jira.sil.org/browse/LT-22577 by highlighting word category guesses and making sure that they get saved when the analysis is approved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/971)
<!-- Reviewable:end -->
