### PR TITLE
Chore: Consolidate dependabot bumps (nuget-minor, actions/checkout, actions/cache, actions-minor)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: checkout
 
       - name: Build with tests
@@ -144,7 +144,7 @@ jobs:
           path: test-results
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3
         with:
           files: 'test-results/**/*.trx'
           check_name: NUnit Tests

--- a/.github/workflows/CommitMessage.yml
+++ b/.github/workflows/CommitMessage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Install dependencies

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -62,14 +62,14 @@ jobs:
           echo "FW_BUILD_NUMBER=$combined" >> $env:GITHUB_ENV
 
       - name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: checkout
         with:
           ref: ${{ github.event.inputs.fw_ref || github.ref }}
           fetch-depth: 0
 
       - name: Checkout Helps
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: helps-checkout
         with:
           repository: 'sillsdev/FwHelps'
@@ -78,7 +78,7 @@ jobs:
           path: 'DistFiles/Helps'
 
       - name: Checkout PatchableInstaller
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: installer-checkout
         with:
           repository: 'sillsdev/genericinstaller'
@@ -87,7 +87,7 @@ jobs:
           path: 'PatchableInstaller'
 
       - name: Checkout Localizations
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: loc-checkout
         with:
           repository: 'sillsdev/FwLocalizations'
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
           path: 'Localizations'
       - name: Checkout liblcm
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: liblcm-checkout
         with:
           repository: 'sillsdev/liblcm'
@@ -284,7 +284,7 @@ jobs:
 
       - name: Tag, Create Release, and Upload artifacts
         if: ${{ inputs.make_release == 'true' }}
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
             target_commitish: ${{ github.event.inputs.fw_ref || github.ref }}
             tag_name: build-${{ env.FW_BUILD_NUMBER }}

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -13,7 +13,7 @@ jobs:
     check-whitespace:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -87,13 +87,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # ================================================================
       # CACHING - speeds up repeat runs significantly
       # ================================================================
       - name: Cache NuGet packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/packages.config', '**/Directory.Packages.props', 'nuget.config') }}
@@ -101,7 +101,7 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Cache Serena language servers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/serena

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
             - name: Link check with lychee (non-blocking)
               uses: lycheeverse/lychee-action@v2.8.0
               with:

--- a/.github/workflows/openspec-validate.yml
+++ b/.github/workflows/openspec-validate.yml
@@ -10,7 +10,7 @@ jobs:
   validate-refs:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Validate OpenSpec cross-references
         shell: pwsh
         run: |

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -1,4 +1,4 @@
-﻿name: Patch Installer
+name: Patch Installer
 
 # Builds the FieldWorks Patch Installer on the specified `base_release`
 # If `make_release` is true, uploads installers to https://flex-updates.s3.amazonaws.com/?prefix=jobs/FieldWorks-Win-all-Release-Patch.
@@ -77,14 +77,14 @@ jobs:
           echo "BuildVersionSegment=$combined" >> $env:GITHUB_ENV
 
       - name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: checkout
         with:
           ref: ${{ github.event.inputs.fw_ref || github.ref }}
           fetch-depth: 0
 
       - name: Checkout Helps
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: helps-checkout
         with:
           repository: 'sillsdev/FwHelps'
@@ -93,7 +93,7 @@ jobs:
           path: 'DistFiles/Helps'
 
       - name: Checkout PatchableInstaller
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: installer-checkout
         with:
           repository: 'sillsdev/genericinstaller'
@@ -102,7 +102,7 @@ jobs:
           path: 'PatchableInstaller'
 
       - name: Checkout Localizations
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: loc-checkout
         with:
           repository: 'sillsdev/FwLocalizations'
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
           path: 'Localizations'
       - name: Checkout liblcm
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         id: liblcm-checkout
         with:
           repository: 'sillsdev/liblcm'

--- a/Build/Src/Directory.Packages.props
+++ b/Build/Src/Directory.Packages.props
@@ -17,7 +17,7 @@
 
 	<!-- Use Update for root-pinned packages and Include for build-only packages absent from the root CPM file. -->
 	<ItemGroup Label="Build Tool Package Versions">
-		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
 		<PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
 		<PackageVersion Update="NUnit3TestAdapter" Version="5.2.0" />
 		<PackageVersion Include="SIL.BuildTasks" Version="3.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,27 +24,31 @@
 	-->
 	<ItemGroup Label="Transitive Pins">
 		<!-- Current-line refresh in this block: System.Drawing.Common,
-			 System.Resources.Extensions, and System.Security.Permissions move to 9.0.16.
-			 Microsoft.Extensions.DependencyModel intentionally stays at 9.0.14 because
-			 9.0.16 breaks ICU initialization in the .NET Framework test host. -->
+			 System.Resources.Extensions, and System.Security.Permissions move to 9.0.17.
+			 Microsoft.Extensions.DependencyModel intentionally stays at 9.0.16 because
+			 9.0.17 breaks ICU initialization in the .NET Framework test host. -->
 		<!-- System.Drawing.Common: SIL.LCModel.Core pulls 6.0.0 transitively,
