### PR TITLE
LT-22610: Fix randomly missing WS labels — RefreshDisplay must always reconstruct

### DIFF
--- a/Src/Common/SimpleRootSite/SimpleRootSite.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSite.cs
@@ -2533,13 +2533,8 @@ namespace SIL.FieldWorks.Common.RootSites
 				return false;
 			}
 
-			// Always reconstruct here, even if the root box reports NeedsReconstruct == false.
-			// That flag only tracks mutations the root box itself can see (PropChanged,
-			// SetRootObjects, OnStylesheetChange). View constructors also read state the
-			// root box cannot see — e.g. the writing-system lists behind the labels in
-			// LabeledMultiStringView — and RefreshDisplay is the only way such changes
-			// reach the screen. Skipping based on NeedsReconstruct left stale writing
-			// system rows/labels in the Lexicon Edit detail pane (LT-22610).
+			// Always reconstruct: view constructors read state the root box can't see
+			// (e.g. WS lists), so skipping on NeedsReconstruct left stale views (LT-22610).
 
 			// Rebuild the display... the drastic way.
 			SelectionRestorer restorer = CreateSelectionRestorer();

--- a/Src/Common/SimpleRootSite/SimpleRootSite.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSite.cs
@@ -252,7 +252,6 @@ namespace SIL.FieldWorks.Common.RootSites
 		/// <summary>True if we are waiting to do a refresh on the view (will be done when the view
 		/// becomes visible); false otherwise</summary>
 		protected bool m_fRefreshPending = false;
-		private bool m_fForceNextRefreshDisplay;
 		private RefreshPhase m_refreshPhase;
 		private bool m_fRefreshReplayRequested;
 
@@ -1054,7 +1053,6 @@ namespace SIL.FieldWorks.Common.RootSites
 			if (m_rootb?.Site == null)
 				return;
 
-			m_fForceNextRefreshDisplay = true;
 			if (!Visible || FindForm() == null)
 			{
 				m_fRefreshPending = true;
@@ -2535,17 +2533,13 @@ namespace SIL.FieldWorks.Common.RootSites
 				return false;
 			}
 
-			// PATH-L5: Skip the expensive selection save/restore and drawing
-			// suspension when the VwRootBox reports no pending changes.
-			// The root box's NeedsReconstruct flag is set by PropChanged,
-			// OnStylesheetChange, and other mutation paths. When false,
-			// Reconstruct() would be a no-op (PATH-R1), so we can avoid
-			// the managed overhead entirely.
-			if (!ShouldReconstructDisplay())
-			{
-				m_fRefreshPending = false;
-				return false;
-			}
+			// Always reconstruct here, even if the root box reports NeedsReconstruct == false.
+			// That flag only tracks mutations the root box itself can see (PropChanged,
+			// SetRootObjects, OnStylesheetChange). View constructors also read state the
+			// root box cannot see — e.g. the writing-system lists behind the labels in
+			// LabeledMultiStringView — and RefreshDisplay is the only way such changes
+			// reach the screen. Skipping based on NeedsReconstruct left stale writing
+			// system rows/labels in the Lexicon Edit detail pane (LT-22610).
 
 			// Rebuild the display... the drastic way.
 			SelectionRestorer restorer = CreateSelectionRestorer();
@@ -2560,7 +2554,6 @@ namespace SIL.FieldWorks.Common.RootSites
 				{
 					m_rootb.Reconstruct();
 					m_fRefreshPending = false;
-					m_fForceNextRefreshDisplay = false;
 				}
 				if (reconstructStopwatch != null)
 				{
@@ -2603,11 +2596,6 @@ namespace SIL.FieldWorks.Common.RootSites
 				else
 					m_fRefreshPending = true;
 			});
