### PR TITLE
This fixes LT-22616: Word Cat contents change when bundle selected

### DIFF
--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -2311,6 +2311,101 @@ namespace SIL.FieldWorks.IText
 			vwenv.CloseParagraph();
 		}
 
+		internal static ILexSense GuessWordSense(IWfiAnalysis wa)
+		{
+			if (wa.MeaningsOC.Count != 0)
+			{
+				return null;
+			}
+			// This is modeled after SandboxBase.SyncMonomorphemicGlossAndPos.
+			ILexSense rootSense = null;
+			foreach (IWfiMorphBundle morphBundle in wa.MorphBundlesOS)
+			{
+				// Get the sense for morphBundle.
+				ILexSense sense = morphBundle.SenseRA;
+				if (sense == null && morphBundle.MorphRA != null)
+				{
+					ILexEntry lexEntry = morphBundle.MorphRA.Owner as ILexEntry;
+					if (lexEntry != null && lexEntry.SensesOS.Count > 0)
+					{
+						sense = lexEntry.SensesOS[0];
+					}
+				}
+				if (sense?.Gloss?.BestAnalysisAlternative == null)
+					continue;
+				// Consider the sense's gloss.
+				IMoMorphSynAnalysis msa = sense.MorphoSyntaxAnalysisRA;
+				bool fStem = msa is IMoStemMsa;
+				// If we have only one morpheme, treat it as the stem from which we will copy the gloss.
+				// otherwise, use the first stem we find, if any.
+				if ((fStem && rootSense == null) || wa.MorphBundlesOS.Count == 1)
+					rootSense = sense;
+			}
+			return rootSense;
+		}
+
+		internal static ITsString GuessWordPOSName(IAnalysis analysis)
+		{
+			IPartOfSpeech lexPOS = GuessWordPOS(analysis);
+			if (lexPOS == null)
+				return null;
+			if (lexPOS.Abbreviation.BestAnalysisAlternative.Length > 0)
+				return lexPOS.Abbreviation.BestAnalysisAlternative;
+			return lexPOS.Name.BestAnalysisAlternative;
+		}
+
+		internal static IPartOfSpeech GuessWordPOS(IAnalysis analysis)
+		{
+			var wa = analysis.Analysis;
+			if (wa.CategoryRA != null)
+			{
+				return null;
+			}
+			// This is modeled after SandboxBase.SyncMonomorphemicGlossAndPos.
+			IPartOfSpeech stemPOS = null;
+			IPartOfSpeech derivedPOS = null;
+			foreach (IWfiMorphBundle morphBundle in wa.MorphBundlesOS)
+			{
+				// Get the sense for morphBundle.
+				ILexSense sense = morphBundle.SenseRA;
+				if (sense == null && morphBundle.MorphRA != null)
+				{
+					if (morphBundle.MorphRA.Owner is ILexEntry lexEntry && lexEntry.SensesOS.Count > 0)
+					{
+						sense = lexEntry.SensesOS[0];
+					}
+				}
+				if (sense == null)
+					continue;
+				// Consider the sense's part of speech.
+				IMoMorphSynAnalysis msa = sense.MorphoSyntaxAnalysisRA;
+				bool fStem = msa is IMoStemMsa;
+				if (fStem)
+				{
+					IPartOfSpeech POS = (msa as IMoStemMsa).PartOfSpeechRA;
+					if (POS != stemPOS && stemPOS != null)
+					{
+						// found conflicting stems
+						return null;
+					}
+					else
+						stemPOS = POS;
+				}
+				else if (msa is IMoDerivAffMsa)
+				{
+					if (derivedPOS != null)
+						return null; // more than one DA
+					else
+						derivedPOS = (msa as IMoDerivAffMsa).ToPartOfSpeechRA;
+				}
+			}
+			if (stemPOS == null)
+				return null;
+
+			IPartOfSpeech lexPOS = derivedPOS ?? stemPOS;
+			return lexPOS;
+		}
+
 		/// <summary>
 		/// Implementation of displaying a word bundle as Method Object
 		/// </summary>
