### PR TITLE
Fix Compare-InstallerSnapshots.ps1 StrictMode crash on empty UninstallEntries

### DIFF
--- a/scripts/Agent/Compare-InstallerSnapshots.ps1
+++ b/scripts/Agent/Compare-InstallerSnapshots.ps1
@@ -54,6 +54,28 @@ function Diff-Sets {
 	return [pscustomobject]@{ Added = $added; Removed = $removed }
 }
 
+function Get-DisplayNameList {
+	# Safely extract DisplayName values from a snapshot's UninstallEntries.
+	# Robust to $null, to a single unwrapped object, and to the empty object ({})
+	# that ConvertTo-Json can emit for an empty list (Collect-InstallerSnapshot serializes
+	# an empty List as {} in Windows PowerShell). Under Set-StrictMode, blindly reading
+	# $entry.DisplayName on such an object throws PropertyNotFoundException.
+	param([Parameter(Mandatory = $false)]$Entries)
+
+	$names = New-Object System.Collections.Generic.List[string]
+	if ($null -eq $Entries) { return ,$names }
+
+	foreach ($entry in @($Entries)) {
+		if ($null -eq $entry) { continue }
+		$prop = $entry.PSObject.Properties['DisplayName']
+		if ($null -eq $prop) { continue }
+		$value = [string]$prop.Value
+		if (-not [string]::IsNullOrWhiteSpace($value)) { $names.Add($value) }
+	}
+
+	return ,$names
+}
+
 function ConvertTo-PropertyMap {
 	param([Parameter(Mandatory = $false)]$Value)
 
@@ -86,14 +108,8 @@ $reportLines.Add("After:  $AfterSnapshotPath")
 $reportLines.Add("")
 
 # Uninstall entries
-$beforeProducts = @()
-foreach ($p in ($before.UninstallEntries | ForEach-Object { $_ })) {
-	$beforeProducts += ([string]$p.DisplayName)
-}
-$afterProducts = @()
-foreach ($p in ($after.UninstallEntries | ForEach-Object { $_ })) {
-	$afterProducts += ([string]$p.DisplayName)
-}
+$beforeProducts = Get-DisplayNameList -Entries $before.UninstallEntries
+$afterProducts = Get-DisplayNameList -Entries $after.UninstallEntries
 
 $diffProducts = Diff-Sets -Before (To-StringSet -Items $beforeProducts) -After (To-StringSet -Items $afterProducts)
 $reportLines.Add("Uninstall entries")

--- a/scripts/Agent/Compare-InstallerSnapshots.ps1
+++ b/scripts/Agent/Compare-InstallerSnapshots.ps1
@@ -55,11 +55,9 @@ function Diff-Sets {
 }
 
 function Get-DisplayNameList {
-	# Safely extract DisplayName values from a snapshot's UninstallEntries.
-	# Robust to $null, to a single unwrapped object, and to the empty object ({})
-	# that ConvertTo-Json can emit for an empty list (Collect-InstallerSnapshot serializes
-	# an empty List as {} in Windows PowerShell). Under Set-StrictMode, blindly reading
-	# $entry.DisplayName on such an object throws PropertyNotFoundException.
+	# Tolerates $null, an unwrapped object, and the empty {} object Windows
+	# PowerShell emits for an empty list -- direct property access on those
+	# shapes throws under Set-StrictMode.
 	param([Parameter(Mandatory = $false)]$Entries)
 
 	$names = New-Object System.Collections.Generic.List[string]


### PR DESCRIPTION
`Compare-InstallerSnapshots.ps1` crashed under `Set-StrictMode` whenever a
before/after snapshot had zero `UninstallEntries`. `Collect-InstallerSnapshot`
serializes an empty list as `{}` (a Windows PowerShell `ConvertTo-Json`
quirk), and the script read `.DisplayName` directly off that property-less
object, which throws under strict mode. This surfaced while gathering
installer evidence: a silent MSI install whose before-snapshot legitimately
had 0 uninstall entries made the diff tool abort instead of producing a
report.

The fix extracts `DisplayName` through a new `Get-DisplayNameList` helper
that tolerates `$null`, a single unwrapped object, and the empty `{}`
object, skipping any entry without a usable `DisplayName`. Everything else
about the diff -- registry and file comparison -- is untouched.

**Where to look**

- `Get-DisplayNameList` (`scripts/Agent/Compare-InstallerSnapshots.ps1`) --
  the null/empty/unwrapped-object handling is the whole fix.
- Both call sites (before- and after-snapshot `UninstallEntries`) now go
  through the same helper, so the two snapshots can't drift in how they
  handle a missing entry.

**Deliberately not here**

- `Collect-InstallerSnapshot`'s `{}`-for-empty-list serialization is
  unchanged; hardening the producer to always emit `[]` is a separate,
  reasonable follow-up.

**Verification**

- Ran the script against a synthetic before/after pair with an empty `{}`
  `UninstallEntries` (the exact shape that crashed): exits 0, produces the
  expected diff.
- `gitlint --ignore body-is-missing --commits origin/main..HEAD` -- clean.
- All 6 CI checks pass.

---

<details>
<summary><b>Reading this a year from now</b> -- start here</summary>

The one thing worth knowing beyond the pitch above: the `{}`-for-empty-list
quirk lives in `Collect-InstallerSnapshot`'s JSON serialization, not in this
script. This script tolerates it rather than fixing the producer, so any
other consumer of a snapshot file needs the same tolerance.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
See `.review/summary.md` on the reviewing machine for the full pass:
no contract/API impact, no open findings, verification steps as listed
above.
<!-- pr-preflight:summary:end -->

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1008)
<!-- Reviewable:end -->
