### PR TITLE
Allow skipping Send/Receive data when restoring a backup

### DIFF
--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
@@ -373,7 +373,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			m_spellCheckAdditions.Checked = settings.IncludeSpellCheckAdditions;
 			m_spellCheckAdditions.Enabled = settings.IncludeSpellCheckAdditions;
 			m_sendReceiveData.Checked = settings.IncludeSendReceiveData;
-			m_sendReceiveData.Enabled = false;
+			m_sendReceiveData.Enabled = settings.IncludeSendReceiveData;
 			if (m_rdoDefaultFolder.Checked)
 				m_lblDefaultBackupIncludes.Text = m_presenter.IncludesFiles(settings);
 			else


### PR DESCRIPTION
Enable the Send/Receive checkbox in the restore dialog when the backup includes S/R data, mirroring the other optional items. The restore service already honors the flag, and the existing guard still blocks overwriting a project that uses Send/Receive without its S/R data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1014)
<!-- Reviewable:end -->
