### PR TITLE
Fix LT-22578: Create new inflectional affix - window Z order issues

### DIFF
--- a/Src/Common/Controls/DetailControls/ChooserCommand.cs
+++ b/Src/Common/Controls/DetailControls/ChooserCommand.cs
@@ -5,14 +5,12 @@
 using System;
 using System.Windows.Forms;
 using System.Linq;
-using SIL.LCModel.Core.Text;
 using SIL.FieldWorks.Common.Framework.DetailControls.Resources;
 using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.FieldWorks.Common.Controls;
-using SIL.FieldWorks.Common.FwUtils;
 using XCore;
 
 namespace SIL.FieldWorks.Common.Framework.DetailControls
@@ -47,7 +45,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				dlg.SetDlgInfo(m_cache, morphType, MsaType.kInfl, m_slot, m_mediator, m_propertyTable,
 					m_fPrefix ? InsertEntryDlg.MorphTypeFilterType.Prefix : InsertEntryDlg.MorphTypeFilterType.Suffix);
 				dlg.DisableAffixTypeMainPosAndSlot();
-				if (dlg.ShowDialog() == DialogResult.OK)
+				if (dlg.ShowDialog(m_propertyTable.GetValue<Form>("window")) == DialogResult.OK)
 				{
 					bool fCreated;
 					ILexEntry entry;

--- a/Src/LexText/Morphology/InflAffixTemplateControl.cs
+++ b/Src/LexText/Morphology/InflAffixTemplateControl.cs
@@ -412,7 +412,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 			using (var chooser = MakeChooserWithExtantMsas(m_slot, cmd as XCore.Command))
 			{
-				chooser.ShowDialog();
+				chooser.ShowDialog(this);
 				if (chooser.DialogResult == DialogResult.OK)
 				{
 					if (chooser.ChosenObjects != null && chooser.ChosenObjects.Count() > 0)


### PR DESCRIPTION
https://jira.sil.org/browse/LT-22578. ShowDialog calls needed to properly pass an `owner` parameter for the windows to behave as expected.

## Quick Summary


## CI-ready checklist

- [ ] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1023)
<!-- Reviewable:end -->
