### PR TITLE
LT-22607 TonePars use XAmpleParser code for result processing

### DIFF
--- a/Src/LexText/ParserCore/XAmpleParser.cs
+++ b/Src/LexText/ParserCore/XAmpleParser.cs
@@ -68,7 +68,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		/// </summary>
 		/// <param name="originalName">The original name to be converted</param>
 		/// <returns>Converted name</returns>
-		internal static string ConvertNameToUseAnsiCharacters(string originalName)
+		public static string ConvertNameToUseAnsiCharacters(string originalName)
 		{
 			var sb = new StringBuilder();
 			char[] letters = originalName.ToCharArray();
@@ -168,13 +168,13 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		{
 			CheckDisposed();
 
-			var results = new StringBuilder(m_xample.ParseWord(word));
-			ParseResult result = ProcessParseResults(ref results);
+			var results = m_xample.ParseWord(word);
+			ParseResult result = ProcessParseResults(results, m_cache);
 
 			return result;
 		}
 
-		public ParseResult ProcessParseResults(ref StringBuilder results)
+		public static ParseResult ProcessParseResults(String results, LcmCache cache)
 		{
 			results = results.Replace("DB_REF_HERE", "'0'");
 			results = results.Replace("<...>", "[...]");
@@ -202,7 +202,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			}
 
 			ParseResult result;
-			using (new WorkerThreadReadHelper(m_cache.ServiceLocator.GetInstance<IWorkerThreadReadHandler>()))
+			using (new WorkerThreadReadHelper(cache.ServiceLocator.GetInstance<IWorkerThreadReadHandler>()))
 			{
 				var analyses = new List<ParseAnalysis>();
 				foreach (XElement analysisElem in wordformElem.Descendants("WfiAnalysis"))
@@ -212,7 +212,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					foreach (XElement morphElem in analysisElem.Descendants("Morph"))
 					{
 						ParseMorph morph;
-						if (!TryCreateParseMorph(m_cache, morphElem, out morph))
+						if (!TryCreateParseMorph(cache, morphElem, out morph))
 						{
 							skip = true;
 							break;

--- a/Src/LexText/ParserCore/XAmpleParser.cs
+++ b/Src/LexText/ParserCore/XAmpleParser.cs
@@ -169,6 +169,13 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			CheckDisposed();
 
 			var results = new StringBuilder(m_xample.ParseWord(word));
+			ParseResult result = ProcessParseResults(ref results);
+
+			return result;
+		}
+
+		public ParseResult ProcessParseResults(ref StringBuilder results)
+		{
 			results = results.Replace("DB_REF_HERE", "'0'");
 			results = results.Replace("<...>", "[...]");
 			var wordformElem = XElement.Parse(results.ToString());

--- a/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
+++ b/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019 SIL International
+// Copyright (c) 2019 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using PtxUtils;
 using SIL.DisambiguateInFLExDB;
 using SIL.FieldWorks.Common.FwUtils;
+using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
 using SIL.ToneParsFLEx;
 using System;
@@ -117,7 +118,8 @@ namespace SIL.DisambiguateInFLExDBTests
 			string toneParsRuleFile = Path.Combine(TestDataDir, "KvgTP.ctl");
 			string intxCtlFile = Path.Combine(TestDataDir, "KVGintx.ctl");
 			string inputFile = Path.Combine(TestDataDir, "KVGinput.txt");
-			invoker = new ToneParsInvoker(toneParsRuleFile, intxCtlFile, inputFile, '+', MyCache);
+			XAmpleParser xampleParser = new XAmpleParser(MyCache, null);
+			invoker = new ToneParsInvoker(toneParsRuleFile, intxCtlFile, inputFile, '+', MyCache, xampleParser);
 			CreateExpectedFileStrings();
 			File.Copy(Path.Combine(TestDataDir, "ToneParsInvoker.ana"), Path.Combine(Path.GetTempPath(), "ToneParsInvoker.ana"), true);
 			ToneParsInvokerOptions.Instance.VerifyInformation = true;

--- a/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
+++ b/Src/Utilities/pcpatrflex/DisambiguateInFLExDB/DisambiguateInFLExDBTests/ToneParsInvokerTests.cs
@@ -118,8 +118,7 @@ namespace SIL.DisambiguateInFLExDBTests
 			string toneParsRuleFile = Path.Combine(TestDataDir, "KvgTP.ctl");
 			string intxCtlFile = Path.Combine(TestDataDir, "KVGintx.ctl");
 			string inputFile = Path.Combine(TestDataDir, "KVGinput.txt");
-			XAmpleParser xampleParser = new XAmpleParser(MyCache, null);
-			invoker = new ToneParsInvoker(toneParsRuleFile, intxCtlFile, inputFile, '+', MyCache, xampleParser);
+			invoker = new ToneParsInvoker(toneParsRuleFile, intxCtlFile, inputFile, '+', MyCache);
 			CreateExpectedFileStrings();
 			File.Copy(Path.Combine(TestDataDir, "ToneParsInvoker.ana"), Path.Combine(Path.GetTempPath(), "ToneParsInvoker.ana"), true);
 			ToneParsInvokerOptions.Instance.VerifyInformation = true;

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -481,8 +481,7 @@ namespace SIL.ToneParsFLEx
 				tbIntxCtlFile.Text,
 				inputFile,
 				GetDecompSeparationCharacter(),
-				Cache,
-				m_XAmpleParser
+				Cache
 			);
 			invoker.Extractor = Extractor;
 			invoker.ParsingStatus = lblParsingStatus;
@@ -787,8 +786,7 @@ namespace SIL.ToneParsFLEx
 				tbIntxCtlFile.Text,
 				"",
 				' ',
-				Cache,
-				m_XAmpleParser
+				Cache
 			);
 			if (File.Exists(invoker.ToneParsLogFile))
 			{

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -481,7 +481,8 @@ namespace SIL.ToneParsFLEx
 				tbIntxCtlFile.Text,
 				inputFile,
 				GetDecompSeparationCharacter(),
-				Cache
+				Cache,
+				m_XAmpleParser
 			);
 			invoker.Extractor = Extractor;
 			invoker.ParsingStatus = lblParsingStatus;
@@ -786,7 +787,8 @@ namespace SIL.ToneParsFLEx
 				tbIntxCtlFile.Text,
 				"",
 				' ',
-				Cache
+				Cache,
+				m_XAmpleParser
 			);
 			if (File.Exists(invoker.ToneParsLogFile))
 			{

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
@@ -56,13 +56,15 @@ namespace SIL.ToneParsFLEx
 
 		public const string kTPLexicon = "TPlex.txt";
 		public FLExDBExtractor Extractor { get; set; }
+		protected XAmpleParser XAmpleParser { get; set; }
 
 		public ToneParsInvoker(
 			string toneParsRuleFile,
 			string intxCtlFile,
 			string inputFile,
 			char decomp,
-			LcmCache cache
+			LcmCache cache,
+			XAmpleParser xAmpleParser
 		)
 		{
 			ToneParsRuleFile = toneParsRuleFile;
@@ -73,6 +75,11 @@ namespace SIL.ToneParsFLEx
 			DatabaseName = ConvertNameToUseAnsiCharacters(cache.ProjectId.Name);
 			InitFileNames();
 			Queue = new IdleQueue { IsPaused = true };
+			XAmpleParser = xAmpleParser;
+			if ( XAmpleParser == null )
+			{
+				XAmpleParser = new XAmpleParser(Cache, null);
+			}
 		}
 
 		private void InitFileNames()
@@ -684,9 +691,8 @@ namespace SIL.ToneParsFLEx
 				IWfiWordform thiswf = GetWordformFromString(wordform);
 				if (thiswf != null)
 				{
-					var parseResult = ConvertParserFilerResultXmlToParseResult(
-						ParserFilerXMLString
-					);
+					var sb = new StringBuilder(ParserFilerXMLString);
+					var parseResult = XAmpleParser.ProcessParseResults(ref sb);
 					m_parseFiler.ProcessParse(thiswf, ParserPriority.Low, parseResult);
 				}
 				i++;
@@ -724,171 +730,5 @@ namespace SIL.ToneParsFLEx
 				task.Delegate(task.Parameter);
 			idleQueue.Clear();
 		}
-
-		//-----------------------
-		// ConvertParserFilerResultXmlToParseResult(), TryCreateParseMorph(), and ProcessMsaHvo() are from XAmpleParser.cs
-		// (I renamed ParseWord() to ConvertParserFilerResultXmlToParseResult() to avoid confusion.)
-		// Ideally, we'd expose them from XAmpleParser.cs
-		public ParseResult ConvertParserFilerResultXmlToParseResult(string results)
-		{
-			//TODO: fix! CheckDisposed();
-			results = results.Replace("DB_REF_HERE", "'0'");
-			results = results.Replace("<...>", "[...]");
-			var wordformElem = XElement.Parse(results.ToString());
-			string errorMessage = null;
-			var exceptionElem = wordformElem.Element("Exception");
-			if (exceptionElem != null)
-			{
-				var totalAnalysesValue = (string)exceptionElem.Attribute("totalAnalyses");
-				switch ((string)exceptionElem.Attribute("code"))
-				{
-					case "ReachedMaxAnalyses":
-						errorMessage = String.Format(
-							"Maximum permitted analyses ({0}) reached." /*ParserCoreStrings.ksReachedMaxAnalysesAllowed*/
-							,
-							totalAnalysesValue
-						);
-						break;
-					case "ReachedMaxBufferSize":
-						errorMessage = String.Format(
-							"Maximum internal buffer size ({0}) reached." /*ParserCoreStrings.ksReachedMaxInternalBufferSize*/
-							,
-							totalAnalysesValue
-						);
-						break;
-				}
-			}
-			else
-			{
-				errorMessage = (string)wordformElem.Element("Error");
-			}
-
-			ParseResult result;
-			using (
-				new WorkerThreadReadHelper(
-					Cache.ServiceLocator.GetInstance<IWorkerThreadReadHandler>()
-				)
-			)
-			{
-				var analyses = new List<ParseAnalysis>();
-				foreach (XElement analysisElem in wordformElem.Descendants("WfiAnalysis"))
-				{
-					var morphs = new List<ParseMorph>();
-					bool skip = false;
-					foreach (XElement morphElem in analysisElem.Descendants("Morph"))
-					{
-						ParseMorph morph;
-						if (!TryCreateParseMorph(Cache, morphElem, out morph))
-						{
-							skip = true;
-							break;
-						}
-						if (morph != null)
-							morphs.Add(morph);
-					}
-
-					if (!skip && morphs.Count > 0)
-						analyses.Add(new ParseAnalysis(morphs));
-				}
-				result = new ParseResult(analyses, errorMessage);
-			}
-
-			return result;
-		}
-
-		private static bool TryCreateParseMorph(
-			LcmCache cache,
-			XElement morphElem,
-			out ParseMorph morph
-		)
-		{
-			XElement formElement = morphElem.Element("MoForm");
-			Debug.Assert(formElement != null);
-			var formHvo = (string)formElement.Attribute("DbRef");
-
-			XElement msiElement = morphElem.Element("MSI");
-			Debug.Assert(msiElement != null);
-			var msaHvo = (string)msiElement.Attribute("DbRef");
-
-			// Normally, the hvo for MoForm is a MoForm and the hvo for MSI is an MSA
-			// There are four exceptions, though, when an irregularly inflected form is involved:
-			// 1. <MoForm DbRef="x"... and x is an hvo for a LexEntryInflType.
-			//       This is one of the null allomorphs we create when building the
-			//       input for the parser in order to still get the Word Grammar to have something in any
-			//       required slots in affix templates.  The parser filer can ignore these.
-			// 2. <MSI DbRef="y"... and y is an hvo for a LexEntryInflType.
-			//       This is one of the null allomorphs we create when building the
-			//       input for the parser in order to still get the Word Grammar to have something in any
-			//       required slots in affix templates.  The parser filer can ignore these.
-			// 3. <MSI DbRef="y"... and y is an hvo for a LexEntry.
-			//       The LexEntry is a variant form for the first set of LexEntryRefs.
-			// 4. <MSI DbRef="y"... and y is an hvo for a LexEntry followed by a period and an index digit.
-			//       The LexEntry is a variant form and the (non-zero) index indicates
-			//       which set of LexEntryRefs it is for.
-			ICmObject objForm;
-			if (String.IsNullOrEmpty(formHvo) ||
-				!cache.ServiceLocator
-					.GetInstance<ICmObjectRepository>()
-					.TryGetObject(int.Parse(formHvo), out objForm)
-			)
-			{
-				morph = null;
-				return false;
-			}
-			var form = objForm as IMoForm;
-			if (form == null)
-			{
-				morph = null;
-				return true;
-			}
-
-			// Irregulary inflected forms can have a combination MSA hvo: the LexEntry hvo, a period, and an index to the LexEntryRef
-			Tuple<int, int> msaTuple = ProcessMsaHvo(msaHvo);
-			ICmObject objMsa;
-			if (
-				!cache.ServiceLocator
-					.GetInstance<ICmObjectRepository>()
-					.TryGetObject(msaTuple.Item1, out objMsa)
-			)
-			{
-				morph = null;
-				return false;
-			}
-			var msa = objMsa as IMoMorphSynAnalysis;
-			if (msa != null)
-			{
-				morph = new ParseMorph(form, msa);
-				return true;
-			}
-
-			var msaAsLexEntry = objMsa as ILexEntry;
-			if (msaAsLexEntry != null)
-			{
-				// is an irregularly inflected form
-				// get the MoStemMsa of its variant
-				if (msaAsLexEntry.EntryRefsOS.Count > 0)
-				{
-					ILexEntryRef lexEntryRef = msaAsLexEntry.EntryRefsOS[msaTuple.Item2];
-					ILexSense sense = MorphServices.GetMainOrFirstSenseOfVariant(lexEntryRef);
-					var inflType = lexEntryRef.VariantEntryTypesRS[0] as ILexEntryInflType;
-					morph = new ParseMorph(form, sense.MorphoSyntaxAnalysisRA, inflType);
-					return true;
-				}
-			}
-
-			// if it is anything else, we ignore it
-			morph = null;
-			return true;
-		}
-
-		private static Tuple<int, int> ProcessMsaHvo(string msaHvo)
-		{
-			string[] msaHvoParts = msaHvo.Split('.');
-			return Tuple.Create(
-				int.Parse(msaHvoParts[0]),
-				msaHvoParts.Length == 2 ? int.Parse(msaHvoParts[1]) : 0
-			);
-		}
-		// -----------------------
 	}
 }

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
@@ -19,7 +19,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Windows.Forms;
-using System.Xml.Linq;
 using System.Xml;
 using System;
 using XAmpleManagedWrapper;
