### PR TITLE
Surface custom fields in Etymology/Pronunciation/LexEntryRef/LexSense panes

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/LexEntry.fwlayout
+++ b/DistFiles/Language Explorer/Configuration/Parts/LexEntry.fwlayout
@@ -80,6 +80,7 @@
 				<part ref="Comment" label="Following Comment" visibility="ifdata"/>
 				<part ref="Bibliography" label="Bibliographic Source" visibility="ifdata"/>
 				<part ref="Note" label="Etymology Note" visibility="ifdata"/>
+				<part ref="_CustomFieldPlaceholder" customFields="here" />
 			</indent>
 		</part>
 	</layout>
@@ -97,6 +98,7 @@
 		<part ref="CVPattern" label="CV Pattern"/>
 		<part ref="Tone"/>
 		<part ref="Location"/>
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 		<part ref="PublishIn" label="Publish Pronunciation In"/>
 	</layout>
 
@@ -106,10 +108,12 @@
 		<part ref="ComplexEntryTypes"/>
 		<part ref="ComponentLexemes"/>
 		<part ref="Summary" visibility="ifdata"/>
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 	</layout>
 
 	<layout class="LexEntryRef" type="detail" name="Publication">
 		<part ref="PrimaryLexemes"/>
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 	</layout>
 
 	<layout class="LexEntryRef" type="detail" name="VariantSection">
@@ -118,6 +122,7 @@
 		<part ref="RefVariantEntryTypes"/>
 		<part ref="RefShowMinorEntry"/>
 		<part ref="RefSummary" visibility="ifdata"/>
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 	</layout>
 
 

--- a/DistFiles/Language Explorer/Configuration/Parts/LexSense.fwlayout
+++ b/DistFiles/Language Explorer/Configuration/Parts/LexSense.fwlayout
@@ -65,6 +65,7 @@
 			<indent>
 				<part ref="Type" label="Type" />
 				<part ref="DiscussionAllA" label="Discussion" />
+				<part ref="_CustomFieldPlaceholder" customFields="here" />
 				<part ref="Examples" param="Notes"/>
 			</indent>
 		</part>
@@ -75,6 +76,7 @@
 		<part ref="ExampleAllV" label="Example" expansion="expanded" menu="mnuDataTree-Example">
 			<indent>
 				<part ref="TranslationsAllA" expansion="expanded" param="Translation"/>
+				<part ref="_CustomFieldPlaceholder" customFields="here" />
 			</indent>
 		</part>
 	</layout>
@@ -84,6 +86,7 @@
 		<part ref="Thumbnail" label="Thumbnail" visibility="never"/>
 		<part ref="CaptionA" label="Caption"/>
 		<part ref="FileName" label="File"/>
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 		<part ref="PublishIn" label="Publish Picture In"/>
 	</layout>
 	<layout class="CmFile" type="detail" name="Normal">
@@ -100,12 +103,14 @@
 		<part ref="TranslationAllA">
 			<indent>
 				<part ref="Type"/>
+				<part ref="_CustomFieldPlaceholder" customFields="here" />
 			</indent>
 		</part>
 	</layout>
 
 	<layout class="CmTranslation" type="detail" name="Translation">
 		<part ref="TranslationAllA" />
+		<part ref="_CustomFieldPlaceholder" customFields="here" />
 	</layout>
 
 	<layout class="LexReference" type="detail" name="ShowSingleReference">


### PR DESCRIPTION
## Summary

Extracted from a rebase hunk on the Avalonia migration branch (#964) — pulled out because it's a user-visible legacy-editor behavior change unrelated to enabling Avalonia, and needs its own review. Opening as a draft for discussion, not as a settled decision.

Adds `<part ref="_CustomFieldPlaceholder" customFields="here" />` to five `LexEntry.fwlayout` sub-layouts (Etymology, Pronunciation, Complex Form Info, Publication, Variant) and five `LexSense.fwlayout` sub-layouts. This is an existing `DataTree.cs` convention (`SpecialPartRefs`, `DataTree.cs:2519`) — the mechanism already exists and is already used elsewhere; this only adds the marker to panes that don't currently have it.

## Uncertainty — please weigh in

- **Is this wanted?** I don't know whether the absence of custom fields in these specific panes is an oversight or a deliberate choice (e.g. keeping Etymology/Pronunciation compact). This needs a product/UX call, not just a mechanical "the marker was missing" fix.
- **Not Avalonia-specific.** This marker isn't gated on `UIMode` — it's recognized by the shared legacy `DataTree`, so this changes the **legacy WinForms editor** for every existing user, immediately, regardless of migration status. It should be evaluated on that basis alone.
- **No screenshots / parity testing done.** I haven't visually verified what these panes look like with custom fields present, on a project that actually has custom fields defined on `LexEtymology`, `LexEntryRef`, `LexSense`, etc.
- **Verified only that nothing breaks mechanically**: `DataTree.cs` already has full support for this marker on `main` (confirmed via grep), so this is inert until a project actually has custom fields on the relevant classes.

## Test plan
- [ ] Team decides whether these panes should show custom fields
- [ ] Manual test: create custom fields on `LexEtymology`/`LexEntryRef`/`LexSense`, confirm each pane renders them sensibly (spacing, label, edit affordance)
- [ ] Confirm no existing layout/export tooling assumes a fixed child list for these sub-layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1010)
<!-- Reviewable:end -->
