### PR TITLE
Fix LT-22630: Custom first vernacular fields defaulting to analysis

### DIFF
--- a/Src/Common/Controls/DetailControls/DetailControlsTests/StringSliceUtilsTests.cs
+++ b/Src/Common/Controls/DetailControls/DetailControlsTests/StringSliceUtilsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 SIL Global
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using NUnit.Framework;
+
+namespace SIL.FieldWorks.Common.Framework.DetailControls
+{
+	/// <summary>
+	/// Unit tests for StringSliceUtils.
+	/// </summary>
+	[TestFixture]
+	public class StringSliceUtilsTests
+	{
+		private const int kwsVern = 101;
+		private const int kwsEmptyDefault = 102;
+		private const int kwsAnal = 103;
+
+		/// <summary>
+		/// A slice created with a specific ws (e.g. a custom field configured as First
+		/// Vernacular) should use that ws for typing in an empty field (LT-22630).
+		/// </summary>
+		[Test]
+		public void GetWsForEmptyField_PrefersSpecifiedWs()
+		{
+			Assert.That(StringSliceUtils.GetWsForEmptyField(kwsVern, kwsEmptyDefault, kwsAnal),
+				Is.EqualTo(kwsVern));
+		}
+
+		/// <summary>
+		/// With no ws specified, the 'wsempty' configuration default should win.
+		/// </summary>
+		[Test]
+		public void GetWsForEmptyField_FallsBackToEmptyDefault()
+		{
+			Assert.That(StringSliceUtils.GetWsForEmptyField(-1, kwsEmptyDefault, kwsAnal),
+				Is.EqualTo(kwsEmptyDefault));
+		}
+
+		/// <summary>
+		/// With nothing configured, the first analysis ws is the last resort (LT-22145).
+		/// </summary>
+		[Test]
+		public void GetWsForEmptyField_FallsBackToDefaultAnalysis()
+		{
+			Assert.That(StringSliceUtils.GetWsForEmptyField(-1, 0, kwsAnal), Is.EqualTo(kwsAnal));
+		}
+
+		/// <summary>
+		/// Magic ws constants are negative and must not be treated as real ws handles.
+		/// </summary>
+		[Test]
+		public void GetWsForEmptyField_IgnoresNonPositiveValues()
+		{
+			Assert.That(StringSliceUtils.GetWsForEmptyField(-6, -3, kwsAnal), Is.EqualTo(kwsAnal));
+		}
+	}
+}