@@ -56,15 +55,13 @@ namespace SIL.ToneParsFLEx
 
 		public const string kTPLexicon = "TPlex.txt";
 		public FLExDBExtractor Extractor { get; set; }
-		protected XAmpleParser XAmpleParser { get; set; }
 
 		public ToneParsInvoker(
 			string toneParsRuleFile,
 			string intxCtlFile,
 			string inputFile,
 			char decomp,
-			LcmCache cache,
-			XAmpleParser xAmpleParser
+			LcmCache cache
 		)
 		{
 			ToneParsRuleFile = toneParsRuleFile;
@@ -72,14 +69,9 @@ namespace SIL.ToneParsFLEx
 			InputFile = inputFile;
 			DecompSeparationChar = decomp;
 			Cache = cache;
-			DatabaseName = ConvertNameToUseAnsiCharacters(cache.ProjectId.Name);
+			DatabaseName = XAmpleParser.ConvertNameToUseAnsiCharacters(cache.ProjectId.Name);
 			InitFileNames();
 			Queue = new IdleQueue { IsPaused = true };
-			XAmpleParser = xAmpleParser;
-			if ( XAmpleParser == null )
-			{
-				XAmpleParser = new XAmpleParser(Cache, null);
-			}
 		}
 
 		private void InitFileNames()
