### PR TITLE
Fix LT-20950: Add New Sense dialog uses wrong Morph Type

### DIFF
--- a/Src/LexText/LexTextControls/AddNewSenseDlg.cs
+++ b/Src/LexText/LexTextControls/AddNewSenseDlg.cs
@@ -229,7 +229,7 @@ namespace SIL.FieldWorks.LexText.Controls
 
 			// get the current morph type from the lexical entry.
 			IMoMorphType mmt;
-			foreach (var mf in le.AlternateFormsOS)
+			foreach (var mf in le.AllAllomorphs)
 			{
 				mmt = mf.MorphTypeRA;
 				if (mmt != null)


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/LT-20950.  le.AlternateFormsOS only consists of the alternate allomorphs, le.AllAllomorphs consists of the lexeme and the alternative allomorphs.  le.AlternateFormsOS didn't find anything if there were no alternate allomorphs.  This worked for stems but not affixes.  In the description the -se affix had an alternate allomorph and so it worked, whereas the -s affix didn't have an alternative allomorph and so it didn't work.  Switching to le.AllAllomorphs fixed the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1019)
<!-- Reviewable:end -->
