### PR TITLE
Fix RegFree manifest-file race under parallel MSBuild

### DIFF
--- a/Build/Src/FwBuildTasks/FwBuildTasksTests/RegFreeConcurrencyTests.cs
+++ b/Build/Src/FwBuildTasks/FwBuildTasksTests/RegFreeConcurrencyTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.CSharp;
+using NUnit.Framework;
+using SIL.FieldWorks.Build.Tasks;
+
+namespace SIL.FieldWorks.Build.Tasks.FwBuildTasksTests
+{
+	/// <summary>
+	/// Verifies concurrent <see cref="RegFree"/> executions produce a valid shared manifest.
+	/// </summary>
+	[TestFixture]
+	public sealed class RegFreeConcurrencyTests
+	{
+		private const string AsmNamespace = "urn:schemas-microsoft-com:asm.v1";
+
+		[Test]
+		public void Execute_ConcurrentInvocationsTargetingSameManifest_AllSucceedAndProduceValidXml()
+		{
+			var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+			Directory.CreateDirectory(tempDir);
+			var assemblyPath = Path.Combine(tempDir, "RegFreeConcurrencyTestAssembly.dll");
+			var manifestPath = Path.Combine(tempDir, "Shared.manifest");
+
+			try
+			{
+				CompileComVisibleAssembly(assemblyPath);
+
+				const int concurrentInvocations = 12;
+				var results = new bool[concurrentInvocations];
+				var tasks = new Task[concurrentInvocations];
+				for (var i = 0; i < concurrentInvocations; i++)
+				{
+					var index = i;
+					tasks[index] = Task.Run(() =>
+					{
+						var regFree = new RegFree
+						{
+							BuildEngine = new FwBuildTasks.TestBuildEngine(),
+							Executable = assemblyPath,
+							Output = manifestPath,
+							ManagedAssemblies = new Microsoft.Build.Utilities.TaskItem[]
+							{
+								new Microsoft.Build.Utilities.TaskItem(assemblyPath)
+							},
+							Platform = "x64"
+						};
+						results[index] = regFree.Execute();
+					});
+				}
+
+				Task.WaitAll(tasks);
+
+				Assert.That(results, Has.All.True,
+					"every concurrent RegFree.Execute() call must succeed - none should fail with the " +
+					"manifest-file-in-use IOException this test guards against");
+
+				Assert.That(File.Exists(manifestPath), Is.True, "the shared manifest file must exist after all writers finish");
+
+				var doc = new XmlDocument();
+				Assert.DoesNotThrow(() => doc.Load(manifestPath),
+					"the manifest file must be well-formed XML, not truncated or interleaved by a concurrent write race");
+
+				var ns = new XmlNamespaceManager(doc.NameTable);
+				ns.AddNamespace("asmv1", AsmNamespace);
+				Assert.That(doc.SelectSingleNode("//asmv1:clrClass", ns), Is.Not.Null,
+					"the manifest must still contain the expected clrClass content after the concurrent writes");
+			}
+			finally
+			{
+				if (Directory.Exists(tempDir))
+				{
+					Directory.Delete(tempDir, true);
+				}
+			}
+		}
+
+		private static void CompileComVisibleAssembly(string outputPath)
+		{
+			const string source = @"using System.Runtime.InteropServices;
+[assembly: ComVisible(true)]
+[assembly: Guid(""6A2C9E1D-6C8B-4B77-9C3E-6F6B6B2C9E1D"")]
+namespace RegFreeConcurrencyTestAssembly
+{
+	[ComVisible(true)]
+	[Guid(""7B3DAF2E-7D9C-4C88-AD4F-7A7C7C3DAF2E"")]
+	[ProgId(""RegFreeConcurrency.SampleClass"")]
+	public class SampleComClass
+	{
+	}
+}";
+			var provider = new CSharpCodeProvider();
+			var parameters = new CompilerParameters
+			{
+				GenerateExecutable = false,
+				OutputAssembly = outputPath,
+				CompilerOptions = "/target:library"
+			};
+			parameters.ReferencedAssemblies.Add(typeof(object).Assembly.Location);
+			parameters.ReferencedAssemblies.Add(typeof(GuidAttribute).Assembly.Location);
+
+			var results = provider.CompileAssemblyFromSource(parameters, source);
+			if (results.Errors.HasErrors)
+			{
+				var message = string.Join(Environment.NewLine, results.Errors.Cast<CompilerError>().Select(e => e.ToString()));
+				throw new InvalidOperationException($"Failed to compile test assembly:{Environment.NewLine}{message}");
+			}
+		}
+	}
+}

