### PR TITLE
Fix for LT-22619

### DIFF
--- a/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
+++ b/DistFiles/Language Explorer/MGA/GlossLists/EticGlossList.xml
@@ -16287,7 +16287,7 @@ or using a tool called AddGuids, and re-insert this comment. -->
                </f>
             </fs>
          </item>
-         <item guid="113f1954-77ed-45ea-9a18-a207d2d6abb1'" id="vBantuClass16Pl" type="value">
+         <item guid="113f1954-77ed-45ea-9a18-a207d2d6abb1" id="vBantuClass16Pl" type="value">
             <abbrev ws="en">16</abbrev>
             <term ws="en">NC 16</term>
             <def ws="en">Noun class 16 typically has a locative sense. Its behavior is highly language specific. The Proto-Bantu nominal, pronominal, and enumerative prefixes for class 16 are pa- / pá- / pá-. It may best be treated as derivational rather than inflectional.</def>

--- a/Src/LexText/Morphology/MGA/GlossLists/FeatureCatalog.xml
+++ b/Src/LexText/Morphology/MGA/GlossLists/FeatureCatalog.xml
@@ -6483,7 +6483,7 @@ type="value"
 ></Languages
 ></item
 ><item
-guid="113f1954-77ed-45ea-9a18-a207d2d6abb1'"
+guid="113f1954-77ed-45ea-9a18-a207d2d6abb1"
 id="vBantuClass16Pl"
 type="value"
 ><Languages


### PR DESCRIPTION
There was a trailing apostrophe in the GUID for noun class 16 in Bantu plural.  This was in two places: the master list (FeatureCatalog.xml) and the list used by the code (EticGlossList.xml).
The fix is to remove the trailing apostrophe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1013)
<!-- Reviewable:end -->
