### PR TITLE
Fix case of FlexBridge 4.3.0 download URL

### DIFF
--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -610,7 +610,7 @@
 		<!-- VisualC++ 14.1 runtime (VS 2015-2019) -->
 		<!-- FLEx Bridge -->
 		<DownloadFile
-			Address="https://software.sil.org/downloads/r/fieldworks/FLExBridge_Offline_4.3.0.exe"
+			Address="https://software.sil.org/downloads/r/fieldworks/FlexBridge_Offline_4.3.0.exe"
 			LocalFilename="FLExBridge_Offline.exe"
 			Condition="!Exists('$(WixLibsDir)/FLExBridge_Offline.exe')"
 			DownloadsDir="$(WixLibsDir)"

--- a/Build/Installer.targets
+++ b/Build/Installer.targets
@@ -239,7 +239,7 @@
 	/>
 	<!-- FLEx Bridge -->
 	<DownloadFile
-	  Address="https://software.sil.org/downloads/r/fieldworks/FLExBridge_Offline_4.3.0.exe"
+	  Address="https://software.sil.org/downloads/r/fieldworks/FlexBridge_Offline_4.3.0.exe"
 	  DownloadsDir="$(WixLibsDir)"
 	  LocalFilename="FLExBridge_Offline.exe"
 	  Condition="!Exists('$(WixLibsDir)\FLExBridge_Offline.exe')"


### PR DESCRIPTION
The uploaded file is `FlexBridge_Offline_4.3.0.exe` (200) but the pin requests `FLExBridge_Offline_4.3.0.exe` (404, case-sensitive server). Failed Base Installer run: [28979542709](https://github.com/sillsdev/FieldWorks/actions/runs/28979542709).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1001)
<!-- Reviewable:end -->
