### PR TITLE
Propagate part-ref caller through NodeChildrenDisplayCommand

### DIFF
--- a/Src/Common/Controls/XMLViews/XMLViewsTests/TestManyOneBrowse.cs
+++ b/Src/Common/Controls/XMLViews/XMLViewsTests/TestManyOneBrowse.cs
@@ -449,5 +449,38 @@ namespace XMLViewsTests
 				m_mdc, m_sda, m_layouts, out useHvo, collectStructNodes);
 			Assert.That(useHvo, Is.EqualTo(9)); // the third sense, in which context we display the 4th SD
 		}
+
+		/// <summary>
+		/// Regression test for the part-ref caller-propagation fix in GetDisplayCommandForColumn1's "part"
+		/// case: in XmlVc, "part" is the one thing that calls ProcessChildren with a non-null caller, so a
+		/// <part ref="..."/> column-spec node must carry ITSELF down as the resulting
+		/// NodeChildrenDisplayCommand's Caller (not null), so that child fragments reading attributes such
+		/// as "ws" from the caller (as multilingual strings configured via the part ref do) can resolve
+		/// them. Before the fix, the caller was always dropped, which is what caused the "Grammatical Info."
+		/// blank-column bug in the Avalonia browse table's off-screen cell rendering.
+		/// </summary>
+		[Test]
+		public void GetDisplayCommandForColumn_PartRefNode_CarriesItselfAsCaller()
+		{
+			ArrayList list = new ArrayList();
+			XmlViewsUtils.CollectBrowseItems(1, m_columnList[0], list, null, m_mdc, m_sda, m_layouts);
+			IManyOnePathSortItem bvi = list[0] as IManyOnePathSortItem;
+
+			// A hand-built <part ref="Msas"/> node, exactly the shape XmlVc embeds inside a layout when it
+			// refers to another part by name (here reusing the existing LexEntry-Jt-Msas part from
+			// TestParts.xml via the same class+layoutName naming convention GetNodeForPart resolves).
+			var doc = new XmlDocument();
+			XmlElement partRefNode = doc.CreateElement("part");
+			partRefNode.SetAttribute("ref", "Msas");
+
+			int hvo;
+			NodeDisplayCommand cmd = XmlViewsUtils.GetDisplayCommandForColumn(bvi, partRefNode, null,
+				m_mdc, m_sda, m_layouts, out hvo, null);
+
+			var childrenCmd = cmd as NodeChildrenDisplayCommand;
+			Assert.That(childrenCmd, Is.Not.Null, "a resolvable part ref must yield a NodeChildrenDisplayCommand");
+			Assert.That(childrenCmd.Caller, Is.SameAs(partRefNode),
+				"the part ref node itself must be carried down as the caller so child fragments can resolve attributes from it");
+		}
 	}
 }

--- a/Src/Common/Controls/XMLViews/XMLViewsTests/TestManyOneBrowse.cs
+++ b/Src/Common/Controls/XMLViews/XMLViewsTests/TestManyOneBrowse.cs
@@ -450,15 +450,7 @@ namespace XMLViewsTests
 			Assert.That(useHvo, Is.EqualTo(9)); // the third sense, in which context we display the 4th SD
 		}
 
