### PR TITLE
Fix LT-22611: Allow Bulk Edit Inflection Features for affixes

### DIFF
--- a/Src/FdoUi/InflectionFeatureEditor.cs
+++ b/Src/FdoUi/InflectionFeatureEditor.cs
@@ -378,8 +378,42 @@ namespace SIL.FieldWorks.FdoUi
 						{
 							newFsTarget = FillInBlanks(fsTarget, ls);
 						}
-						IMoStemMsa msmTarget = GetMsmTarget(newFsTarget, entry, sensesToChange, pos);
-						ls.MorphoSyntaxAnalysisRA = msmTarget;
+						if (ls.MorphoSyntaxAnalysisRA is IMoStemMsa)
+						{
+							IMoStemMsa msmTarget = GetMsmTarget(newFsTarget, entry, sensesToChange, pos);
+							ls.MorphoSyntaxAnalysisRA = msmTarget;
+						}
+						else if (ls.MorphoSyntaxAnalysisRA is IMoInflAffMsa oldMsa)
+						{
+							// Make a copy of oldMsa.
+							IMoInflAffMsa newMsa = m_cache.ServiceLocator.GetInstance<IMoInflAffMsaFactory>().Create();
+							entry.MorphoSyntaxAnalysesOC.Add(newMsa);
+							newMsa.PartOfSpeechRA = oldMsa.PartOfSpeechRA;
+							newMsa.AffixCategoryRA = oldMsa.AffixCategoryRA;
+							foreach (var restriction in oldMsa.FromProdRestrictRC)
+							{
+								newMsa.FromProdRestrictRC.Add(restriction);
+							}
+							foreach (var slot in oldMsa.SlotsRC)
+							{
+								newMsa.SlotsRC.Add(slot);
+							}
+							if (newFsTarget != null)
+							{
+								// Always make a copy since InflFeatsOA is the owner.
+								IFsFeatStruc copy = Cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
+								newMsa.InflFeatsOA = copy;
+								newFsTarget.SetCloneProperties(copy);
+							}
+							// Look for an existing Msa.
+							IMoInflAffMsa msaMatch = entry.MorphoSyntaxAnalysesOC.OfType<IMoInflAffMsa>()
+								.FirstOrDefault(msa => msa != newMsa && msa.EqualsMsa(newMsa));
+							ls.MorphoSyntaxAnalysisRA = msaMatch ?? newMsa;
+							if (msaMatch != null)
+							{
+								entry.MorphoSyntaxAnalysesOC.Remove(newMsa);
+							}
+						}
 					}
 				}
 			});
@@ -619,7 +653,6 @@ namespace SIL.FieldWorks.FdoUi
 						IMoInflAffMsa msa = m_cache.ServiceLocator.GetInstance<IMoInflAffMsaRepository>().GetObject(hvoMsa);
 						fEnable = !EquivalentFs(fsTarget, msa?.InflFeatsOA);
 					}
-					return false; // This is a temporary fix to LT-22601. Don't do bulk edits of inflection features of affixes.
 				}
 			}
 			return fEnable;

--- a/Src/FdoUi/InflectionFeatureEditor.cs
+++ b/Src/FdoUi/InflectionFeatureEditor.cs
@@ -405,14 +405,19 @@ namespace SIL.FieldWorks.FdoUi
 								newMsa.InflFeatsOA = copy;
 								newFsTarget.SetCloneProperties(copy);
 							}
-							// Look for an existing Msa.
 							IMoInflAffMsa msaMatch = entry.MorphoSyntaxAnalysesOC.OfType<IMoInflAffMsa>()
 								.FirstOrDefault(msa => msa != newMsa && msa.EqualsMsa(newMsa));
 							ls.MorphoSyntaxAnalysisRA = msaMatch ?? newMsa;
 							if (msaMatch != null)
 							{
+								// msaMatch got used instead of newMsa.
 								entry.MorphoSyntaxAnalysesOC.Remove(newMsa);
 							}
+						}
+						if (newFsTarget != null && newFsTarget != fsTarget && newFsTarget.ReferringObjects.Count == 0)
+						{
+							// Delete the feature structure created by FillInBlanks.
+							newFsTarget.Delete();
 						}
 					}
 				}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-22611.  We can't just set the inflection features of the MSA since it may be shared with other lexical senses.  So we make a copy of the MSA and set its inflection features.  We then see whether there is an existing MSA that matches it.  If there is, then we use it and delete the copy.

I added code for deleting newFsTarget if it was created by FillInBlanks and it isn't used elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1018)
<!-- Reviewable:end -->