--- a/Build/Src/FwBuildTasks/RegFree.cs
+++ b/Build/Src/FwBuildTasks/RegFree.cs
@@ -20,7 +20,10 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Principal;
+using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
 using Microsoft.Build.Framework;
@@ -181,185 +184,214 @@ namespace SIL.FieldWorks.Build.Tasks
 				? Executable + ".manifest"
 				: Output;
 
-			try
+			// Parallel build workers can update the same manifest, so serialize by manifest path
+			// while leaving unrelated manifests independent.
+			using (var manifestLock = new Mutex(false, ManifestLockName(manifestFile)))
 			{
-				var doc = new XmlDocument { PreserveWhitespace = true };
-
-				// Try to load existing manifest, or create empty document if it doesn't exist
-				if (File.Exists(manifestFile))
-				{
-					using (XmlReader reader = new XmlTextReader(manifestFile))
-					{
-						if (reader.MoveToElement())
-							doc.ReadNode(reader);
-					}
-				}
-				else
-				{
-					// Create a minimal valid XML document if manifest doesn't exist
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tCreating new manifest file {0}",
-						manifestFile
-					);
-				}
-
-				// Process all DLLs using direct type library parsing (no registry redirection needed)
-				var creator = new RegFreeCreator(doc, Log);
-				if (ExcludedClsids != null)
-				{
-					creator.AddExcludedClsids(GetFilesFrom(ExcludedClsids));
-				}
-
-				// Remove non-existing files from the list
-				itemsToProcess.RemoveAll(item => !File.Exists(item.ItemSpec));
-
-				string assemblyName = Path.GetFileNameWithoutExtension(manifestFile);
-				if (assemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-				{
-					assemblyName = Path.GetFileNameWithoutExtension(assemblyName);
-				}
-				Debug.Assert(assemblyName != null);
-				// The C++ test programs won't run if an assemblyIdentity element exists.
-				//if (assemblyName.StartsWith("test"))
-				//	assemblyName = null;
-				string assemblyVersion = null;
 				try
 				{
-					assemblyVersion = FileVersionInfo.GetVersionInfo(Executable).FileVersion;
+					manifestLock.WaitOne();
 				}
-				catch
+				catch (AbandonedMutexException)
 				{
-					// just ignore
+					// Ownership is granted even when the previous holder abandoned the mutex.
 				}
-				if (string.IsNullOrEmpty(assemblyVersion))
+				try
 				{
-					assemblyVersion = "1.0.0.0";
-				}
-				else
-				{
-					// Ensure version has exactly 4 numeric parts for manifest compliance (Major.Minor.Build.Revision)
-					// Some assemblies might have 3-part versions (e.g. 1.1.0) or non-numeric suffixes
-					// (e.g. 9.3.5.local_20260119) which are invalid in SxS manifests.
-					// Always sanitize to extract only the leading digits from each part.
-					var parts = assemblyVersion.Split('.');
-					var newParts = new string[4];
-					for (int i = 0; i < 4; i++)
-					{
-						// Simple parsing to ensure we only get numbers
-						string part = "0";
-						if (i < parts.Length)
-						{
-							// Take only the leading digits from each version part
-							var digits = new string(parts[i].TakeWhile(char.IsDigit).ToArray());
-							if (!string.IsNullOrEmpty(digits))
-								part = digits;
-						}
-						newParts[i] = part;
-					}
-					assemblyVersion = string.Join(".", newParts);
-				}
+					var doc = new XmlDocument { PreserveWhitespace = true };
 
-				XmlElement root = creator.CreateExeInfo(assemblyName, assemblyVersion, Platform);
-
-				foreach (string fileName in GetFilesFrom(ManagedAssemblies))
-				{
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tProcessing managed assembly {0}",
-						Path.GetFileName(fileName)
-					);
-					creator.ProcessManagedAssembly(root, fileName);
-				}
-
-				foreach (var item in itemsToProcess)
-				{
-					string fileName = item.ItemSpec;
-					if (NoTypeLib.Count(f => f.ItemSpec == fileName) != 0)
-						continue;
-
-					string server = item.GetMetadata("Server");
-					if (string.IsNullOrEmpty(server))
-						server = null;
-
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tProcessing library {0}",
-						Path.GetFileName(fileName)
-					);
-
-					// Process type library directly (no registry redirection needed)
-					creator.ProcessTypeLibrary(root, fileName, server);
-				}
-
-				// Process classes and interfaces from HKCR (where COM is already registered)
-				creator.ProcessClasses(root);
-				creator.ProcessInterfaces(root);
-
-				foreach (string fragmentName in GetFilesFrom(Fragments))
-				{
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tAdding fragment {0}",
-						Path.GetFileName(fragmentName)
-					);
-					creator.AddFragment(root, fragmentName);
-				}
-
-				foreach (string fragmentName in GetFilesFrom(AsIs))
-				{
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tAdding as-is fragment {0}",
-						Path.GetFileName(fragmentName)
-					);
-					creator.AddAsIs(root, fragmentName);
-				}
-
-				foreach (string assemblyFileName in GetFilesFrom(DependentAssemblies))
-				{
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tAdding dependent assembly {0}",
-						Path.GetFileName(assemblyFileName)
-					);
-					creator.AddDependentAssembly(root, assemblyFileName);
-				}
-
-				if (!HasRegFreeContent(doc))
-				{
-					Log.LogMessage(
-						MessageImportance.Low,
-						"\tNo registration-free content found for {0}; manifest will not be emitted.",
-						Path.GetFileName(manifestFile)
-					);
+					// Try to load existing manifest, or create empty document if it doesn't exist
 					if (File.Exists(manifestFile))
-						File.Delete(manifestFile);
-					return true;
-				}
+					{
+						using (XmlReader reader = new XmlTextReader(manifestFile))
+						{
+							if (reader.MoveToElement())
+								doc.ReadNode(reader);
+						}
+					}
+					else
+					{
+						// Create a minimal valid XML document if manifest doesn't exist
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tCreating new manifest file {0}",
+							manifestFile
+						);
+					}
 
