### PR TITLE
Fix LT-22606: Word Cat has tan background when bundle selected

### DIFF
--- a/Src/LexText/Interlinear/ITextDllTests/SandboxBaseTests.cs
+++ b/Src/LexText/Interlinear/ITextDllTests/SandboxBaseTests.cs
@@ -100,7 +100,7 @@ namespace SIL.FieldWorks.IText
 				VerifySelection(sandbox, false, SandboxBase.ktagSbWordGloss, 0, -1);
 				// Next the icon on the word cat line.
 				sandbox.HandleTab(false);
-				VerifySelection(sandbox, true, SandboxBase.ktagSbNamedObjName, SandboxBase.ktagSbWordPos, -1);
+				VerifySelection(sandbox, true, SandboxBase.ktagWordPosIcon, 0, -1);
 				// Then we wrap around to the start icon on the word line.
 				sandbox.HandleTab(false);
 				VerifySelection(sandbox, true, SandboxBase.ktagAnalysisIcon, 0, -1);
@@ -117,7 +117,7 @@ namespace SIL.FieldWorks.IText
 				sandbox.HandleTab(true);
 				VerifySelection(sandbox, true, SandboxBase.ktagAnalysisIcon, 0, -1);
 				sandbox.HandleTab(true);
-				VerifySelection(sandbox, true, SandboxBase.ktagSbNamedObjName, SandboxBase.ktagSbWordPos, -1);
+				VerifySelection(sandbox, true, SandboxBase.ktagWordPosIcon, 0, -1);
 				sandbox.HandleTab(true);
 				VerifySelection(sandbox, false, SandboxBase.ktagSbWordGloss, 0, -1);
 				sandbox.HandleTab(true);

--- a/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
+++ b/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
@@ -1213,7 +1213,7 @@ namespace SIL.FieldWorks.IText
 				MorphemeBreaker mb = new MorphemeBreaker(m_caches, sMorphs, m_hvoSbWord,
 					m_wsVern, m_sandbox);
 				mb.Run();
-				m_sandbox.CopyLexEntryInfoToMonomorphemicWordGlossAndPos();
+				m_sandbox.CopyLexEntryInfoToMonomorphemicWordGlossAndPos(m_sandbox.UsingGuess);
 				m_rootb.Reconstruct(); // Everything changed, more or less.
 				// We've changed properties that the morph manager cares about, but we don't want it
 				// to fire when we fix the selection.

--- a/Src/LexText/Interlinear/SandboxBase.SandboxVc.cs
+++ b/Src/LexText/Interlinear/SandboxBase.SandboxVc.cs
@@ -550,14 +550,6 @@ namespace SIL.FieldWorks.IText
 				vwenv.set_IntProperty((int)FwTextPropType.ktptEditable,
 					(int)FwTextPropVar.ktpvEnum,
 					(int)TptEditable.ktptNotEditable);
-				int wordPosHvo = vwenv.DataAccess.get_ObjectProp(hvo, ktagSbWordPos);
-				if (vwenv.DataAccess.get_IntProp(wordPosHvo, ktagSbNamedObjGuess) == 1)
-				{
-					// Show that the word category is guessed.
-					vwenv.set_IntProperty((int)FwTextPropType.ktptBackColor,
-						(int)FwTextPropVar.ktpvDefault,
-						InterlinVc.MachineGuessColor);
-				}
 				AddOptionalNamedObj(vwenv, hvo, ktagSbWordPos, ktagMissingWordPos,
 					kfragMissingWordPos, ktagWordPosIcon, ws, choiceIndex);
 			}

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1461,7 +1461,7 @@ namespace SIL.FieldWorks.IText
 			bool fHasApprovedWordGloss = HasWordGloss() && (fDirty || fApproved);
 			bool fHasApprovedWordCat = HasWordCat() && (fDirty || fApproved);
 			// conditionally set up the word gloss and POS to correspond to monomorphemic lex morph entry info.
-			SyncMonomorphemicGlossAndPos(!fHasApprovedWordGloss, !fHasApprovedWordCat);
+			SyncMonomorphemicGlossAndPos(UsingGuess && !fHasApprovedWordGloss, UsingGuess && !fHasApprovedWordCat);
 			// Forget we had an existing wordform; otherwise, the program considers
 			// all changes to be editing the wordform, and since it belongs to the
 			// old analysis, the old analysis gets resurrected.

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1412,7 +1412,7 @@ namespace SIL.FieldWorks.IText
 				}
 				if (hasMf)
 					// Wait until all of the morphemes have been loaded (cf. LT-22235).
-					CopyLexEntryInfoToMonomorphemicWordGlossAndPos();
+					CopyLexEntryInfoToMonomorphemicWordGlossAndPos(fGuessing != 0);
 				if (bldrError.Length > 0)
 				{
 					var msg = bldrError.ToString().Trim();
@@ -1454,14 +1454,14 @@ namespace SIL.FieldWorks.IText
 			return fGuessing != 0;
 		}
 
-		internal void CopyLexEntryInfoToMonomorphemicWordGlossAndPos()
+		internal void CopyLexEntryInfoToMonomorphemicWordGlossAndPos(bool usingGuess)
 		{
 			bool fDirty = Caches.DataAccess.IsDirty();
-			bool fApproved = !UsingGuess;
+			bool fApproved = !usingGuess;
 			bool fHasApprovedWordGloss = HasWordGloss() && (fDirty || fApproved);
 			bool fHasApprovedWordCat = HasWordCat() && (fDirty || fApproved);
 			// conditionally set up the word gloss and POS to correspond to monomorphemic lex morph entry info.
-			SyncMonomorphemicGlossAndPos(UsingGuess && !fHasApprovedWordGloss, UsingGuess && !fHasApprovedWordCat);
+			SyncMonomorphemicGlossAndPos(usingGuess && !fHasApprovedWordGloss, usingGuess && !fHasApprovedWordCat);
 			// Forget we had an existing wordform; otherwise, the program considers
 			// all changes to be editing the wordform, and since it belongs to the
 			// old analysis, the old analysis gets resurrected.


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22606.  Don't guess the word cat or word gloss if the analysis was approved by the user since it is confusing to have a mixture of approved and guessed data.  This changes the fix to https://jira.sil.org/browse/LT-22577.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/999)
<!-- Reviewable:end -->