-		/// <summary>
-		/// Regression test for the part-ref caller-propagation fix in GetDisplayCommandForColumn1's "part"
-		/// case: in XmlVc, "part" is the one thing that calls ProcessChildren with a non-null caller, so a
-		/// <part ref="..."/> column-spec node must carry ITSELF down as the resulting
-		/// NodeChildrenDisplayCommand's Caller (not null), so that child fragments reading attributes such
-		/// as "ws" from the caller (as multilingual strings configured via the part ref do) can resolve
-		/// them. Before the fix, the caller was always dropped, which is what caused the "Grammatical Info."
-		/// blank-column bug in the Avalonia browse table's off-screen cell rendering.
-		/// </summary>
+		/// <summary>A part-ref node must carry itself as the resulting Caller, so child fragments (e.g. multilingual strings) can resolve attributes like "ws" from it.</summary>
 		[Test]
 		public void GetDisplayCommandForColumn_PartRefNode_CarriesItselfAsCaller()
 		{
@@ -466,9 +458,7 @@ namespace XMLViewsTests
 			XmlViewsUtils.CollectBrowseItems(1, m_columnList[0], list, null, m_mdc, m_sda, m_layouts);
 			IManyOnePathSortItem bvi = list[0] as IManyOnePathSortItem;
 
-			// A hand-built <part ref="Msas"/> node, exactly the shape XmlVc embeds inside a layout when it
-			// refers to another part by name (here reusing the existing LexEntry-Jt-Msas part from
-			// TestParts.xml via the same class+layoutName naming convention GetNodeForPart resolves).
+			// Hand-built <part ref="Msas"/> node, the shape XmlVc embeds when a part ref names another part.
 			var doc = new XmlDocument();
 			XmlElement partRefNode = doc.CreateElement("part");
 			partRefNode.SetAttribute("ref", "Msas");

--- a/Src/Common/Controls/XMLViews/XmlVc.cs
+++ b/Src/Common/Controls/XMLViews/XmlVc.cs
@@ -5074,6 +5074,12 @@ namespace SIL.FieldWorks.Common.Controls
 	/// </summary>
 	public class NodeChildrenDisplayCommand : NodeDisplayCommand
 	{
+		// Optional "part ref" node that called the part whose children we display. When non-null it is
+		// passed down as the caller so that child fragments (e.g. multilingual strings) can resolve
+		// attributes such as "ws" from it. This mirrors XmlVc's behavior where the "part" case is the
+		// one thing that calls ProcessChildren with a non-null caller.
+		readonly XmlNode m_caller;
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Initializes a new instance of the <see cref="NodeChildrenDisplayCommand"/> class.
@@ -5085,14 +5091,39 @@ namespace SIL.FieldWorks.Common.Controls
 		{
 		}
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NodeChildrenDisplayCommand"/> class that
+		/// carries a caller (part ref) node down to the children being displayed.
+		/// </summary>
+		/// <param name="node">The node whose children are displayed.</param>
+		/// <param name="caller">The calling part ref node (may be null).</param>
+		/// ------------------------------------------------------------------------------------
+		public NodeChildrenDisplayCommand(XmlNode node, XmlNode caller)
+			: base(node)
+		{
+			m_caller = caller;
+		}
+
+		/// <summary>
+		/// The calling part ref node, or null if none was supplied.
+		/// </summary>
+		public XmlNode Caller
+		{
+			get { return m_caller; }
+		}
+
 		internal override void PerformDisplay(XmlVc vc, int fragId, int hvo, IVwEnv vwenv)
 		{
-			vc.ProcessChildren(Node, vwenv, hvo);
+			if (m_caller == null)
+				vc.ProcessChildren(Node, vwenv, hvo);
+			else
+				vc.ProcessChildren(Node, vwenv, hvo, m_caller);
 		}
 
 		internal override void DetermineNeededFields(XmlVc vc, int fragId, NeededPropertyInfo info)
 		{
-			DetermineNeededFieldsForChildren(vc, Node, null, info);
+			DetermineNeededFieldsForChildren(vc, Node, m_caller, info);
 		}
 
 		// Make it work sensibly as a hash key
@@ -5108,7 +5139,8 @@ namespace SIL.FieldWorks.Common.Controls
 		/// ------------------------------------------------------------------------------------
 		public override bool Equals(object obj)
 		{
-			return base.Equals(obj) && obj is NodeChildrenDisplayCommand;
+			var other = obj as NodeChildrenDisplayCommand;
+			return other != null && base.Equals(obj) && other.m_caller == m_caller;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -5122,7 +5154,7 @@ namespace SIL.FieldWorks.Common.Controls
 		/// ------------------------------------------------------------------------------------
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return base.GetHashCode() ^ (m_caller == null ? 0 : m_caller.GetHashCode());
 		}
 
 

--- a/Src/Common/Controls/XMLViews/XmlViewsUtils.cs
+++ b/Src/Common/Controls/XMLViews/XmlViewsUtils.cs
@@ -1134,19 +1134,23 @@ namespace SIL.FieldWorks.Common.Controls
 					collectOuterStructParts.Add(node);
 				return GetDisplayCommandForColumn1(bvi, mainChild, cache, mdc, sda, layouts, depth, out hvo, collectOuterStructParts);
 			}
-				// Review JohnT: In XmlVc, "part" is the one thing that calls ProcessChildren with non-null caller.
-				// this should make some difference here, but I can't figure what yet, or come up with a test that fails.
-				// We may need a "caller" argument to pass this down so it can be used in GetNodeForRelatedObject.
+				// In XmlVc, "part" is the one thing that calls ProcessChildren with a non-null caller (the
+				// part ref node). The off-screen cell-render path must do the same, otherwise children that
+				// read attributes such as "ws" from the caller (e.g. multilingual strings configured via the
+				// part ref) resolve nothing and render blank. So we capture the part ref node and carry it as
+				// the caller into the NodeChildrenDisplayCommand. (See LT- for the "Grammatical Info." blank
+				// column bug in the Avalonia browse table.)
 			case "part":
 			{
 				string layoutName = XmlUtils.GetOptionalAttributeValue(node, "ref");
 				if (layoutName != null)
 				{
 					// It's actually a part ref, in a layout, not a part looked up by one!
-					// Get the node it refers to, and make a command to process its children.
+					// Get the node it refers to, and make a command to process its children, passing this
+					// part ref node down as the caller so child fragments can resolve attributes from it.
 					XmlNode part = XmlVc.GetNodeForPart(hvo, layoutName, false, sda, layouts);
 					if (part != null)
-						return new NodeChildrenDisplayCommand(part); // display this object using the children of the part referenced.
+						return new NodeChildrenDisplayCommand(part, node); // display this object using the children of the part referenced.
 					else
 						return new NodeDisplayCommand(node); // no matching part, do default.
 				}


### PR DESCRIPTION
## Summary

Extracted from a rebase hunk found on the Avalonia migration branch (#964) — pulled out because it changes shared, legacy-reachable rendering behavior and shouldn't ride along in that PR. Opening this as a draft for team discussion, not as a confident fix.

`XmlViewsUtils.GetDisplayCommandForColumn1`'s `"part"` case builds a `NodeChildrenDisplayCommand(part)` and always passes a `null` caller into `ProcessChildren`. `XmlVc`'s own `"part"` handling passes a *non-null* caller in the equivalent situation. This change makes the two agree by carrying the part-ref node down as the caller.

There's a pre-existing `// Review JohnT:` comment sitting right on this code in `XmlViewsUtils.cs` (removed by this diff) that names exactly this gap and says it couldn't be confirmed to matter:

> In XmlVc, "part" is the one thing that calls ProcessChildren with non-null caller. this should make some difference here, but I can't figure what yet, or come up with a test that fails.

## Uncertainty — please weigh in

- **Is this actually needed on `main` today?** The rebase hunk's comment referenced "the 'Grammatical Info.' blank column bug in the Avalonia browse table" with an unfilled `LT-` ticket reference — I don't have a real ticket number and haven't reproduced a blank-column bug on `main` myself. I can't confirm this fixes a live bug vs. a bug that only manifests once the Avalonia browse-column path exists.
- **No test added.** The original JohnT comment says he couldn't construct a failing test either. If we land this, it should come with a regression test for whatever blank-column scenario motivated it — otherwise we're changing shared rendering code on faith.
- **Verified:** builds clean (`XMLViews.csproj`, 0 errors/warnings) and no other call site depends on the old single-arg-only shape.

## Test plan
- [ ] Confirm/attach the real ticket (or a repro) for the blank-column symptom this addresses
- [ ] Add a regression test for a `"part"`-based browse column that reads a caller-relative attribute (e.g. `ws`)
- [ ] Manual smoke test of existing "part"-based browse columns to confirm no visual/behavioral change for the common case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1009)
<!-- Reviewable:end -->