@@ -89,33 +81,6 @@ namespace SIL.ToneParsFLEx
 			ToneParsBatchFile = Path.Combine(Path.GetTempPath(), "ToneParsFLEx.bat");
 			ToneParsCmdFile = Path.Combine(Path.GetTempPath(), "ToneParsCmd.cmd");
 			ToneParsLogFile = Path.Combine(Path.GetTempPath(), "ToneParsInvoker.log");
-		}
-
-		// following borrowed from SIL.FieldWorks.WordWorks.Parser (ParserCore.dll)
-		/// <summary>
-		/// Convert any characters in the name which are higher than 0x00FF to hex.
-		/// Neither XAmple nor PC-PATR can read a file name containing letters above 0x00FF.
-		/// </summary>
-		/// <param name="originalName">The original name to be converted</param>
-		/// <returns>Converted name</returns>
-		internal static string ConvertNameToUseAnsiCharacters(string originalName)
-		{
-			var sb = new StringBuilder();
-			char[] letters = originalName.ToCharArray();
-			foreach (var letter in letters)
-			{
-				int value = Convert.ToInt32(letter);
-				if (value > 255)
-				{
-					string hex = value.ToString("X4");
-					sb.Append(hex);
-				}
-				else
-				{
-					sb.Append(letter);
-				}
-			}
-			return sb.ToString();
 		}
 
 		private void CreateToneParsBatchFile()
@@ -691,8 +656,7 @@ namespace SIL.ToneParsFLEx
 				IWfiWordform thiswf = GetWordformFromString(wordform);
 				if (thiswf != null)
 				{
-					var sb = new StringBuilder(ParserFilerXMLString);
-					var parseResult = XAmpleParser.ProcessParseResults(ref sb);
+					var parseResult = XAmpleParser.ProcessParseResults(ParserFilerXMLString, Cache);
 					m_parseFiler.ProcessParse(thiswf, ParserPriority.Low, parseResult);
 				}
 				i++;


### PR DESCRIPTION
Now that the TonePars utility is part of FLEx, we can have it use the same code that XAmple does when processing its result.

1. This change took the result processing of XAmpleParser and put it in a new public method.
2. ToneParsInvoker now gets an instance of XAmpleParser (or creates it, if needed).
3. The change removes the duplicated code from ToneParsInvoker.
4. ToneParsFLExForm passes in an instance of XAmpleParser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1002)
<!-- Reviewable:end -->