--- a/Src/Common/Controls/DetailControls/StringSlice.cs
+++ b/Src/Common/Controls/DetailControls/StringSlice.cs
@@ -654,6 +654,18 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				{
 					s_fProcessingSelectionChanged = true;
 
+					// An insertion point in an empty field has no text to supply a ws, so its
+					// props fall back to the UI ws. Give it the slice's data-entry ws so the
+					// ws chooser and keyboard match what typing will produce (LT-22630).
+					if (!vwselNew.IsRange && FieldIsEmpty())
+					{
+						var propsBldr = TsStringUtils.MakePropsBldr();
+						propsBldr.SetIntPropValues((int)FwTextPropType.ktptWs,
+							(int)FwTextPropVar.ktpvDefault,
+							StringSliceUtils.GetWsForEmptyField(m_ws, m_wsDefault, Cache.DefaultAnalWs));
+						vwselNew.SetTypingProps(propsBldr.GetTextProps());
+					}
+
 					// If the selection is entirely formattable ("IsSelectionInOneFormattableProp"), we don't need to do
 					// the following selection truncation.
 					var hlpr = SelectionHelper.Create(vwselNew, this);

--- a/Src/Common/Controls/DetailControls/StringSlice.cs
+++ b/Src/Common/Controls/DetailControls/StringSlice.cs
@@ -382,8 +382,10 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 
 		#region RootSite implementation
 		/// <summary>
-		/// This is a RootSiteControl that displays a non-multilingual string slice
-		/// Data entry should always default to the DefaultAnalWs writing system according to LT-22145
+		/// A RootSiteControl that displays a single string: a plain (non-multilingual)
+		/// string property, a Unicode property, or one alternative of a multilingual
+		/// property. When the field is empty, data entry uses the writing system
+		/// configured for the slice, defaulting to first analysis (LT-22145, LT-22630).
 		/// </summary>
 		class StringSliceView : RootSiteControl, INotifyControlInCurrentSlice
 		{
@@ -391,6 +393,8 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			readonly int m_hvoObj;
 			readonly int m_flid;
 			readonly int m_ws = -1; // -1 signifies not a multilingual property
+			int m_wsDefault; // ws to use in an empty field, from the 'wsempty' config attribute
+			CellarPropertyType m_propType;
 			IVwViewConstructor m_vc;
 
 			public StringSliceView(int hvo, int flid, int ws)
@@ -424,17 +428,53 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				set
 				{
 					CheckDisposed();
+					m_wsDefault = value;
 					if (m_vc is StringSliceVc)
 						(m_vc as StringSliceVc).DefaultWs = value;
 				}
 			}
 
+			/// <summary>
+			/// When the field is empty there is no adjacent text to give newly typed characters a
+			/// writing system, so supply the one configured for the slice (LT-22145, LT-22630).
+			/// Once the field has content, -1 lets typing inherit from the surrounding text.
+			/// Sets are ignored so input-language changes can't hijack an empty field.
+			/// </summary>
 			public override int WsPending
 			{
-				// Ignore requests to set pending writing system, this slice always deals with the DefaultAnalWs.
 				// ReSharper disable once ValueParameterNotUsed
 				set { }
-				get => Cache != null ? Cache.DefaultAnalWs : -1;
+				get
+				{
+					if (Cache == null || m_obj == null || !FieldIsEmpty())
+						return -1;
+					return StringSliceUtils.GetWsForEmptyField(m_ws, m_wsDefault, Cache.DefaultAnalWs);
+				}
+			}
+
+			/// <summary>
+			/// Is the string property this slice edits currently empty?
+			/// Unicode and unrecognized property types report false.
+			/// </summary>
+			private bool FieldIsEmpty()
+			{
+				if (!Cache.ServiceLocator.IsValidObjectId(m_hvoObj))
+					return false;
+				var sda = m_cache.DomainDataByFlid;
+				switch (m_propType)
+				{
+					case CellarPropertyType.String:
+						var tss = sda.get_StringProp(m_hvoObj, m_flid);
+						return tss == null || tss.Length == 0;
+					case CellarPropertyType.MultiString:
+					case CellarPropertyType.MultiUnicode:
+						if (m_ws <= 0)
+							return false;
+						var tssAlt = sda.get_MultiStringAlt(m_hvoObj, m_flid, m_ws);
+						return tssAlt == null || tssAlt.Length == 0;
+					default:
+						return false;
+				}
 			}
 			#region IDisposable override
 
@@ -569,6 +609,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				m_obj = m_cache.ServiceLocator.GetInstance<ICmObjectRepository>().GetObject(m_hvoObj);
 
 				CellarPropertyType type = (CellarPropertyType)m_cache.DomainDataByFlid.MetaDataCache.GetFieldType(m_flid);
+				m_propType = type;
 				if (type == CellarPropertyType.Unicode)
 				{
 					m_vc = new UnicodeStringSliceVc(m_flid, m_ws, m_cache);

--- a/Src/Common/Controls/DetailControls/StringSliceUtils.cs
+++ b/Src/Common/Controls/DetailControls/StringSliceUtils.cs
@@ -37,6 +37,21 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 		}
 
 		/// <summary>
+		/// Pick the writing system for text typed into an empty string field: the ws the slice
+		/// was created with (e.g. a custom field's First Vernacular), else the configured
+		/// empty-field default (the 'wsempty' attribute), else the first analysis ws (LT-22145).
+		/// See LT-22630.
+		/// </summary>
+		public static int GetWsForEmptyField(int wsSpecified, int wsEmptyDefault, int wsDefaultAnal)
+		{
+			if (wsSpecified > 0)
+				return wsSpecified;
+			if (wsEmptyDefault > 0)
+				return wsEmptyDefault;
+			return wsDefaultAnal;
+		}
+
+		/// <summary>
 		/// Get the writing systems we should actually display right now. That is, from the ones
 		/// that are currently possible, select any we've previously configured to show.
 		/// </summary>


### PR DESCRIPTION
## Quick Summary

Fixes [LT-22630](https://jira.sil.org/browse/LT-22630): since FW 9.3.7, typing in a custom single-string field configured for First Vernacular came out in the first analysis writing system.

The [LT-22145](https://jira.sil.org/browse/LT-22145) fix overrode `StringSliceView.WsPending` to always return `DefaultAnalWs` and swallow writes, turning the one-shot pending-ws mechanism into a permanent forced writing system for every keystroke in these slices. This PR scopes the override to the case LT-22145 was actually about — an empty field, where there is no adjacent text to inherit a ws from — and picks the ws the slice was configured with: the constructor-specified ws (custom fields), else the `wsempty` config default, else `DefaultAnalWs`. When the field has content, the getter returns -1 so typing inherits the surrounding text's writing system.

- `StringSlice.cs`: empty-field-scoped `WsPending` getter; `DefaultWs` (the `wsempty` attribute) now stored on the view; empty-check handles String and MultiString/MultiUnicode props.
- `StringSliceUtils.cs`: the ws fallback chain as a pure `GetWsForEmptyField` function.
- `StringSliceUtilsTests.cs`: unit tests for the chain, including that negative magic-ws constants are never treated as real handles.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)

- Behavior for LT-22145's fields (Source on Sense, Reference on Example) is unchanged when empty: they still default to first analysis. The change additionally un-breaks typing inside existing non-analysis text in plain string fields, which the old override forced to analysis per keystroke.
- The only shipped `wsempty` user (Data Notebook Title, `wsempty="analysis"`) resolves to `DefaultAnalWs`, identical to the last-resort fallback, so honoring it changes nothing for existing configurations.
- `DetailControlsTests` pass locally (67 passed, 1 skipped, including 4 new tests). Manual acceptance tests for both tickets in live FLEx are still pending; this is a draft until that verification is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1015)
<!-- Reviewable:end -->
