### PR TITLE
Fix LT-22579: Guesses not marked in .flextext if exported from Gloss

### DIFF
--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -2489,6 +2489,8 @@ namespace SIL.FieldWorks.IText
 					if (m_hvoDefault != m_hvoWordBundleAnalysis)
 					{
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
+						// Let the exporter know that this is a guessed analysis.
+						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
 					}
 					var wa = (IWfiAnalysis) m_defaultObj;
 					if (wa.MeaningsOC.Count == 0)
@@ -2526,6 +2528,8 @@ namespace SIL.FieldWorks.IText
 					else
 					{
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
+						// Let the exporter know that this is a guessed analysis.
+						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
 						m_vwenv.AddObj(m_hvoDefault, m_this, kfragLineChoices + choiceIndex);
 					}
 					break;
@@ -2575,6 +2579,8 @@ namespace SIL.FieldWorks.IText
 					if (m_hvoDefault != m_hvoWordBundleAnalysis)
 					{
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
+						// Let the exporter know that this is a guessed analysis.
+						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
 						var wa = (IWfiAnalysis) m_defaultObj;
 						int hvoPos = wa.CategoryRA != null ? wa.CategoryRA.Hvo : 0;
 						if (hvoPos == 0)
@@ -2594,7 +2600,11 @@ namespace SIL.FieldWorks.IText
 				case WfiGlossTags.kClassId:
 					m_hvoWfiAnalysis = m_defaultObj.Owner.Hvo;
 					if (m_hvoWordBundleAnalysis == m_hvoWordform) // then our analysis is a guess
+					{
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
+						// Let the exporter know that this is a guessed analysis.
+						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
+					}
 					m_vwenv.AddObj(m_hvoWfiAnalysis, m_this, kfragAnalysisCategoryChoices + choiceIndex);
 					break;
 				default:

--- a/Src/LexText/Interlinear/InterlinearExporter.cs
+++ b/Src/LexText/Interlinear/InterlinearExporter.cs
@@ -348,10 +348,23 @@ namespace SIL.FieldWorks.IText
 		protected void WriteItem(string itemType, ITsString tss)
 		{
 			m_writer.WriteStartElement("item");
+			if (itemType == "gls" || itemType == "pos")
+			{
+				WriteAnalysisStatus();
+			}
 			m_writer.WriteAttributeString("type", itemType);
 			int ws = GetWsFromTsString(tss);
 			WriteLangAndContent(ws, tss);
 			m_writer.WriteEndElement();
+		}
+
+		private void WriteAnalysisStatus()
+		{
+			StackItem top = this.PeekStack;
+			if (top != null && top.m_stringProps.ContainsKey(InterlinVc.ktagAnalysisStatus))
+			{
+				m_writer.WriteAttributeString("analysisStatus", top.m_stringProps[InterlinVc.ktagAnalysisStatus]);
+			}
 		}
 
 		private int GetWsFromTsString(ITsString tss)
@@ -601,6 +614,10 @@ namespace SIL.FieldWorks.IText
 		private void OpenItem(string itemType)
 		{
 			m_writer.WriteStartElement("item");
+			if (itemType == "gls" || itemType == "pos")
+			{
+				WriteAnalysisStatus();
+			}
 			m_writer.WriteAttributeString("type", itemType);
 			m_fItemIsOpen = true;
 		}
@@ -835,11 +852,7 @@ namespace SIL.FieldWorks.IText
 					break;
 				case InterlinVc.kfragMorphBundle:
 					m_writer.WriteStartElement("morphemes");
-					StackItem top = this.PeekStack;
-					if (top != null && top.m_stringProps.ContainsKey(InterlinVc.ktagAnalysisStatus))
-					{
-						m_writer.WriteAttributeString("analysisStatus", top.m_stringProps[InterlinVc.ktagAnalysisStatus]);
-					}
+					WriteAnalysisStatus();
 					break;
 				default:
 					break;


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22579 by marking gloss and part of speech items if they are guessed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/974)
<!-- Reviewable:end -->