-				var settings = new XmlWriterSettings
-				{
-					OmitXmlDeclaration = false,
-					NewLineOnAttributes = false,
-					NewLineChars = Environment.NewLine,
-					Indent = true,
-					IndentChars = "\t",
-				};
-				using (XmlWriter writer = XmlWriter.Create(manifestFile, settings))
-				{
-					doc.WriteContentTo(writer);
-				}
+					// Process all DLLs using direct type library parsing (no registry redirection needed)
+					var creator = new RegFreeCreator(doc, Log);
+					if (ExcludedClsids != null)
+					{
+						creator.AddExcludedClsids(GetFilesFrom(ExcludedClsids));
+					}
 
-				// Note: No unregistration needed - we never registered anything!
-				// Direct type library parsing doesn't touch the registry.
-			}
-			catch (Exception e)
-			{
-				Log.LogErrorFromException(e, true, true, null);
-				return false;
+					// Remove non-existing files from the list
+					itemsToProcess.RemoveAll(item => !File.Exists(item.ItemSpec));
+
+					string assemblyName = Path.GetFileNameWithoutExtension(manifestFile);
+					if (assemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+					{
+						assemblyName = Path.GetFileNameWithoutExtension(assemblyName);
+					}
+					Debug.Assert(assemblyName != null);
+					// The C++ test programs won't run if an assemblyIdentity element exists.
+					//if (assemblyName.StartsWith("test"))
+					//	assemblyName = null;
+					string assemblyVersion = null;
+					try
+					{
+						assemblyVersion = FileVersionInfo.GetVersionInfo(Executable).FileVersion;
+					}
+					catch
+					{
+						// just ignore
+					}
+					if (string.IsNullOrEmpty(assemblyVersion))
+					{
+						assemblyVersion = "1.0.0.0";
+					}
+					else
+					{
+						// Ensure version has exactly 4 numeric parts for manifest compliance (Major.Minor.Build.Revision)
+						// Some assemblies might have 3-part versions (e.g. 1.1.0) or non-numeric suffixes
+						// (e.g. 9.3.5.local_20260119) which are invalid in SxS manifests.
+						// Always sanitize to extract only the leading digits from each part.
+						var parts = assemblyVersion.Split('.');
+						var newParts = new string[4];
+						for (int i = 0; i < 4; i++)
+						{
+							// Simple parsing to ensure we only get numbers
+							string part = "0";
+							if (i < parts.Length)
+							{
+								// Take only the leading digits from each version part
+								var digits = new string(parts[i].TakeWhile(char.IsDigit).ToArray());
+								if (!string.IsNullOrEmpty(digits))
+									part = digits;
+							}
+							newParts[i] = part;
+						}
+						assemblyVersion = string.Join(".", newParts);
+					}
+
+					XmlElement root = creator.CreateExeInfo(assemblyName, assemblyVersion, Platform);
+
+					foreach (string fileName in GetFilesFrom(ManagedAssemblies))
+					{
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tProcessing managed assembly {0}",
+							Path.GetFileName(fileName)
+						);
+						creator.ProcessManagedAssembly(root, fileName);
+					}
+
+					foreach (var item in itemsToProcess)
+					{
+						string fileName = item.ItemSpec;
+						if (NoTypeLib.Count(f => f.ItemSpec == fileName) != 0)
+							continue;
+
+						string server = item.GetMetadata("Server");
+						if (string.IsNullOrEmpty(server))
+							server = null;
+
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tProcessing library {0}",
+							Path.GetFileName(fileName)
+						);
+
+						// Process type library directly (no registry redirection needed)
+						creator.ProcessTypeLibrary(root, fileName, server);
+					}
+
+					// Process classes and interfaces from HKCR (where COM is already registered)
+					creator.ProcessClasses(root);
+					creator.ProcessInterfaces(root);
+
+					foreach (string fragmentName in GetFilesFrom(Fragments))
+					{
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tAdding fragment {0}",
+							Path.GetFileName(fragmentName)
+						);
+						creator.AddFragment(root, fragmentName);
+					}
+
+					foreach (string fragmentName in GetFilesFrom(AsIs))
+					{
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tAdding as-is fragment {0}",
+							Path.GetFileName(fragmentName)
+						);
+						creator.AddAsIs(root, fragmentName);
+					}
+
+					foreach (string assemblyFileName in GetFilesFrom(DependentAssemblies))
+					{
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tAdding dependent assembly {0}",
+							Path.GetFileName(assemblyFileName)
+						);
+						creator.AddDependentAssembly(root, assemblyFileName);
+					}
+
+					if (!HasRegFreeContent(doc))
+					{
+						Log.LogMessage(
+							MessageImportance.Low,
+							"\tNo registration-free content found for {0}; manifest will not be emitted.",
+							Path.GetFileName(manifestFile)
+						);
+						if (File.Exists(manifestFile))
+							File.Delete(manifestFile);
+						return true;
+					}
+
+					var settings = new XmlWriterSettings
+					{
+						OmitXmlDeclaration = false,
+						NewLineOnAttributes = false,
+						NewLineChars = Environment.NewLine,
+						Indent = true,
+						IndentChars = "\t",
+					};
+					using (XmlWriter writer = XmlWriter.Create(manifestFile, settings))
+					{
+						doc.WriteContentTo(writer);
+					}
+
+					// Note: No unregistration needed - we never registered anything!
+					// Direct type library parsing doesn't touch the registry.
+				}
+				catch (Exception e)
+				{
+					Log.LogErrorFromException(e, true, true, null);
+					return false;
+				}
+				finally
+				{
+					manifestLock.ReleaseMutex();
+				}
 			}
 			return true;
