### PR TITLE
Build: drop retired ManagedVwWindow.dll from RegFree managed COM list

### DIFF
--- a/Build/RegFree.targets
+++ b/Build/RegFree.targets
@@ -66,7 +66,7 @@
 		<!-- Explicitly list managed assemblies that expose COM types -->
 		<ManagedComAssemblies Include="$(OutDir)FwUtils.dll" />
 		<ManagedComAssemblies Include="$(OutDir)SimpleRootSite.dll" />
-		<ManagedComAssemblies Include="$(OutDir)ManagedVwWindow.dll" />
+		<!-- ManagedVwWindow.dll was retired with the Linux-era view shims (#906); do not process it. -->
 	</ItemGroup>
 	<ItemGroup>
 		<ManagedComAssemblies Remove="$(OutDir)*.resources.dll" />


### PR DESCRIPTION
## Summary

`ManagedVwWindow.dll` was retired with the Linux-era view shims (#906). That cleanup updated `Build/mkall.targets` (excludes its CLSID) and `Build/Installer.legacy.targets` (lists it as removed-since-last-base), but **missed `Build/RegFree.targets`**, which still listed the DLL in `ManagedComAssemblies`.

Because the file no longer exists, the `RegFree` task emits a warning for every EXE that imports the target:

```
Build\RegFree.targets(91,3): warning : Failed to process managed assembly
  ...\Output\Debug\ManagedVwWindow.dll: Could not find file
  '...\Output\Debug\ManagedVwWindow.dll'.
  [Src\UnicodeCharEditor\UnicodeCharEditor.csproj]
  [Src\LCMBrowser\LCMBrowser.csproj]
```

## Change

Remove the stale `<ManagedComAssemblies Include="$(OutDir)ManagedVwWindow.dll" />` entry (replaced with an explanatory comment). The remaining managed COM assemblies (`FwUtils.dll`, `SimpleRootSite.dll`) are real and unaffected.

## Impact

- Clears the warning from both `UnicodeCharEditor` and `LCMBrowser` builds (one root cause, surfaced once per EXE).
- No behavior change: the DLL doesn't exist, so it was never actually being processed — only warned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/989)
<!-- Reviewable:end -->