@@ -2495,7 +2590,7 @@ namespace SIL.FieldWorks.IText
 					var wa = (IWfiAnalysis) m_defaultObj;
 					if (wa.MeaningsOC.Count == 0)
 					{
-						ITsString rootGlossName = GetRootGlossName(wa);
+						ITsString rootGlossName = GuessWordSense(wa)?.Gloss?.BestAnalysisAlternative;
 						if (m_hvoDefault != m_hvoWordBundleAnalysis && rootGlossName != null)
 						{
 							// Display our best guess for the gloss.
@@ -2538,37 +2633,9 @@ namespace SIL.FieldWorks.IText
 				}
 			}
 
-			private ITsString GetRootGlossName(IWfiAnalysis wa)
-			{
-				// This is modeled after SandboxBase.SyncMonomorphemicGlossAndPos.
-				ITsString rootGloss = null;
-				foreach (IWfiMorphBundle morphBundle in wa.MorphBundlesOS)
-				{
-					// Get the sense for morphBundle.
-					ILexSense sense = morphBundle.SenseRA;
-					if (sense == null && morphBundle.MorphRA != null)
-					{
-						ILexEntry lexEntry = morphBundle.MorphRA.Owner as ILexEntry;
-						if (lexEntry != null && lexEntry.SensesOS.Count > 0)
-						{
-							sense = lexEntry.SensesOS[0];
-						}
-					}
-					if (sense?.Gloss?.BestAnalysisAlternative == null)
-						continue;
-					// Consider the sense's gloss.
-					IMoMorphSynAnalysis msa = sense.MorphoSyntaxAnalysisRA;
-					bool fStem = msa is IMoStemMsa;
-					// If we have only one morpheme, treat it as the stem from which we will copy the gloss.
-					// otherwise, use the first stem we find, if any.
-					if ((fStem && rootGloss == null) || wa.MorphBundlesOS.Count == 1)
-						rootGloss = sense.Gloss.BestAnalysisAlternative;
-				}
-				return rootGloss;
-			}
-
 			private void DisplayWordPOS(int choiceIndex)
 			{
+				ITsString guessedPOSName = null;
 				switch(m_defaultObj.ClassID)
 				{
 				case WfiWordformTags.kClassId:
@@ -2581,19 +2648,14 @@ namespace SIL.FieldWorks.IText
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
 						// Let the exporter know that this is a guessed analysis.
 						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
-						var wa = (IWfiAnalysis) m_defaultObj;
-						int hvoPos = wa.CategoryRA != null ? wa.CategoryRA.Hvo : 0;
-						if (hvoPos == 0)
-						{
-							ITsString rootPOSName = GetRootPOSName(wa);
-							if (rootPOSName != null)
-							{
-								// Display our best guess for the gloss.
-								m_this.SetColor(m_vwenv, m_this.LabelRGBFor(choiceIndex));
-								m_vwenv.AddString(rootPOSName);
-								break;
-							}
-						}
+						guessedPOSName = GuessWordPOSName((IAnalysis)m_defaultObj);
+					}
+					if (guessedPOSName != null)
+					{
+						// Display our best guess for the gloss.
+						m_this.SetColor(m_vwenv, m_this.LabelRGBFor(choiceIndex));
+						m_vwenv.AddString(guessedPOSName);
+						break;
 					}
 					m_this.AddAnalysisPos(m_vwenv, m_hvoDefault, m_hvoWordBundleAnalysis, choiceIndex);
 					break;
@@ -2604,63 +2666,20 @@ namespace SIL.FieldWorks.IText
 						m_this.SetGuessing(m_vwenv, m_this.GetGuessColor(m_defaultObj));
 						// Let the exporter know that this is a guessed analysis.
 						m_vwenv.set_StringProperty(ktagAnalysisStatus, "guess");
+						guessedPOSName = GuessWordPOSName((IAnalysis)m_defaultObj);
+					}
+					if (guessedPOSName != null)
+					{
+						// Display our best guess for the gloss.
+						m_this.SetColor(m_vwenv, m_this.LabelRGBFor(choiceIndex));
+						m_vwenv.AddString(guessedPOSName);
+						break;
 					}
 					m_vwenv.AddObj(m_hvoWfiAnalysis, m_this, kfragAnalysisCategoryChoices + choiceIndex);
 					break;
 				default:
 					throw new Exception("Invalid type found in Segment analysis");
 				}
