### PR TITLE
Fix LT-22525 (pass 2)

### DIFF
--- a/Src/LexText/ParserCore/XAmpleParser.cs
+++ b/Src/LexText/ParserCore/XAmpleParser.cs
@@ -15,6 +15,7 @@ using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
 using SIL.ObjectModel;
+using SIL.Xml;
 using XAmpleManagedWrapper;
 
 namespace SIL.FieldWorks.WordWorks.Parser
@@ -234,6 +235,16 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		{
 			XElement formElement = morphElem.Element("MoForm");
 			Debug.Assert(formElement != null);
+			if (formElement.GetOuterXml().Contains("DbRef=\"\""))
+			{
+				// For proclitics and enclitics, the form's HVO can end up being empty coming out of TonePars.
+				// This is because there are two entries with the same morphname since we have to treat these
+				// clitics as both affixes and stems.  Unlike XAmple, TonePars needs unique morphnames just like
+				// STAMP does.  See section 5 "Known problems," item 3 in the TonePars with FLEx user documentation.
+				// Ignore this case.
+				morph = null;
+				return false;
+			}
 			var formHvo = (string) formElement.Attribute("DbRef");
 
 			XElement msiElement = morphElem.Element("MSI");

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/MorpherAnaProducer.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/MorpherAnaProducer.cs
@@ -39,31 +39,5 @@ namespace SIL.ToneParsFLEx
 		public abstract void ProduceANA(SegmentToShow segmentToShow);
 		public abstract void ProduceANA(IText selectedTextToShow);
 
-		// following borrowed from SIL.FieldWorks.WordWorks.Parser (ParserCore.dll)
-		/// <summary>
-		/// Convert any characters in the name which are higher than 0x00FF to hex.
-		/// Neither XAmple nor PC-PATR can read a file name containing letters above 0x00FF.
-		/// </summary>
-		/// <param name="originalName">The original name to be converted</param>
-		/// <returns>Converted name</returns>
-		internal static string ConvertNameToUseAnsiCharacters(string originalName)
-		{
-			var sb = new StringBuilder();
-			char[] letters = originalName.ToCharArray();
-			foreach (var letter in letters)
-			{
-				int value = Convert.ToInt32(letter);
-				if (value > 255)
-				{
-					string hex = value.ToString("X4");
-					sb.Append(hex);
-				}
-				else
-				{
-					sb.Append(letter);
-				}
-			}
-			return sb.ToString();
-		}
 	}
 }

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -578,15 +578,7 @@ namespace SIL.ToneParsFLEx
 			string sSelectedIndicies = FormatSelectedSegmentIndices();
 			lblStatus.Text = sSelectedIndicies + "/" + lbSegments.Items.Count;
 			LastSegment = selectedSegmentToShow.Segment.Guid.ToString();
-			var ana = GetAnaForm(selectedSegmentToShow);
-			if (ana.Contains("\\a \n"))
-			{
-				btnParseSegment.Enabled = false;
-			}
-			else
-			{
-				btnParseSegment.Enabled = true;
-			}
+			btnParseSegment.Enabled = true;
 		}
 
 		private string FormatSelectedSegmentIndices()

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsInvoker.cs
@@ -414,7 +414,9 @@ namespace SIL.ToneParsFLEx
 			int i = 0;
 			foreach (string msa in msaHvos)
 			{
-				if (msa == "<" || msa == "W" || msa == ">")
+				// When using XAmple, we need to check for particles (Prt) as well as words (W).
+				// Hermit Crab only has W's.
+				if (msa == "<" || msa == "W" || msa == "Prt" || msa == ">")
 					continue;
 				sb.Append("<Morph>\n");
 				sb.Append("<MoForm DbRef=\"");

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/XAmpleMorpherAnaProducer.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/XAmpleMorpherAnaProducer.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using SIL.DisambiguateInFLExDB;
 using SIL.FieldWorks.Common.FwUtils;
+using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
 using XAmpleWithToneParse;
 
@@ -29,7 +30,7 @@ namespace SIL.ToneParsFLEx
 			Cache = cache;
 			IntxCtlFile = intxCtlFile;
 			InputFilePath = Path.Combine(Path.GetTempPath(), "ToneParsInvoker.txt");
-			DatabaseName = ConvertNameToUseAnsiCharacters(cache.ProjectId.Name);
+			DatabaseName = XAmpleParser.ConvertNameToUseAnsiCharacters(cache.ProjectId.Name);
 		}
 
 		public override void ProduceANA(SegmentToShow segmentToShow)


### PR DESCRIPTION
When using the TonePars with FLEx utility and the data has one or more procltics or enclitics, one could get an empty/blank HVO value for the clitic with a resulting crash.

This has two fixes:
1. A check for an empty HVO which is skipped like other data items that are not found in the database (in XAmpleParser.cs).
2. For XAmple-produced input to TonePars, skip the Prt "category" as well as the W "category" in the ANA line (in ToneParsInvoker.cs).

While doing this, I happened to notice that there was a case of some code that was no longer needed now that this utility is part of FLEx.  See MorpherAnaProducer.cs and XAmpleMorpherAnaProducer.cs.

Finally, I also realized that every segment listed in the UI could be processed.  I had been blocking ones that did not have every word with an analysis.  That is needed for PcPatr with FLEx, but not for TonePars with FLEx.  See ToneParsFLExForm.cs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1020)
<!-- Reviewable:end -->