+		}
+
+		/// <summary>Returns a process-stable mutex name for the manifest path.</summary>
+		private static string ManifestLockName(string manifestFile)
+		{
+			var normalizedPath = Path.GetFullPath(manifestFile).ToUpperInvariant();
+			// String hash codes vary by process, so use a deterministic digest.
+			using (var md5 = MD5.Create())
+			{
+				var hash = md5.ComputeHash(Encoding.UTF8.GetBytes(normalizedPath));
+				return "FwRegFreeManifest_" + BitConverter.ToString(hash).Replace("-", "");
+			}
 		}
 
 		private static bool HasRegFreeContent(XmlDocument doc)


### PR DESCRIPTION
Parallel FieldWorks builds can now generate registration-free COM manifests without racing when multiple MSBuild workers target the same output file. `RegFree.Execute()` serializes each manifest's complete read-modify-write operation across processes while unrelated manifests remain independent.

The key review question is whether the lock is narrow enough to preserve build parallelism but broad enough to protect every manifest mutation. The mutex is keyed by the normalized manifest path and encloses the load, update, write, and delete paths. Its name uses a deterministic digest because .NET string hash codes are process-specific. An abandoned mutex is treated as acquired, matching the platform contract, so the existing task error handling can report any damaged manifest instead of leaking an unhandled exception.

