### PR TITLE
Fix LT-22589: Crash on clicking Item button in custom list

### DIFF
--- a/Src/xWorks/XWorksViewBase.cs
+++ b/Src/xWorks/XWorksViewBase.cs
@@ -233,6 +233,11 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
+		internal bool ClerkIsDisposed()
+		{
+			return m_clerk?.IsDisposed == true;
+		}
+
 		public IPaneBar MainPaneBar
 		{
 			get

--- a/Src/xWorks/XhtmlRecordDocView.cs
+++ b/Src/xWorks/XhtmlRecordDocView.cs
@@ -188,12 +188,7 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		public void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
 		{
-			if (ClerkIsDisposed())
-			{
-				// This fixes LT-22589.
-				return;
-			}
-			if (Clerk == null || m_mainView == null || m_mediator == null || hvo != Clerk.CurrentObjectHvo)
+			if (ClerkIsDisposed() || Clerk == null || m_mainView == null || m_mediator == null || hvo != Clerk.CurrentObjectHvo)
 				return;
 
 			var gb = m_mainView.NativeBrowser as GeckoWebBrowser;

--- a/Src/xWorks/XhtmlRecordDocView.cs
+++ b/Src/xWorks/XhtmlRecordDocView.cs
@@ -188,6 +188,11 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		public void PropChanged(int hvo, int tag, int ivMin, int cvIns, int cvDel)
 		{
+			if (ClerkIsDisposed())
+			{
+				// This fixes LT-22589.
+				return;
+			}
 			if (Clerk == null || m_mainView == null || m_mediator == null || hvo != Clerk.CurrentObjectHvo)
 				return;
 


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22589.  A PropChanged was called when the Clerk was disposed.  This shouldn't happen.  I fixed it so that at least the PropChanged doesn't crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/975)
<!-- Reviewable:end -->