-			}
-
-			private ITsString GetRootPOSName(IWfiAnalysis wa)
-			{
-				// This is modeled after SandboxBase.SyncMonomorphemicGlossAndPos.
-				IPartOfSpeech stemPOS = null;
-				IPartOfSpeech derivedPOS = null;
-				foreach (IWfiMorphBundle morphBundle in wa.MorphBundlesOS)
-				{
-					// Get the sense for morphBundle.
-					ILexSense sense = morphBundle.SenseRA;
-					if (sense == null && morphBundle.MorphRA != null)
-					{
-						if (morphBundle.MorphRA.Owner is ILexEntry lexEntry && lexEntry.SensesOS.Count > 0)
-						{
-							sense = lexEntry.SensesOS[0];
-						}
-					}
-					if (sense == null)
-						continue;
-					// Consider the sense's part of speech.
-					IMoMorphSynAnalysis msa = sense.MorphoSyntaxAnalysisRA;
-					bool fStem = msa is IMoStemMsa;
-					if (fStem)
-					{
-						IPartOfSpeech POS = (msa as IMoStemMsa).PartOfSpeechRA;
-						if (POS != stemPOS && stemPOS != null)
-						{
-							// found conflicting stems
-							return null;
-						}
-						else
-							stemPOS = POS;
-					}
-					else if (msa is IMoDerivAffMsa)
-					{
-						if (derivedPOS != null)
-							return null; // more than one DA
-						else
-							derivedPOS = (msa as IMoDerivAffMsa).ToPartOfSpeechRA;
-					}
-				}
-				if (stemPOS == null)
-					return null;
-
-				IPartOfSpeech lexPOS = derivedPOS ?? stemPOS;
-				if (lexPOS == null)
-					return null;
-				if (lexPOS.Abbreviation.BestAnalysisAlternative.Length > 0)
-					return lexPOS.Abbreviation.BestAnalysisAlternative;
-				return lexPOS.Name.BestAnalysisAlternative;
 			}
 		}
 

--- a/Src/LexText/Interlinear/InterlinVc.cs
+++ b/Src/LexText/Interlinear/InterlinVc.cs
@@ -2361,7 +2361,16 @@ namespace SIL.FieldWorks.IText
 			{
 				return null;
 			}
-			// This is modeled after SandboxBase.SyncMonomorphemicGlossAndPos.
+			// Guess the word category from the morphemes' MSAs, matching
+			// SyncMonomorphemicGlossAndPos so the display and the sandbox agree:
+			//   - if there is more than one stem and they have different parts of
+			//     speech, give up (return null);
+			//   - if there is more than one derivational affix (DA), give up;
+			//   - if there is no stem, give up — a derived-to category is only
+			//     meaningful relative to the stem it attaches to, so a lone DA is
+			//     not enough to guess from;
+			//   - otherwise use the DA's 'to' POS if there is one, else the stem's POS.
+			//     (we don't insist that the DA's 'from' POS matches the stem)
 			IPartOfSpeech stemPOS = null;
 			IPartOfSpeech derivedPOS = null;
 			foreach (IWfiMorphBundle morphBundle in wa.MorphBundlesOS)

--- a/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
+++ b/Src/LexText/Interlinear/SandboxBase.ComboHandlers.cs
@@ -1213,7 +1213,7 @@ namespace SIL.FieldWorks.IText
 				MorphemeBreaker mb = new MorphemeBreaker(m_caches, sMorphs, m_hvoSbWord,
 					m_wsVern, m_sandbox);
 				mb.Run();
-				m_sandbox.CopyLexEntryInfoToMonomorphemicWordGlossAndPos(m_sandbox.UsingGuess);
+				m_sandbox.CopyLexEntryInfoToWordGlossAndPosIfEmpty(m_sandbox.UsingGuess);
 				m_rootb.Reconstruct(); // Everything changed, more or less.
 				// We've changed properties that the morph manager cares about, but we don't want it
 				// to fire when we fix the selection.

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1178,7 +1178,7 @@ namespace SIL.FieldWorks.IText
 			m_case = cf.StringCase(RawWordform.Text);
 			// empty it in case we're redoing after choose from combo.
 			cda.CacheVecProp(hvoSbWord, ktagSbWordMorphs, new int[0], 0);