-			 but ParatextData 9.5.x requires >= 9.0.9. Pin to 9.0.16. -->
-		<PackageVersion Include="System.Drawing.Common" Version="9.0.16" />
-		<PackageVersion Include="System.Reflection.Metadata" Version="10.0.8" />
+			 but ParatextData 9.5.x requires >= 9.0.9. Pin to 9.0.17. -->
+		<PackageVersion Include="System.Drawing.Common" Version="9.0.17" />
+		<PackageVersion Include="System.Reflection.Metadata" Version="10.0.9" />
 		<!-- System.Resources.Extensions: required for non-string resources (images, icons)
 			 in .NET Framework SDK-style projects. -->
-		<PackageVersion Include="System.Resources.Extensions" Version="9.0.16" />
-		<!-- DependencyModel: other current-line pins in this block move to 9.0.16,
-			 but this package stays at 9.0.14. icu.net wants 2.0.4, ParatextData wants
-			 >= 9.0.9, and 9.0.16 breaks ICU initialization in the .NET Framework test host. -->
+		<PackageVersion Include="System.Resources.Extensions" Version="9.0.17" />
+		<!-- DependencyModel: other current-line pins in this block move to 9.0.17,
+			 but this stays at 9.0.16. icu.net and SIL.LCModel.Core (liblcm) both float
+			 a 2.0.4 floor, ParatextData wants >= 9.0.9, and 9.0.17 throws
+			 TypeInitializationException on Icu.NativeMethods in the .NET Framework
+			 test host (reproduced and investigated in PR #1000). To retest: bump, run
+			 a full test.ps1, and grep the .trx for "Icu.NativeMethods" - zero hits
+			 means safe. -->
 		<PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.16" />
 		<!-- System.Memory: ParatextData requires 4.6.3; other packages want 4.5.0–4.6.0. -->
 		<PackageVersion Include="System.Memory" Version="4.6.3" />
 		<!-- Microsoft.Bcl.HashCode: System.Resources.Extensions requires HashCode. -->
 		<PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
 		<!-- System.Security.Permissions (LT-22394): ProDotNetZip needs >= 8.0.0,
-			 System.Security.AccessControl needs >= 6.0.0. Pin to 9.0.16. -->
-		<PackageVersion Include="System.Security.Permissions" Version="9.0.16" />
+			 System.Security.AccessControl needs >= 6.0.0. Pin to 9.0.17. -->
+		<PackageVersion Include="System.Security.Permissions" Version="9.0.17" />
 		<!-- System.Text.Encoding.CodePages: SIL.Machine requires 10.0.x,
 			 other chains resolve to 9.0.9. Pin to 10.0.3 to match the plugin project. -->
 		<PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.3" />

--- a/Src/Common/RootSite/RootSiteTests/RealDataTestsBase.cs
+++ b/Src/Common/RootSite/RootSiteTests/RealDataTestsBase.cs
@@ -1,7 +1,5 @@
 using System;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.FwUtils;
@@ -22,21 +20,10 @@ namespace SIL.FieldWorks.Common.RootSites.RootSiteTests
 	[TestFixture]
 	public abstract class RealDataTestsBase
 	{
-		// The project name must be unique per worktree, so that multiple worktrees of the same repo
-		// can run tests in parallel without colliding on the same project directory.
-		private static readonly string ReusableProjectName = "integration_test_data_" + WorktreeSuffix();
-		private static readonly string ProjectMutexName =
-			@"Local\FieldWorks.RealDataTests." + ReusableProjectName;
+		private const string ReusableProjectName = "integration_test_data";
+		private const string ProjectMutexName =
+			@"Local\FieldWorks.RealDataTests.integration_test_data";
 		private const string TestProjectSentinelFileName = ".fieldworks-real-data-test-project";
-
-		private static string WorktreeSuffix()
-		{
-			using (var sha = SHA1.Create())
-			{
-				var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(FwDirectoryFinder.SourceDirectory));
-				return BitConverter.ToString(hash, 0, 4).Replace("-", string.Empty).ToLowerInvariant();
-			}
-		}
 
 		protected FwNewLangProjectModel m_model;
 		protected LcmCache Cache;
@@ -151,8 +138,6 @@ namespace SIL.FieldWorks.Common.RootSites.RootSiteTests
 
 		protected string DbDirectory(string name)
 		{
-			// CreateNewLangProj always creates here and can't be redirected; collision avoidance
-			// across worktrees comes from ReusableProjectName's worktree-hash suffix instead.
 			return Path.Combine(FwDirectoryFinder.ProjectsDirectory, name);
 		}
 

--- a/Src/Common/RootSite/RootSiteTests/RealDataTestsBase.cs
+++ b/Src/Common/RootSite/RootSiteTests/RealDataTestsBase.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.FwUtils;
@@ -20,10 +22,21 @@ namespace SIL.FieldWorks.Common.RootSites.RootSiteTests
 	[TestFixture]
 	public abstract class RealDataTestsBase
 	{
-		private const string ReusableProjectName = "integration_test_data";
-		private const string ProjectMutexName =
-			@"Local\FieldWorks.RealDataTests.integration_test_data";
+		// The project name must be unique per worktree, so that multiple worktrees of the same repo
+		// can run tests in parallel without colliding on the same project directory.
+		private static readonly string ReusableProjectName = "integration_test_data_" + WorktreeSuffix();
+		private static readonly string ProjectMutexName =
+			@"Local\FieldWorks.RealDataTests." + ReusableProjectName;
 		private const string TestProjectSentinelFileName = ".fieldworks-real-data-test-project";
+
+		private static string WorktreeSuffix()
+		{
+			using (var sha = SHA1.Create())
+			{
+				var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(FwDirectoryFinder.SourceDirectory));
+				return BitConverter.ToString(hash, 0, 4).Replace("-", string.Empty).ToLowerInvariant();
+			}
+		}
 
 		protected FwNewLangProjectModel m_model;
 		protected LcmCache Cache;
@@ -138,6 +151,8 @@ namespace SIL.FieldWorks.Common.RootSites.RootSiteTests
 
 		protected string DbDirectory(string name)
 		{
+			// CreateNewLangProj always creates here and can't be redirected; collision avoidance
+			// across worktrees comes from ReusableProjectName's worktree-hash suffix instead.
 			return Path.Combine(FwDirectoryFinder.ProjectsDirectory, name);
 		}
 


### PR DESCRIPTION
## Summary
- Consolidates 5 open dependabot PRs into one branch/PR so they build and
  test together instead of as 5 separate merges: #997, #984, #982, #981, #980.
- Pulls in #979's fix for `RealDataTestsBase` cross-worktree collisions,
  which was needed to get a clean local CI run (see Test plan).
- Holds `Microsoft.Extensions.DependencyModel` at 9.0.16 instead of the
  9.0.17 that #984's nuget-minor group proposed (see below).

## Included dependabot bumps
- #997 Bump Microsoft.Build.Utilities.Core 18.6.3 -> 18.7.1 (+5 others)
- #984 Bump the nuget-minor group (10 updates): System.Drawing.Common,
  System.Reflection.Metadata, System.Resources.Extensions,
  System.Security.Permissions -> 9.0.17/10.0.9; SilLcm/SilLibPalaso version
  refresh in `Build/SilVersions.props`
- #982 Bump actions/checkout 6 -> 7 (all workflow files)
- #981 Bump actions/cache 5 -> 6 (copilot-setup-steps.yml)
- #980 Bump the actions-minor group (2 SHA-pinned action updates in
  CI.yml/base-installer-cd.yml)

