### PR TITLE
Fix LT-22581: Crash clicking Values expansion button

### DIFF
--- a/Src/Common/Controls/DetailControls/DataTree.cs
+++ b/Src/Common/Controls/DetailControls/DataTree.cs
@@ -5302,7 +5302,6 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			m_indent = indent;
 			m_node = node;
 			m_path = path;
-			m_key = path.ToArray(); // This fixes LT-22581.
 			m_obj = obj;
 			m_flid = flid;
 			m_ihvoMin = ihvoMin;

--- a/Src/Common/Controls/DetailControls/DataTree.cs
+++ b/Src/Common/Controls/DetailControls/DataTree.cs
@@ -5302,6 +5302,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			m_indent = indent;
 			m_node = node;
 			m_path = path;
+			m_key = path.ToArray(); // This fixes LT-22581.
 			m_obj = obj;
 			m_flid = flid;
 			m_ihvoMin = ihvoMin;

--- a/Src/Common/Controls/DetailControls/Slice.cs
+++ b/Src/Common/Controls/DetailControls/Slice.cs
@@ -2938,6 +2938,10 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 
 		private int GetMoveableDepth()
 		{
+			if (Key == null)
+			{
+				return 0;
+			}
 			int count = 0;
 			foreach (object obj in Key)
 			{


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22581.  The code crashed because m_key wasn't initialized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/973)
<!-- Reviewable:end -->
