### PR TITLE
LT-22685: Add sense pictures to the legacy Lexicon Edit pane (split from #964)

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Parts/LexSenseParts.xml
+++ b/DistFiles/Language Explorer/Configuration/Parts/LexSenseParts.xml
@@ -625,6 +625,15 @@
 			<seq field="ExtendedNote" ghost="Discussion" ghostWs="analysis" ghostLabel="Extended Note" ghostAbbe="ext"
 				menu="mnuDataTree-ExtendedNotes"/>
 		</part>
+		<!-- Sense pictures: a sequence rendering each CmPicture via its own Normal detail layout (the
+		     standard owned-sequence idiom, like LexSense-Detail-ExampleList above). NOT editor="picture"
+		     on the Pictures sequence field — that cast the owning LexSense to ICmPicture and crashed the
+		     legacy DataTree (the malformed form this replaces). This makes sense pictures visible in the
+		     legacy Lexicon Edit pane; they have been silently omitted there for years because no
+		     LexSense-Detail-Pictures part existed to resolve the long-standing <part ref="Pictures"/>. -->
+		<part id="LexSense-Detail-Pictures" type="detail">
+			<seq field="Pictures" layout="Normal" menu="mnuDataTree-Picture"/>
+		</part>
 		<part id="LexSense-Jt-HeadWord" type="jtview">
 			<string field="HeadWord"/>
 		</part>


### PR DESCRIPTION
## Sense pictures in the Lexicon Edit detail pane

Jira: [LT-22685](https://jira.sil.org/browse/LT-22685) · split out of the Phase-1 Avalonia spine (#964)

One `<part>` element — three lines of XML plus a six-line comment, in one
configuration file. No C#, no tests, no build changes. `LexSense.fwlayout:46` has
carried `<part ref="Pictures" param="Normal"/>` for years; the detail pane is
data-driven, so naming a `LexSense-Detail-Pictures` part is the entire switch.
Every piece behind it — `PictureSlice`, the five `CmPicture-Detail-*` parts,
`CmFile-Detail-FileName`, `mnuDataTree-Picture` — already ships.

**The premise this PR was opened on is wrong, and that changes what it is.** The
review asked for a `DataTree` test as a merge condition. That test was written,
and it reports the legacy pane **already renders Picture / Caption / File /
Publish Picture In on pristine `main`**. `DistFiles/Parts/GeneratedParts.xml:1494`
has carried an equivalent part all along, emitted at build time and **gitignored**
(`.gitignore:131`) — which is why `git log -S "LexSense-Detail-Pictures"` found
nothing and read as proof of absence.

So this is not a legacy fix. It is an **Avalonia-visible change**, because the two
UIs read different part inventories.

Where to look:

- **Legacy is a no-op.** Slice labels are identical with and without this part;
  the hand-written one merely overrides the generated default with two attributes.
- **Avalonia is not.** `DetailComposer.cs:3226` loads only
  `Configuration\Parts` — never the generated inventory — so this is the first
  `LexSense-Detail-Pictures` it can see, and `DetailComposer.cs:958` routes
  `Picture` to `WalkUnsupported`. Senses with pictures gain an **"Unsupported" row**.
- **CI is red, and correctly so.** `ShippedLayouts_UnresolvedParts_AreExactlyTheLegacyUnresolvableSet`
  fails: `LexSense-Pictures` leaves the baseline (63 → 62). That test's own comment
  encodes the same false premise.
- **Six of the seven review points are still open.** Table below.
- **The `menu` and `layout` attributes are both inert.** Review points 2 and 3.

Not here: no `DataTree` test committed, no `LabelAbbreviations` entries, no
`DetailComposer` picture support, no Jira record of the Avalonia gap.

**Status: draft, CHANGES_REQUESTED, CI red.** The open question is not "is the
diff right" but "does this PR still have a purpose" — see the last accordion.

---

<details>
<summary><b>Reading this a year from now</b> — start here</summary>

This PR was split out of #964 on the belief that sense pictures had never
appeared in the Lexicon Edit pane. That belief was false, and the review's own
merge condition — write the `DataTree` test — is what disproved it. The body
above is the corrected account; the accordions hold the mechanism, the evidence,
and the review history that is otherwise only recoverable by reading a long
thread.

The Aug 27 comment on this PR is the original write-up of the falsification. Its
substance is folded in here so the description is the single record.

</details>

<details>
<summary><b>Why three lines of XML is the whole change</b></summary>

The FLEx detail pane is configuration, not code. A `.fwlayout` names fields as
part references; `DataTree` resolves `<part ref="X"/>` against the parts
inventory by composing `{ClassName}-Detail-{X}`, and **silently omits the slice
when no such part id exists** (`DataTree.cs:2445`, "Just omit the missing
part"). There is no error, no log line, no test failure — a missing part is
indistinguishable from a field nobody configured.

So making a field appear is not a code change. It is one part id. The rendering
machinery is generic and already present:

| Piece | Where | Already shipped |
| --- | --- | --- |
| The layout ref | `LexSense.fwlayout:46` | yes, for years |
| The picture slice | `PictureSlice.cs` | yes |
| The per-picture parts | `LexSenseParts.xml:895-920` (`CmPicture-Detail-*`) | yes |
| The file-name row | `CmFile-Detail-FileName`, `LexSenseParts.xml:887` | yes |
| The context menu | `mnuDataTree-Picture`, `Lexicon/DataTreeInclude.xml:403` | yes |
| The insert command | `CmdInsertPicture` on `mnuDataTree-Sense`, `Lexicon/DataTreeInclude.xml:448` | yes |

Nine lines added: three of XML, six of comment. `git diff --stat main...HEAD`
is one file, `+9 -0`.

</details>

<details>
<summary><b>The surprising finding: a gitignored half of the inventory</b></summary>

`Build/SetupInclude.targets` (`GeneratePartsAndLayoutFiles`) runs
`PartGenerate.xslt` over `MasterLCModel.xml` at build time and emits a default
Detail part for **every field in the model**. The output lands in
`DistFiles/Parts/GeneratedParts.xml`, which `.gitignore:131` excludes.

Line 1494 of that file:

```xml
<part id="LexSense-Detail-Pictures" type="Detail"><seq field="Pictures" /></part>
```

The `Inventory` constructor unconditionally prepends
`FwDirectoryFinder.GetCodeSubDirectory("Parts")` to its search paths
(`Inventory.cs:174`), and the parts inventory's file pattern is `*Parts.xml`
(`LayoutCache.cs:128-132`) — which `GeneratedParts.xml` matches. `LoadElements`
walks the paths in order and `InsertNodeInDoc` replaces on a key collision
(`Inventory.cs:1400-1425`), so a hand-written part in `Configuration/Parts`
overrides the generated default rather than colliding with it.

**The lesson worth keeping:** `git log -S` cannot see the generated half of the
parts inventory. For any future configuration-resolution question, check the
built `DistFiles/Parts/` output, not just the tracked XML. The absence of history
was evidence of nothing.

</details>

<details>
<summary><b>Why legacy and Avalonia disagree — the two inventories</b></summary>

| | Directories read | Sees `GeneratedParts.xml`? |
| --- | --- | --- |
| Legacy `DataTree` | `DistFiles/Parts` (via `Inventory.cs:174`) **plus** `…/Configuration/Parts` (`LayoutCache.cs:103`) | **yes** |
| Avalonia `DetailComposer` | `…\Language Explorer\Configuration\Parts` only (`DetailComposer.cs:3226`) | **no** |
| `LayoutImportCoverage` tests | same single directory (`LayoutImportCoverageTests.cs:516`) | **no** |

That asymmetry is the whole story of this PR. Because the Avalonia composer never
loads the generated defaults, it has been resolving a strictly smaller inventory
than production legacy — and its unresolved-part baseline has been measuring that
smaller set while describing it as "what legacy also omits".

Adding the part to `Configuration/Parts` is therefore the first time
`LexSense-Detail-Pictures` becomes visible to Avalonia. `DetailComposer.cs:958`
sends `DetailEditorCategory.Picture` to `WalkUnsupported`, so the user-visible
effect lands entirely on the new UI: legacy users see no change, new-UI users
gain a labeled "Unsupported" worklist row on every sense with a picture.

Whether the Avalonia composer *should* load the generated inventory is a larger
question than this branch, and is the thing most worth deciding before it merges.

</details>

<details>
<summary><b>Review points, and where each one stands</b></summary>

From the `CHANGES_REQUESTED` review of 2026-08-24. Each was checked against the
current tree; the line numbers in the review were accurate.

| # | Point | State |
| --- | --- | --- |
| 1 | `DataTree` test is a merge condition | **Open** — written, and it falsified the premise, but never committed to this branch |
| 2 | Drop `layout="Normal"` (a no-op today, a silent override tomorrow, `DataTree.cs:2918`) | **Open** — still present |
| 3 | Fix or drop `menu="mnuDataTree-Picture"` (wrong menu — `Lexicon/DataTreeInclude.xml:403` holds Properties/MoveUp/MoveDown/Delete and no insert command; and a `seq` node is neither `CallerNode` nor `ConfigurationNode`, so it likely never fires) | **Open** — still present |
| 4 | Rewrite the comment (~570 chars, six lines over the 98-column limit, an em dash, a dead `ref="ExampleList"` exemplar, and a misquote of the layout node) | **Open** — unchanged, and now also factually wrong about the part not existing |
| 5 | Body understates the blast radius; record the Avalonia picture gap in Jira | **Half** — the body above now leads with the Avalonia effect; no Jira record filed |
| 6 | Add `LabelAbbreviations` for Picture / Caption / File / Publish Picture In | **Open** — none added. Note this is now a `main` bug, not a bug of this PR: those rows already render |
| 7 | Commit title 79 chars against gitlint's 72 | **Fixed** — now 60 chars, `Check commit messages` passes |
| — | *Question:* why is the thumbnail the part turned off? `PictureSlice.InstallPicture` does an uncapped `File.ReadAllBytes` → `Image.FromStream` per picture on the UI thread (`PictureSlice.cs:59-73`) | **Unanswered** — and it is a `main` question, since that code already runs |

Two things the review credited that still hold, recorded so they are not
re-litigated: rejecting `editor="picture"` was right (`SliceFactory.cs:210` hard-casts
to `ICmPicture` and would receive the owning `LexSense`), and omitting `ghost` was
right (`MakeGhostSlice` always builds a `GhostStringSlice`, which cannot express a
`CmPicture` that needs `PicturePropertiesDialog` to pick a file first).

</details>

<details>
<summary><b>Evidence</b></summary>

**The legacy no-op.** A `DataTree` test built against the production
`FwDirectoryFinder.FlexFolder` + `Configuration/Parts` (not the
`DetailControlsTests` fixtures, since what is under test is whether the *shipped*
XML resolves) creates a `LexSense` with one `CmPicture` and calls
`ShowObject(sense, "Normal", …)`. On pristine `origin/main`, with none of this
branch applied:

```
LABELS=[(null) | Gloss | Definition | Grammatical Info. | Example |
        Semantic Domains | Lexical Relations |
        Picture | Caption | File | Publish Picture In]
```

Applying this branch leaves that list unchanged.

**The Avalonia effect.** `FwAvaloniaTests.LayoutImportCoverageTests.ShippedLayouts_UnresolvedParts_AreExactlyTheLegacyUnresolvableSet`
fails on this branch (`LayoutImportCoverageTests.cs:678`):

```
Missing (1): < ["LexSense-Pictures", 1] >
```

The baseline holds `LexSense-Pictures` as unresolvable; this part resolves it.
Merging as-is requires deleting that entry, changing the occurrence ceiling from
63 to 62, and rewriting the comment above it, which currently reads "LexSense
`Pictures` has no LexSense-Detail-Pictures part, so legacy DataTree (and this
importer) omit sense pictures" — false for legacy on `main`.

**CI state:** `Build Debug and run tests` and `NUnit Tests` fail on that one test.
Everything else passes: commit messages, comment hygiene, whitespace, lychee,
stray-docs, codecov.

</details>

<details>
<summary><b>What is left to decide</b></summary>

Given that legacy already works, three routes:

1. **Close it.** The bug it was opened to fix does not exist. The findings live
   here and in LT-22685.
2. **Re-scope it to the Avalonia inventory gap** — make `DetailComposer` load the
   generated parts, which is the actual defect this investigation found. That is
   larger than this branch and belongs with the migration work.
3. **Keep the explicit part** on the argument that a hand-written part in
   `Configuration/Parts` is more legible than a gitignored generated default, and
   that `menu=`/`layout=` can be corrected per review points 2 and 3. This still
   requires the coverage-test baseline update and accepts the "Unsupported" row.

Route 1 or 2 seems right; route 3 needs a reason to prefer explicitness that
outweighs handing new-UI users a worklist row. Reviewer's call.

Two findings deserve their own tickets regardless of what happens to this branch,
because both are true on `main` today: the missing `LabelAbbreviations` entries
for four already-visible sense-picture labels, and the uncapped full-size image
decode on the UI thread in `PictureSlice.InstallPicture`.

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1012)
<!-- Reviewable:end -->