-			if (gloss == null || analysis == null)
+			if (analysis == null)
 			{
 				if (fLookForDefaults)
 				{
@@ -4258,7 +4258,11 @@ namespace SIL.FieldWorks.IText
 			base.HandleSelectionChange(rootb, vwselNew);
 			if (!vwselNew.IsValid)
 				return;
-			m_editMonitor.DoPendingMorphemeUpdates();
+			if (m_editMonitor.NeedMorphemeUpdate)
+			{
+				m_editMonitor.DoPendingMorphemeUpdates();
+				CopyLexEntryInfoToMonomorphemicWordGlossAndPos(true);
+			}
 			if (!vwselNew.IsValid)
 				return;
 			DoActionOnIconSelection(vwselNew);

--- a/Src/LexText/Interlinear/SandboxBase.cs
+++ b/Src/LexText/Interlinear/SandboxBase.cs
@@ -1178,7 +1178,7 @@ namespace SIL.FieldWorks.IText
 			m_case = cf.StringCase(RawWordform.Text);
 			// empty it in case we're redoing after choose from combo.
 			cda.CacheVecProp(hvoSbWord, ktagSbWordMorphs, new int[0], 0);
-			if (analysis == null)
+			if (gloss == null || analysis == null)
 			{
 				if (fLookForDefaults)
 				{
@@ -1410,9 +1410,17 @@ namespace SIL.FieldWorks.IText
 						hasMf = true;
 					}
 				}
-				if (hasMf)
+				if (fGuessing != 0)
+				{
 					// Wait until all of the morphemes have been loaded (cf. LT-22235).
-					CopyLexEntryInfoToMonomorphemicWordGlossAndPos(fGuessing != 0);
+					if (gloss != null)
+					{
+						GuessWordCatAndGloss(gloss);
+					} else if (analysis != null)
+					{
+						GuessWordCatAndGloss(analysis);
+					}
+				}
 				if (bldrError.Length > 0)
 				{
 					var msg = bldrError.ToString().Trim();
@@ -1454,7 +1462,22 @@ namespace SIL.FieldWorks.IText
 			return fGuessing != 0;
 		}
 
-		internal void CopyLexEntryInfoToMonomorphemicWordGlossAndPos(bool usingGuess)
+		private void GuessWordCatAndGloss(IAnalysis analysis)
+		{
+			// Use the same guesses as InterlinVc to avoid confusing the user (LT-22616).
+			IPartOfSpeech wordCatGuess = InterlinVc.GuessWordPOS(analysis);
+			ILexSense wordSenseGuess = InterlinVc.GuessWordSense(analysis.Analysis);
+			if (wordCatGuess != null)
+			{
+				CopyLexPosToWordPos(true, wordCatGuess.Hvo);
+			}
+			if (wordSenseGuess != null)
+			{
+				CopySenseToWordGloss(true, wordSenseGuess.Hvo);
+			}
+		}
+
+		internal void CopyLexEntryInfoToWordGlossAndPosIfEmpty(bool usingGuess)
 		{
 			bool fDirty = Caches.DataAccess.IsDirty();
 			bool fApproved = !usingGuess;
@@ -1490,7 +1513,7 @@ namespace SIL.FieldWorks.IText
 
 			ISilDataAccess sda = m_caches.DataAccess;
 			int cmorphs = sda.get_VecSize(RootWordHvo, ktagSbWordMorphs);
-			int hvoSbRootSense = 0;
+			int hvoRealRootSense = 0;
 			int hvoStemPos = 0; // ID in real database of part-of-speech of stem.
 			bool fGiveUpOnPOS = false;
 			int hvoDerivedPos = 0; // real ID of POS output of derivational MSA.
@@ -1511,8 +1534,8 @@ namespace SIL.FieldWorks.IText
 
 				// If we have only one morpheme, treat it as the stem from which we will copy the gloss.
 				// otherwise, use the first stem we find, if any.
-				if ((fStem && hvoSbRootSense == 0) || cmorphs == 1)
-					hvoSbRootSense = hvoSbSense;
+				if ((fStem && hvoRealRootSense == 0) || cmorphs == 1)
+					hvoRealRootSense = m_caches.RealHvo(hvoSbSense);
 
 				if (fStem)
 				{
@@ -1537,7 +1560,7 @@ namespace SIL.FieldWorks.IText
 			// If we found a sense to copy from, do it.  Replace the word gloss even there already is
 			// one, since users get confused/frustrated if we don't.  (See LT-6141.)  It's marked as a
 			// guess after all!
-			CopySenseToWordGloss(fCopyToWordGloss, hvoSbRootSense);
+			CopySenseToWordGloss(fCopyToWordGloss, hvoRealRootSense);
 
 			// If we didn't find a stem, we don't have enough information to find a POS.
 			if (hvoStemPos == 0)
@@ -1554,13 +1577,12 @@ namespace SIL.FieldWorks.IText
 			CopyLexPosToWordPos(fCopyToWordPos, hvoLexPos);
 		}
 
-		protected virtual void CopySenseToWordGloss(bool fCopyWordGloss, int hvoSbRootSense)
+		protected virtual void CopySenseToWordGloss(bool fCopyWordGloss, int hvoRealSense)
 		{
-			if (hvoSbRootSense != 0 && fCopyWordGloss)
+			if (hvoRealSense != 0 && fCopyWordGloss)
 			{
 				ISilDataAccess sda = m_caches.DataAccess;
 				m_caches.DataAccess.SetInt(RootWordHvo, ktagSbWordGlossGuess, 1);
-				int hvoRealSense = m_caches.RealHvo(hvoSbRootSense);
 				foreach (int wsId in m_choices.EnabledWritingSystemsForFlid(InterlinLineChoices.kflidWordGloss))
 				{
 					// Update the guess, by copying the glosses of the SbNamedObj representing the sense
@@ -1574,6 +1596,7 @@ namespace SIL.FieldWorks.IText
 				}
 			}
 		}
+
 		protected virtual int CopyLexPosToWordPos(bool fCopyToWordCat, int hvoMsaPos)
 		{
 			int hvoPos = 0;
@@ -4261,7 +4284,7 @@ namespace SIL.FieldWorks.IText
 			if (m_editMonitor.NeedMorphemeUpdate)
 			{
 				m_editMonitor.DoPendingMorphemeUpdates();
-				CopyLexEntryInfoToMonomorphemicWordGlossAndPos(true);
+				CopyLexEntryInfoToWordGlossAndPosIfEmpty(true);
 			}
 			if (!vwselNew.IsValid)
 				return;


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22616.  The root problem was that SandboxBase and InterlinVc were making different guesses about the word cat and gloss, which confused the user.  The general principle is that when you first click on a word in the interlinear text, the sandbox should show whatever was showing in the interlinear text.  The word cat and gloss should only change after the user makes a change to the sandbox.

I also added code to guess the word gloss and category whenever the morphemes change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1007)
<!-- Reviewable:end -->

Devin's analysis:

The interlinear display (InterlinVc) and the editing sandbox (SandboxBase) had independent implementations for guessing word glosses and parts of speech from morph bundles. This caused inconsistencies—the display could show one guess while the sandbox applied a different one.
This PR:
Extracts the private guess methods from an inner class of InterlinVc into internal static methods at the InterlinVc class level, returning richer types (ILexSense, IPartOfSpeech) instead of just display strings.
Adds SandboxBase.GuessWordCatAndGloss which delegates to those same InterlinVc methods, ensuring consistent guesses.
Renames CopyLexEntryInfoToMonomorphemicWordGlossAndPos → CopyLexEntryInfoToWordGlossAndPosIfEmpty and adjusts CopySenseToWordGloss to accept a real HVO directly.
After morpheme updates in HandleSelectMorphComboItem, calls CopyLexEntryInfoToWordGlossAndPosIfEmpty to refresh guesses.
