### PR TITLE
Fix LT-21913: Prevent crash when restoring over an open project

### DIFF
--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -38,6 +38,7 @@ using SIL.FieldWorks.FwCoreDlgs.BackupRestore;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel;
+using SIL.LCModel.DomainServices;
 using SIL.LCModel.DomainServices.BackupRestore;
 using SIL.LCModel.DomainServices.DataMigration;
 using SIL.LCModel.Infrastructure;
@@ -2539,6 +2540,24 @@ namespace SIL.FieldWorks
 		private static void RestoreCurrentProject(FwRestoreProjectSettings restoreSettings,
 			Form dialogOwner)
 		{
+			// If the project we are about to restore already exists and is open (its data
+			// file is locked) in some other program, then block the restore before we overwrite any
+			// files. Otherwise we would destroy the opened project's data and eventually crash trying to
+			// reopen the locked project (LT-21913).
+			// We skip this check when 'this' process is the one that has the project open, since we already
+			// prompted the user and ExecuteWithAppsShutDown will release our own lock before restoring.
+			var projectPath = restoreSettings.Settings.FullProjectPath;
+			var weHaveProjectOpen = s_projectId != null &&
+				s_projectId.IsSameLocalProject(new ProjectId(projectPath));
+			if (!weHaveProjectOpen && restoreSettings.Settings.ProjectExists &&
+				ProjectLockingService.IsProjectLocked(projectPath))
+			{
+				MessageBox.Show(dialogOwner,
+					string.Format(Properties.Resources.ksCannotRestoreProjectInUse, restoreSettings.Settings.ProjectName),
+					Properties.Resources.ksErrorCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+				return;
+			}
+
 			// When we get here we can safely do the backup of the project because we either
 			// have no cache (and no other process has this project open), or we are the
 			// process that has this project open. (FWR-3344)
@@ -3805,6 +3824,27 @@ namespace SIL.FieldWorks
 					return;
 
 				s_projectId = projId; // Process needs to know its project
+			}
+			catch (StartupException e) when (e.InnerException is LcmFileLockedException)
+			{
+				// The action (e.g. a restore) succeeded, but the project could not be reopened
+				// afterwards because it is now open (and its file locked) in another program
+				// (LT-21913). This is a safety net for the narrow window where the project gets
+				// locked after RestoreCurrentProject's up-front check but before we reopen it
+				// here. Inform the user with a message box rather than crashing with the green
+				// error-reporting dialog. Any other StartupException is left to propagate so
+				// that unexpected failures still generate a crash report.
+				if (s_cache != null)
+				{
+					s_cache.Dispose();
+					s_cache = null;
+				}
+				// Dispose the partially-created application so that we end up with no running
+				// apps (which lets the process shut down cleanly, just as if the action had
+				// failed or been cancelled).
+				GracefullyShutDownApp(s_flexApp);
+				MessageBox.Show(e.Message, Properties.Resources.ksErrorCaption,
+					MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 			finally
 			{

--- a/Src/Common/FieldWorks/Properties/Resources.Designer.cs
+++ b/Src/Common/FieldWorks/Properties/Resources.Designer.cs
@@ -136,6 +136,15 @@ namespace SIL.FieldWorks.Properties {
                 return ResourceManager.GetString("ksCancelButton", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The project &apos;{0}&apos; cannot be restored because it is currently open in another program. Please close the project everywhere it is open and try the restore again..
+        /// </summary>
+        internal static string ksCannotRestoreProjectInUse {
+            get {
+                return ResourceManager.GetString("ksCannotRestoreProjectInUse", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to FieldWorks is unable to move the following projects to the new location..

--- a/Src/Common/FieldWorks/Properties/Resources.resx
+++ b/Src/Common/FieldWorks/Properties/Resources.resx
@@ -234,6 +234,10 @@ Ensure that this folder is shared and that you have permission to access it.</va
   <data name="ksBackupErrorDuringRestore" xml:space="preserve">
     <value>Do you want to continue with the restore?</value>
   </data>
+  <data name="ksCannotRestoreProjectInUse" xml:space="preserve">
+    <value>The project '{0}' cannot be restored because it is currently open in another program. Please close the project everywhere it is open and try the restore again.</value>
+    <comment>Message shown when a restore is attempted over a project that is still open (and its data file is locked) in another program. {0} is the project name.</comment>
+  </data>
   <data name="ksChangeProjectLocationFailed" xml:space="preserve">
     <value>Could not change Projects location</value>
   </data>


### PR DESCRIPTION
Restoring a backup over a project that was open (and therefore file-locked) overwrote the project's data and then crashed.

Fix it in two places:
- RestoreCurrentProject now checks if the project is locked before doing anything destructive (overwriting files).

- ExecuteWithAppsShutDown adds a narrow safety net that catches a LcmFileLockedException when reopening. This covering the small window where the project could get locked between the up-front check and the reopen. Any other StartupException is left to propagate so unexpected failures still generate a crash report.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/986)
<!-- Reviewable:end -->