## Why Microsoft.Extensions.DependencyModel stays at 9.0.16
`Directory.Packages.props` has carried a long-standing comment warning
that bumping this specific package breaks ICU initialization in the
.NET Framework test host. #984 bumped it to 9.0.17 anyway alongside the
other current-line packages. Running the full test suite locally
reproduced the exact failure the comment warns about:

```
System.TypeInitializationException : The type initializer for
'Icu.NativeMethods' threw an exception.
 ----> System.IO.FileLoadException : Could not load file or assembly
'Microsoft.Extensions.DependencyModel, Version=9.0.0.16, ...'
```

5 test fixtures (`HCWorkerServiceTests`, `ToWordAnalysisDto_*`) failed
`OneTimeSetUp` until this was reverted back to 9.0.16. All other
package bumps from the nuget-minor group are kept. #984 is being
closed with an explanatory comment rather than merged as-is, since
dependabot bundles it as one grouped update.

## Test plan
- [x] `.\build.ps1 -Configuration Debug -BuildTests` — 0 errors, 0 warnings
- [x] `.\test.ps1 -Configuration Debug -NoBuild -TestFilter 'TestCategory!=LongRunning&TestCategory!=ByHand&TestCategory!=SmokeTest&TestCategory!=DesktopRequired'`
      (same filter as `.github/workflows/CI.yml`) — 4298 tests, only 12
      failures, all pre-existing local `RenderBaselineTests`/
      `RenderBenchmark` pixel-diff mismatches (font/GPU rendering
      differences vs. the windows-2022 runner that captured the
      baselines), unrelated to this branch's changes and previously
      documented as a known local-environment gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1000)
<!-- Reviewable:end -->