## Where to look

- `RegFree.Execute()` owns the mutex for the complete manifest transaction and releases it in `finally`.
- `ManifestLockName()` creates the same lock identity in every worker without globally serializing different manifests.
- `AbandonedMutexException` handling preserves ownership and lets normal manifest validation and error reporting continue.
- `RegFreeConcurrencyTests` runs 12 tasks against one manifest and verifies every result plus the final XML content.

## Deliberately not here

- No global build lock or serialization between unrelated manifest files.
- No COM registration, registry workaround, retry loop, or change to manifest contents.

## Verification

`./test.ps1 -TestProject Build/Src/FwBuildTasks/FwBuildTasksTests -StartedBy agent` passed locally: 146 managed tests passed, 3 skipped, and the repository script's 31 native smoke tests passed. The full FieldWorks suite was not rerun locally after the rebase; CI remains the full gate.

---

<details>
<summary><b>Reading this a year from now</b> -- start here</summary>

This focused branch carried no Markdown research or working notes to preserve or delete. The decision record lives here because the source comments intentionally retain only the local concurrency invariants a maintainer needs while reading the code.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

- The lock covers the entire manifest transaction, not only `XmlWriter.Create()`. A worker must not read another worker's partially updated state or overwrite changes made after its own read.
- The lock is path-specific. Builds can still generate different manifests concurrently.
- The normalized full path is converted to a deterministic MD5 digest for the mutex name. `string.GetHashCode()` was rejected because its value can differ between worker processes. MD5 is used only as a stable identifier, not for security.
- `AbandonedMutexException` is a successful acquisition signal with warning semantics. Continuing under ownership allows the existing XML load and task error handling to detect and report a manifest left incomplete by the previous holder.

</details>

<details>
<summary><b>Regression evidence</b></summary>

The original failure was an intermittent `IOException` while parallel workers wrote the same manifest during PR #964; rerunning the same CI job passed, which isolated the problem to timing rather than deterministic input.

The regression test compiles a COM-visible assembly, launches 12 concurrent `RegFree.Execute()` calls against one manifest, requires every call to succeed, loads the result as XML, and verifies the expected `clrClass`. During development it failed in 3 of 3 runs with the mutex removed and passed in 5 of 5 runs with the mutex restored. The final squashed commit passed the complete `FwBuildTasksTests` project locally: 146 passed and 3 skipped.

</details>

<!-- Reviewable:start -->
- - -
[<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/988)
<!-- Reviewable:end -->