-		}
-
-		private bool ShouldReconstructDisplay()
-		{
-			return m_fForceNextRefreshDisplay || m_rootb.NeedsReconstruct;
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayNeedsReconstruct.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayNeedsReconstruct.cs
@@ -72,9 +72,8 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		[Test]
 		public void RefreshDisplay_Reconstructs_EvenWhenRootBoxReportsNoPendingChanges()
 		{
-			// LT-22610: view constructors read state the root box cannot see (e.g. the
-			// writing-system lists behind the labels in LabeledMultiStringView), so
-			// RefreshDisplay must always reconstruct, even when NeedsReconstruct is false.
+			// LT-22610: view constructors read state the root box can't see, so
+			// RefreshDisplay must reconstruct even when NeedsReconstruct is false.
 			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
 			m_rootbMock.Setup(rb => rb.Reconstruct());
 

--- a/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayNeedsReconstruct.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayNeedsReconstruct.cs
@@ -70,13 +70,17 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		}
 
 		[Test]
-		public void RefreshDisplay_SkipsReconstruct_WhenRootBoxDoesNotNeedReconstruct()
+		public void RefreshDisplay_Reconstructs_EvenWhenRootBoxReportsNoPendingChanges()
 		{
+			// LT-22610: view constructors read state the root box cannot see (e.g. the
+			// writing-system lists behind the labels in LabeledMultiStringView), so
+			// RefreshDisplay must always reconstruct, even when NeedsReconstruct is false.
 			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
+			m_rootbMock.Setup(rb => rb.Reconstruct());
 
 			Assert.That(m_site.RefreshDisplay(), Is.False);
 			Assert.That(m_site.RefreshPending, Is.False);
-			m_rootbMock.Verify(rb => rb.Reconstruct(), Times.Never);
+			m_rootbMock.Verify(rb => rb.Reconstruct(), Times.Once);
 		}
 
 		[Test]

--- a/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayReconstruct.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSiteTests/SimpleRootSiteTests_RefreshDisplayReconstruct.cs
@@ -36,7 +36,7 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 	}
 
 	[TestFixture]
-	public class RefreshDisplayNeedsReconstructTests
+	public class RefreshDisplayReconstructTests
 	{
 		private RefreshDisplayDummyRootSite m_site;
 		private Mock<IVwRootBox> m_rootbMock;
@@ -70,11 +70,10 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		}
 
 		[Test]
-		public void RefreshDisplay_Reconstructs_EvenWhenRootBoxReportsNoPendingChanges()
+		public void RefreshDisplay_AlwaysReconstructs()
 		{
 			// LT-22610: view constructors read state the root box can't see, so
-			// RefreshDisplay must reconstruct even when NeedsReconstruct is false.
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
+			// RefreshDisplay must always reconstruct, regardless of NeedsReconstruct.
 			m_rootbMock.Setup(rb => rb.Reconstruct());
 
 			Assert.That(m_site.RefreshDisplay(), Is.False);
@@ -83,20 +82,8 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		}
 
 		[Test]
