### PR TITLE
LT-22609: Crash when creating New Project with trailing space in name

### DIFF
--- a/Src/Common/Controls/DetailControls/ChooserCommand.cs
+++ b/Src/Common/Controls/DetailControls/ChooserCommand.cs
@@ -5,14 +5,12 @@
 using System;
 using System.Windows.Forms;
 using System.Linq;
-using SIL.LCModel.Core.Text;
 using SIL.FieldWorks.Common.Framework.DetailControls.Resources;
 using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.FieldWorks.Common.Controls;
-using SIL.FieldWorks.Common.FwUtils;
 using XCore;
 
 namespace SIL.FieldWorks.Common.Framework.DetailControls
@@ -47,7 +45,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				dlg.SetDlgInfo(m_cache, morphType, MsaType.kInfl, m_slot, m_mediator, m_propertyTable,
 					m_fPrefix ? InsertEntryDlg.MorphTypeFilterType.Prefix : InsertEntryDlg.MorphTypeFilterType.Suffix);
 				dlg.DisableAffixTypeMainPosAndSlot();
-				if (dlg.ShowDialog() == DialogResult.OK)
+				if (dlg.ShowDialog(m_propertyTable.GetValue<Form>("window")) == DialogResult.OK)
 				{
 					bool fCreated;
 					ILexEntry entry;

--- a/Src/FwCoreDlgs/FwCoreDlgsTests/FwNewLangProjectModelTests.cs
+++ b/Src/FwCoreDlgs/FwCoreDlgsTests/FwNewLangProjectModelTests.cs
@@ -106,6 +106,8 @@ namespace SIL.FieldWorks.FwCoreDlgs
 		[TestCase("*", false)]
 		[TestCase("franç", false)] // upper ASCII is forbidden
 		[TestCase("\u0344", false)] // non-ASCII is forbidden
+		[TestCase("MyProject ", true)] // trailing space is trimmed, still valid (LT-22578)
+		[TestCase("   ", false)] // whitespace-only trims to empty -> invalid (LT-22578)
 		public void FwNewLangProjectModel_ProjectNameIsValid(string projName, bool expectedResult)
 		{
 			var testModel = new FwNewLangProjectModel
@@ -114,6 +116,25 @@ namespace SIL.FieldWorks.FwCoreDlgs
 				ProjectName = projName
 			};
 			Assert.That(testModel.IsProjectNameValid, Is.EqualTo(expectedResult));
+		}
+
+		/// <summary>
+		/// The name is trimmed of surrounding whitespace when stored, so the validated name matches
+		/// the name used to create the project directory. Windows strips trailing spaces/dots from
+		/// folder names, so an untrimmed name crashes on creation (LT-22578).
+		/// </summary>
+		[TestCase("MyProject ", "MyProject", TestName = "TrailingSpace")]
+		[TestCase(" MyProject", "MyProject", TestName = "LeadingSpace")]
+		[TestCase("  MyProject  ", "MyProject", TestName = "SurroundingSpace")]
+		[TestCase("My Project", "My Project", TestName = "InteriorSpacePreserved")]
+		public void FwNewLangProjectModel_ProjectName_TrimsSurroundingWhitespace(string input, string expected)
+		{
+			var testModel = new FwNewLangProjectModel
+			{
+				LoadProjectNameSetup = () => { },
+				ProjectName = input
+			};
+			Assert.That(testModel.ProjectName, Is.EqualTo(expected));
 		}
 
 		/// <summary/>

--- a/Src/FwCoreDlgs/FwNewLangProjectModel.cs
+++ b/Src/FwCoreDlgs/FwNewLangProjectModel.cs
@@ -208,7 +208,7 @@ namespace SIL.FieldWorks.FwCoreDlgs
 			get { return _projectName; }
 			set
 			{
-				_projectName = value;
+				_projectName = value?.Trim();
 				_steps[(int)CurrentStep].IsComplete = IsProjectNameValid;
 				LoadProjectNameSetup();
 			}

--- a/Src/LexText/Morphology/InflAffixTemplateControl.cs
+++ b/Src/LexText/Morphology/InflAffixTemplateControl.cs
@@ -412,7 +412,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 			using (var chooser = MakeChooserWithExtantMsas(m_slot, cmd as XCore.Command))
 			{
-				chooser.ShowDialog();
+				chooser.ShowDialog(this);
 				if (chooser.DialogResult == DialogResult.OK)
 				{
 					if (chooser.ChosenObjects != null && chooser.ChosenObjects.Count() > 0)


### PR DESCRIPTION
## Quick Summary

Fix LT-22609: FLEx crashes when creating a New Project with a trailing space in the Project name
[LT0-22609](https://jira.sil.org/browse/LT-22609). Trimming project name before file creation to fix the issue. Added FwNewLangProjectModel_ProjectName_TrimsSurroundingWhitespace tests to ensure project name leading or trailing spaces are trimmed.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1021)
<!-- Reviewable:end -->