-		public void RefreshDisplay_Reconstructs_WhenRootBoxNeedsReconstruct()
+		public void NotifyDataAccessSemanticsChanged_Reconstructs()
 		{
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(true);
-			m_rootbMock.Setup(rb => rb.Reconstruct());
-
-			Assert.That(m_site.RefreshDisplay(), Is.False);
-			Assert.That(m_site.RefreshPending, Is.False);
-			m_rootbMock.Verify(rb => rb.Reconstruct(), Times.Once);
-		}
-
-		[Test]
-		public void NotifyDataAccessSemanticsChanged_Reconstructs_WhenRootBoxDoesNotNeedReconstruct()
-		{
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
 			m_rootbMock.Setup(rb => rb.Reconstruct());
 
 			m_site.NotifyDataAccessSemanticsChangedForTest();
@@ -108,7 +95,6 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		[Test]
 		public void NotifyDataAccessSemanticsChanged_DefersUntilVisible()
 		{
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
 			m_rootbMock.Setup(rb => rb.Reconstruct());
 			m_site.Visible = false;
 
@@ -128,7 +114,6 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		{
 			var replacementDataAccess = Mock.Of<ISilDataAccess>();
 			m_rootbMock.SetupSet(rb => rb.DataAccess = replacementDataAccess);
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
 
 			m_site.SetRootBoxDataAccessForTest(replacementDataAccess);
 
@@ -142,7 +127,6 @@ namespace SIL.FieldWorks.Common.RootSites.SimpleRootSiteTests
 		{
 			var replacementDataAccess = Mock.Of<ISilDataAccess>();
 			m_rootbMock.SetupSet(rb => rb.DataAccess = replacementDataAccess);
-			m_rootbMock.SetupGet(rb => rb.NeedsReconstruct).Returns(false);
 			m_rootbMock.Setup(rb => rb.Reconstruct());
 
 			m_site.SetRootBoxDataAccessAndRefreshForTest(replacementDataAccess);

--- a/openspec/changes/render-speedup-benchmark/refresh-dirty-flag-audit.md
+++ b/openspec/changes/render-speedup-benchmark/refresh-dirty-flag-audit.md
@@ -2,6 +2,14 @@
 
 Date: 2026-03-10
 
+> **Superseded 2026-07-10 (LT-22610, PR #1006):** the managed PATH-L5 gate
+> described below (`SimpleRootSite.RefreshDisplay()` skipping on
+> `NeedsReconstruct`) was removed — it missed managed-only view-constructor
+> state (e.g. writing-system display lists) invisible to the native flag,
+> causing stale views. `RefreshDisplay()` now always reconstructs. The native
+> PATH-R1 guard and dirtying paths documented here are unaffected and still
+> accurate.
+
 ## Purpose
 
 This document audits the parts of FieldWorks that can require a visual refresh after the PATH-L5 / PATH-R1 optimization work.
@@ -15,7 +23,7 @@ The recent `SetRootObjects()` fix in [Src/views/VwRootBox.cpp](../../../../Src/v
 ## Executive Summary
 
 - The native source of truth for whether a box tree needs rebuilding is `VwRootBox::m_fNeedsReconstruct` in [Src/views/VwRootBox.h](../../../../Src/views/VwRootBox.h).
-- The managed fast path is [SimpleRootSite.RefreshDisplay()](../../../../Src/Common/SimpleRootSite/SimpleRootSite.cs), which now skips managed overhead when `m_rootb.NeedsReconstruct == false`.
+- The managed fast path was [SimpleRootSite.RefreshDisplay()](../../../../Src/Common/SimpleRootSite/SimpleRootSite.cs) skipping managed overhead when `m_rootb.NeedsReconstruct == false`; this gate was removed in LT-22610 (see superseded note above) and `RefreshDisplay()` now always reconstructs.
 - The native fast path is `VwRootBox::Reconstruct()`, which now returns early when `m_fConstructed && !m_fNeedsReconstruct`.
 - The architecture is correct only if every semantic mutation that can stale the view either:
   - sets `m_fNeedsReconstruct = true` directly in native code, or
@@ -50,11 +58,11 @@ Confirmed native clearing paths:
 
 ### Managed refresh gate
 
-[SimpleRootSite.RefreshDisplay()](../../../../Src/Common/SimpleRootSite/SimpleRootSite.cs) does this:
+[SimpleRootSite.RefreshDisplay()](../../../../Src/Common/SimpleRootSite/SimpleRootSite.cs) did this (removed in LT-22610; step 3 no longer exists — see superseded note above):
 
 1. If a decorator is installed as `m_rootb.DataAccess`, call `decorator.Refresh()`.
 2. If the control is not visible, defer refresh.
-3. If `!m_rootb.NeedsReconstruct`, return without selection save/restore or drawing suspension.
+3. ~~If `!m_rootb.NeedsReconstruct`, return without selection save/restore or drawing suspension.~~
 4. Otherwise call `m_rootb.Reconstruct()`.
 
 This means the system has two layered assumptions:

--- a/openspec/changes/render-speedup-benchmark/tasks.md
+++ b/openspec/changes/render-speedup-benchmark/tasks.md
@@ -85,6 +85,6 @@
 - [x] PATH-L1-VERIFY Run full benchmark suite and compare before/after timing evidence. Result: **99.99% warm render reduction** (153.00ms → 0.01ms). All 15 scenarios pass with 0% pixel variance. Cold render unaffected (62.33ms → 62.95ms).
 
 **Deferred** (future iterations):
-- [x] PATH-L5 Skip Reconstruct when data unchanged — gate `SimpleRootSite.RefreshDisplay()` on `VwRootBox.NeedsReconstruct` and cover it with focused tests.
+- [x] ~~PATH-L5 Skip Reconstruct when data unchanged — gate `SimpleRootSite.RefreshDisplay()` on `VwRootBox.NeedsReconstruct` and cover it with focused tests.~~ **Reverted 2026-07-10 (LT-22610, PR #1006):** the gate missed managed-only view-constructor state, causing stale views. `RefreshDisplay()` now always reconstructs.
 - [ ] PATH-L3 Per-paragraph layout caching — dirty-flag line-breaking in `VwParagraphBox::DoLayout()`.
 - [ ] PATH-L2 Deferred layout in Reconstruct — remove internal `Layout()` call from `Reconstruct()` (blocked: `RootBoxSizeChanged` callback needs dimensions immediately).


### PR DESCRIPTION
Fixes [LT-22610](https://jira.sil.org/browse/LT-22610) — "Sometimes the WS labels are not visible (random?)" (regression in 9.3.9).

## What happened

FieldWorks views are drawn from a "root box" — a native object that builds what you see on screen by running a view constructor. The render-speedup work in #724 taught the root box to remember whether anything had changed since it was last built (a `NeedsReconstruct` flag), and taught `SimpleRootSite.RefreshDisplay()` to **skip rebuilding the view whenever that flag said "nothing changed."**

The problem is that the flag only knows about changes the root box itself can see: edits to the data it displays, a stylesheet change, or being handed a new root object. But view constructors also read state the root box *cannot* see. The clearest example is the multi-string fields in the Lexicon Edit detail pane (Lexeme Form, Citation Form, etc.): the list of writing-system rows to show, and the little "Frn" / "Frn-Aud" / "FrIPA" labels next to them, come from writing-system lists held on the managed side, not from the root box's data.

When you change which writing systems a field displays — "Show all writing systems," the per-field Configure Writing Systems dialog, or the Set Up Vernacular Writing Systems dialog — the code updates those lists and then calls `RefreshDisplay()` to redraw the field. After #724, that call looked at `NeedsReconstruct`, saw "nothing changed" (no data edit had happened), and **silently did nothing**. The field kept showing the rows and labels from its previous state: labels missing, or one stale label sitting on the wrong row, with the audio-field sound button positioned against the stale layout.

This also explains every odd detail in the bug report:

- **"I tried the Set Up Vernacular WS dialog and changing things, but that didn't help"** — that dialog's refresh goes through exactly the code path that was being skipped.
- **"Later on it seemed to correct itself"** — the moment you actually edit data in the field, a real data-change notification sets the flag, and the next refresh genuinely rebuilds the view.
- **Restarting FLEx fixed it** — a fresh start rebuilds everything from scratch.
- **"Random"** — the skip path also cleared the "refresh pending" flag without doing the refresh, so a refresh queued while a field was scrolled out of view or being reused could be dropped permanently, depending on timing.

## How this fixes it

`RefreshDisplay()` now always rebuilds the view, as it did in every release before 9.3.9. It is the deliberate "rebuild everything the drastic way" API, called rarely (master refresh, writing-system changes) and precisely when something *outside* the root box's knowledge has changed — so the root box is the wrong thing to ask about whether the rebuild is needed.

Scope notes:

- The now-unused `m_fForceNextRefreshDisplay` / `ShouldReconstructDisplay()` plumbing is removed; the `NotifyDataAccessSemanticsChanged()` / `SetRootBoxDataAccess*` API surface is kept.
- The native performance work from #724 is untouched: the layout guard (`PATH-L1`), the HFONT/color caches, and the Uniscribe shape/analysis caches all remain, so the warm-render wins are preserved. Only the managed refresh short-circuit — the one piece that made a correctness decision from incomplete information — is removed.
- The regression test that pinned the skip behavior now pins the opposite: `RefreshDisplay` must reconstruct even when the root box reports no pending changes.

## Testing

- `SimpleRootSiteTests`: 116/116 pass (includes the updated `RefreshDisplayNeedsReconstruct` tests).
- `WidgetsTests` (LabeledMultiStringView): 19/19 pass.
- `XMLViewsTests`, `DetailControlsTests` (DataTree render baselines): pass.

Manual repro for verification: in Lexicon Edit, right-click a multi-string field → "Show All Writing Systems" (or Configure Writing Systems) and confirm the rows and WS labels update immediately, without editing data first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1006)
<!-- Reviewable:end -->
