### PR TITLE
Fix LT-22632: Show # of changed analyses in Run Tests report

### DIFF
--- a/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
@@ -194,7 +194,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			zeroReport = new ParseReport(zeroWordform, zeroResult);
 			CheckParseReport(zeroReport, parseTime: 2);
 
-			var parserReport = new ParserReport(Cache);
+			var parserReport = new ParserReport(Cache, null);
 			parserReport.SourceText = "Testbed";
 			parserReport.AddParseReport("cat", parseReport);
 			parserReport.AddParseReport("error", errorReport);

--- a/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
@@ -52,10 +52,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			return newAnal;
 		}
 
-		private void CheckParseReport(ParseReport report, int numAnalyses = 0, int numApprovedMissing = 0,
+		private void CheckParseReport(ParseReport report, int numAnalyses = 0, int numChangedAnalyses = 0, int numApprovedMissing = 0,
 			int numDisapproved = 0, int numNoOpinion = 0, int parseTime = 0, string errorMessage = null)
 		{
 			Assert.That(report.NumAnalyses, Is.EqualTo(numAnalyses));
+			Assert.That(report.NumChangedAnalyses, Is.EqualTo(numChangedAnalyses));
 			Assert.That(report.NumUserDisapprovedAnalyses, Is.EqualTo(numDisapproved));
 			Assert.That(report.NumUserApprovedAnalysesMissing, Is.EqualTo(numApprovedMissing));
 			Assert.That(report.NumUserNoOpinionAnalyses, Is.EqualTo(numNoOpinion));
@@ -64,10 +65,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		}
 
 		private void CheckParserReport(ParserReport report, int numParseErrors = 0, int numWords = 0,
-			int numZeroParses = 0, int totalAnalyses = 0, int totalApprovedMissing = 0,
+			int numZeroParses = 0, int totalAnalyses = 0, int totalChangedAnalyses = 0, int totalApprovedMissing = 0,
 			int totalDisapproved = 0, int totalNoOpinion = 0,int totalParseTime = 0)
 		{
 			Assert.That(report.TotalAnalyses, Is.EqualTo(totalAnalyses));
+			Assert.That(report.TotalChangedAnalyses, Is.EqualTo(totalChangedAnalyses));
 			Assert.That(report.TotalUserDisapprovedAnalyses, Is.EqualTo(totalDisapproved));
 			Assert.That(report.TotalUserApprovedAnalysesMissing, Is.EqualTo(totalApprovedMissing));
 			Assert.That(report.TotalUserNoOpinionAnalyses, Is.EqualTo(totalNoOpinion));
@@ -164,6 +166,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				});
 				var analysis = CreateIWfiAnalysis(catWordform, new List<ParseMorph> {parseMorph});
 				analysis.SetAgentOpinion(Cache.LanguageProject.DefaultUserAgent, Opinions.approves);
+				analysis.SetAgentOpinion(Cache.LanguageProject.DefaultParserAgent, Opinions.approves);
 				var analysisX = CreateIWfiAnalysis(catWordform, new List<ParseMorph> { parseMorph3 });
 				analysisX.SetAgentOpinion(Cache.LanguageProject.DefaultUserAgent, Opinions.disapproves);
 				// Missing approved analyses.
@@ -177,17 +180,17 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			});
 
 			var parseReport = new ParseReport(catWordform, result);
-			CheckParseReport(parseReport, numAnalyses: 4, numApprovedMissing: 3, numDisapproved: 1, numNoOpinion: 2, parseTime: 10);
+			CheckParseReport(parseReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3, numDisapproved: 1, numNoOpinion: 2, parseTime: 10);
 
 			var errorResult = new ParseResult("error"){ ParseTime = 1 };
 			var errorReport = new ParseReport(catWordform, errorResult);
-			CheckParseReport(errorReport, numApprovedMissing: 4, parseTime: 1, errorMessage: "error");
+			CheckParseReport(errorReport, numApprovedMissing: 4, numChangedAnalyses: 1, parseTime: 1, errorMessage: "error");
 			errorReport = new ParseReport(errorWordform, errorResult);
 			CheckParseReport(errorReport, parseTime: 1, errorMessage: "error");
 
 			var zeroResult = new ParseResult(Enumerable.Empty<ParseAnalysis>()){ ParseTime = 2 };
 			var zeroReport = new ParseReport(catWordform, zeroResult);
-			CheckParseReport(zeroReport, numApprovedMissing: 4, parseTime: 2);
+			CheckParseReport(zeroReport, numApprovedMissing: 4, numChangedAnalyses: 1, parseTime: 2);
 			zeroReport = new ParseReport(zeroWordform, zeroResult);
 			CheckParseReport(zeroReport, parseTime: 2);
 
@@ -198,7 +201,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			parserReport.AddParseReport("zero", zeroReport);
 			Assert.That(parserReport.ParseReports.ContainsKey("cat"), Is.True);
 			CheckParserReport(parserReport, numParseErrors: 1, numWords: 3,
-				numZeroParses: 2, totalAnalyses: 4, totalApprovedMissing: 3,
+				numZeroParses: 2, totalAnalyses: 4, totalChangedAnalyses: 2, totalApprovedMissing: 3,
 				totalDisapproved: 1, totalNoOpinion: 2, totalParseTime: 13);
 
 			// Check SubtractParseReport.
@@ -206,28 +209,28 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			CheckParseReport(eeReport);
 
 			var epReport = parseReport.DiffParseReport(errorReport);
-			CheckParseReport(epReport, numAnalyses: 4, numApprovedMissing: 3,
+			CheckParseReport(epReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3,
 				numDisapproved: 1, numNoOpinion: 2, parseTime: 9, errorMessage: "error => ");
 
 			var ezReport = errorReport.DiffParseReport(zeroReport);
 			CheckParseReport(ezReport, parseTime: -1, errorMessage: " => error");
 
 			var peReport = errorReport.DiffParseReport(parseReport);
-			CheckParseReport(peReport, numAnalyses: -4, numApprovedMissing: -3,
+			CheckParseReport(peReport, numAnalyses: -4, numChangedAnalyses: -2, numApprovedMissing: -3,
 				numDisapproved: -1, numNoOpinion: -2, parseTime: -9, errorMessage: " => error");
 
 			var ppReport = parseReport.DiffParseReport(parseReport);
 			CheckParseReport(ppReport);
 
 			var pzReport = zeroReport.DiffParseReport(parseReport);
-			CheckParseReport(pzReport, numAnalyses: -4, numApprovedMissing: -3,
+			CheckParseReport(pzReport, numAnalyses: -4, numChangedAnalyses: -2, numApprovedMissing: -3,
 				numDisapproved: -1, numNoOpinion: -2, parseTime: -8);
 
 			var zeReport = errorReport.DiffParseReport(zeroReport);
 			CheckParseReport(zeReport, parseTime: -1, errorMessage: " => error");
 
 			var zpReport = parseReport.DiffParseReport(zeroReport);
-			CheckParseReport(zpReport, numAnalyses: 4, numApprovedMissing: 3,
+			CheckParseReport(zpReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3,
 				numDisapproved: 1, numNoOpinion: 2, parseTime: 8);
 
 			var zzReport = zeroReport.DiffParseReport(zeroReport);

--- a/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParserReportTests.cs
@@ -180,7 +180,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			});
 
 			var parseReport = new ParseReport(catWordform, result);
-			CheckParseReport(parseReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3, numDisapproved: 1, numNoOpinion: 2, parseTime: 10);
+			CheckParseReport(parseReport, numAnalyses: 4, numChangedAnalyses: 3, numApprovedMissing: 3, numDisapproved: 1, numNoOpinion: 2, parseTime: 10);
 
 			var errorResult = new ParseResult("error"){ ParseTime = 1 };
 			var errorReport = new ParseReport(catWordform, errorResult);
@@ -201,7 +201,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			parserReport.AddParseReport("zero", zeroReport);
 			Assert.That(parserReport.ParseReports.ContainsKey("cat"), Is.True);
 			CheckParserReport(parserReport, numParseErrors: 1, numWords: 3,
-				numZeroParses: 2, totalAnalyses: 4, totalChangedAnalyses: 2, totalApprovedMissing: 3,
+				numZeroParses: 2, totalAnalyses: 4, totalChangedAnalyses: 3, totalApprovedMissing: 3,
 				totalDisapproved: 1, totalNoOpinion: 2, totalParseTime: 13);
 
 			// Check SubtractParseReport.
@@ -209,28 +209,28 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			CheckParseReport(eeReport);
 
 			var epReport = parseReport.DiffParseReport(errorReport);
-			CheckParseReport(epReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3,
+			CheckParseReport(epReport, numAnalyses: 4, numChangedAnalyses: 3, numApprovedMissing: 3,
 				numDisapproved: 1, numNoOpinion: 2, parseTime: 9, errorMessage: "error => ");
 
 			var ezReport = errorReport.DiffParseReport(zeroReport);
 			CheckParseReport(ezReport, parseTime: -1, errorMessage: " => error");
 
 			var peReport = errorReport.DiffParseReport(parseReport);
-			CheckParseReport(peReport, numAnalyses: -4, numChangedAnalyses: -2, numApprovedMissing: -3,
+			CheckParseReport(peReport, numAnalyses: -4, numChangedAnalyses: -3, numApprovedMissing: -3,
 				numDisapproved: -1, numNoOpinion: -2, parseTime: -9, errorMessage: " => error");
 
 			var ppReport = parseReport.DiffParseReport(parseReport);
 			CheckParseReport(ppReport);
 
 			var pzReport = zeroReport.DiffParseReport(parseReport);
-			CheckParseReport(pzReport, numAnalyses: -4, numChangedAnalyses: -2, numApprovedMissing: -3,
+			CheckParseReport(pzReport, numAnalyses: -4, numChangedAnalyses: -3, numApprovedMissing: -3,
 				numDisapproved: -1, numNoOpinion: -2, parseTime: -8);
 
 			var zeReport = errorReport.DiffParseReport(zeroReport);
 			CheckParseReport(zeReport, parseTime: -1, errorMessage: " => error");
 
 			var zpReport = parseReport.DiffParseReport(zeroReport);
-			CheckParseReport(zpReport, numAnalyses: 4, numChangedAnalyses: 2, numApprovedMissing: 3,
+			CheckParseReport(zpReport, numAnalyses: 4, numChangedAnalyses: 3, numApprovedMissing: 3,
 				numDisapproved: 1, numNoOpinion: 2, parseTime: 8);
 
 			var zzReport = zeroReport.DiffParseReport(zeroReport);

--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -86,6 +86,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public int TotalUserNoOpinionAnalyses { get; set; }
 
 		/// <summary>
+		/// Total number of parse analyses that changed since the last parse
+		/// </summary>
+		public int TotalChangedAnalyses { get; set; }
+
+		/// <summary>
 		/// Parse reports for each word
 		/// </summary>
 		public IDictionary<string, ParseReport> ParseReports { get; set; }
@@ -132,6 +137,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			NumWords += 1;
 			TotalParseTime += report.ParseTime;
 			TotalAnalyses += report.NumAnalyses;
+			TotalChangedAnalyses += report.NumChangedAnalyses;
 			TotalUserApprovedAnalysesMissing += report.NumUserApprovedAnalysesMissing;
 			TotalUserDisapprovedAnalyses += report.NumUserDisapprovedAnalyses;
 			TotalUserNoOpinionAnalyses += report.NumUserNoOpinionAnalyses;
@@ -245,6 +251,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			diff.NumZeroParses = NumZeroParses - other.NumZeroParses;
 			diff.TotalParseTime = TotalParseTime - other.TotalParseTime;
 			diff.TotalAnalyses = TotalAnalyses - other.TotalAnalyses;
+			diff.TotalChangedAnalyses = TotalChangedAnalyses - other.TotalChangedAnalyses;
 			diff.TotalUserApprovedAnalysesMissing = TotalUserApprovedAnalysesMissing - other.TotalUserApprovedAnalysesMissing;
 			diff.TotalUserDisapprovedAnalyses = TotalUserDisapprovedAnalyses - other.TotalUserDisapprovedAnalyses;
 			diff.TotalUserNoOpinionAnalyses = TotalUserNoOpinionAnalyses - other.TotalUserNoOpinionAnalyses;
@@ -295,6 +302,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			if (TotalParseTime != other.TotalParseTime) return false;
 
 			if (TotalAnalyses != other.TotalAnalyses) return false;
+
+			if (TotalChangedAnalyses != other.TotalChangedAnalyses) return false;
 
 			if (TotalUserApprovedAnalysesMissing != other.TotalUserApprovedAnalysesMissing) return false;
 
@@ -358,6 +367,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		/// </summary>
 		public int NumUserNoOpinionAnalyses { get; set; }
 
+		/// <summary>
+		/// Number of analyses that changed since the last parse
+		/// </summary>
+		public int NumChangedAnalyses { get; set; }
+
 		public ParseReport() { }
 
 		/// <summary>
@@ -409,7 +423,44 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					NumUserNoOpinionAnalyses++;
 
 			}
-
+			// Count changed analyses.
+			var parserAgent = wordform.Cache.LanguageProject.DefaultParserAgent;
+			foreach (IWfiAnalysis wfAnalysis in wordform.AnalysesOC)
+			{
+				var opinion = wfAnalysis.GetAgentOpinion(parserAgent);
+				if (opinion == Opinions.approves)
+				{
+					var found = false;
+					foreach (ParseAnalysis pAnalysis in result.Analyses)
+					{
+						if (pAnalysis.MatchesIWfiAnalysis(wfAnalysis))
+						{
+							found = true;
+							break;
+						}
+					}
+					if (!found)
+					{
+						NumChangedAnalyses++;
+					}
+				}
+			}
+			foreach (ParseAnalysis pAnalysis in result.Analyses)
+			{
+				var found = false;
+				foreach (IWfiAnalysis wfAnalysis in wordform.AnalysesOC)
+				{
+					if (pAnalysis.MatchesIWfiAnalysis(wfAnalysis))
+					{
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+				{
+					NumChangedAnalyses++;
+				}
+			}
 		}
 
 		/// <summary>
@@ -420,6 +471,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			ParseReport diffReport = new ParseReport
 			{
 				NumAnalyses = NumAnalyses - oldReport.NumAnalyses,
+				NumChangedAnalyses = NumChangedAnalyses - oldReport.NumChangedAnalyses,
 				NoParse = NoParse - oldReport.NoParse,
 				NumUserApprovedAnalysesMissing = NumUserApprovedAnalysesMissing - oldReport.NumUserApprovedAnalysesMissing,
 				NumUserDisapprovedAnalyses = NumUserDisapprovedAnalyses - oldReport.NumUserDisapprovedAnalyses,
@@ -451,6 +503,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			if (ErrorMessage != other.ErrorMessage) return false;
 
 			if (NumAnalyses != other.NumAnalyses) return false;
+
+			if (NumChangedAnalyses != other.NumChangedAnalyses) return false;
 
 			if (NumUserApprovedAnalysesMissing != other.NumUserApprovedAnalysesMissing) return false;
 

--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -450,7 +450,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				var found = false;
 				foreach (IWfiAnalysis wfAnalysis in wordform.AnalysesOC)
 				{
-					if (pAnalysis.MatchesIWfiAnalysis(wfAnalysis))
+					var opinion = wfAnalysis.GetAgentOpinion(parserAgent);
+					if (opinion == Opinions.approves && pAnalysis.MatchesIWfiAnalysis(wfAnalysis))
 					{
 						found = true;
 						break;

--- a/Src/LexText/ParserCore/ParserReport.cs
+++ b/Src/LexText/ParserCore/ParserReport.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Policy;
+using XCore;
 
 namespace SIL.FieldWorks.WordWorks.Parser
 {
@@ -91,6 +92,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public int TotalChangedAnalyses { get; set; }
 
 		/// <summary>
+		/// Whether changes were recorded in ChangedAnalyses.
+		/// </summary>
+		public bool ChangesRecorded { get; set; }
+
+		/// <summary>
 		/// Parse reports for each word
 		/// </summary>
 		public IDictionary<string, ParseReport> ParseReports { get; set; }
@@ -118,12 +124,14 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			ParseReports = new Dictionary<string, ParseReport>();
 		}
 
-		public ParserReport(LcmCache cache)
+		public ParserReport(LcmCache cache, PropertyTable propertyTable)
 		{
 			ProjectName = cache.LanguageProject.ShortName;
 			MachineName = Environment.MachineName;
 			Timestamp = DateTime.UtcNow.ToFileTime();
 			ParseReports = new Dictionary<string, ParseReport>();
+			bool updatesAnalyses = propertyTable == null ? true : propertyTable.GetBoolProperty("CheckParserUpdatesAnalyses", true);
+			ChangesRecorded = !updatesAnalyses;
 		}
 
 		/// <summary>

--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -764,7 +764,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// </summary>
 		ParserReport CreateParserReport()
 		{
-			var parserReport = new ParserReport(m_cache)
+			var parserReport = new ParserReport(m_cache, m_propertyTable)
 			{
 				SourceText = m_sourceText
 			};

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -169,7 +169,7 @@
 							</StackPanel>
 						</DataGridTextColumn.Header>
 					</DataGridTextColumn>
-					<DataGridTextColumn Binding="{Binding NumChangedAnalyses}">
+					<DataGridTextColumn x:Name="NumChangedAnalyses" Binding="{Binding NumChangedAnalyses}">
 						<DataGridTextColumn.Header>
 							<StackPanel>
 								<Label Content="{x:Static local:ParserUIStrings.ksNumChangedAnalyses}"

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml
@@ -169,6 +169,17 @@
 							</StackPanel>
 						</DataGridTextColumn.Header>
 					</DataGridTextColumn>
+					<DataGridTextColumn Binding="{Binding NumChangedAnalyses}">
+						<DataGridTextColumn.Header>
+							<StackPanel>
+								<Label Content="{x:Static local:ParserUIStrings.ksNumChangedAnalyses}"
+								   ToolTip="{x:Static local:ParserUIStrings.ksNumChangedAnalysesToolTip}"/>
+								<Separator/>
+								<TextBlock ToolTip ="{x:Static local:ParserUIStrings.ksTotalChangedAnalysesToolTip}"
+								   Text="{Binding DataContext.ParserReport.TotalChangedAnalyses, RelativeSource={RelativeSource AncestorType=DataGrid}}"></TextBlock>
+							</StackPanel>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
 					<DataGridTextColumn Binding="{Binding ParseTime, Converter={StaticResource MillisecondsToTimeSpanConverter}, StringFormat=\{0:g\}}">
 						<DataGridTextColumn.Header>
 							<StackPanel>

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -31,6 +31,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportDialog(ParserReportViewModel parserReport, ParserListener parserListener, Mediator mediator, LcmCache cache, PropertyTable propertyTable)
 		{
 			InitializeComponent();
+			bool updatesAnalyses = propertyTable == null ? true : propertyTable.GetBoolProperty("CheckParserUpdatesAnalyses", true);
+			if (updatesAnalyses)
+			{
+				NumChangedAnalyses.Visibility = Visibility.Collapsed;
+			}
 			ParserListener = parserListener;
 			Mediator = mediator;
 			Cache = cache;

--- a/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportDialog.xaml.cs
@@ -31,9 +31,9 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportDialog(ParserReportViewModel parserReport, ParserListener parserListener, Mediator mediator, LcmCache cache, PropertyTable propertyTable)
 		{
 			InitializeComponent();
-			bool updatesAnalyses = propertyTable == null ? true : propertyTable.GetBoolProperty("CheckParserUpdatesAnalyses", true);
-			if (updatesAnalyses)
+			if (!parserReport.ParserReport.ChangesRecorded)
 			{
+				// Showing NumChangedAnalyses would be misleading.
 				NumChangedAnalyses.Visibility = Visibility.Collapsed;
 			}
 			ParserListener = parserListener;

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml
@@ -95,6 +95,11 @@
 							<Label Content="{x:Static local:ParserUIStrings.ksTotalAnalyses}" ToolTip="{x:Static local:ParserUIStrings.ksTotalAnalysesToolTip}"/>
 						</DataGridTextColumn.Header>
 					</DataGridTextColumn>
+					<DataGridTextColumn x:Name="TotalChangedAnalyses" Binding="{Binding ParserReport.TotalChangedAnalyses}">
+						<DataGridTextColumn.Header>
+							<Label Content="{x:Static local:ParserUIStrings.ksTotalChangedAnalyses}" ToolTip="{x:Static local:ParserUIStrings.ksTotalChangedAnalysesToolTip}"/>
+						</DataGridTextColumn.Header>
+					</DataGridTextColumn>
 					<DataGridTextColumn Binding="{Binding ParserReport.TotalParseTime, Converter={StaticResource MillisecondsToTimeSpanConverter}, StringFormat=\{0:g\}}">
 						<DataGridTextColumn.Header>
 							<Label Content="{x:Static local:ParserUIStrings.ksTotalParseTime}" ToolTip="{x:Static local:ParserUIStrings.ksTotalParseTimeToolTip}"/>

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -42,6 +42,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportsDialog(ObservableCollection<ParserReportViewModel> parserReports, ParserListener listener, Mediator mediator, LcmCache cache, PropertyTable propertyTable, string defaultComment)
 		{
 			InitializeComponent();
+			bool updatesAnalyses = propertyTable == null ? true : propertyTable.GetBoolProperty("CheckParserUpdatesAnalyses", true);
+			if (updatesAnalyses)
+			{
+				TotalChangedAnalyses.Visibility = Visibility.Collapsed;
+			}
 			parserReports.Sort((x, y) => y.Timestamp.CompareTo(x.Timestamp));
 			ParserReports = parserReports;
 			Listener = listener;

--- a/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
+++ b/Src/LexText/ParserUI/ParserReportsDialog.xaml.cs
@@ -42,11 +42,6 @@ namespace SIL.FieldWorks.LexText.Controls
 		public ParserReportsDialog(ObservableCollection<ParserReportViewModel> parserReports, ParserListener listener, Mediator mediator, LcmCache cache, PropertyTable propertyTable, string defaultComment)
 		{
 			InitializeComponent();
-			bool updatesAnalyses = propertyTable == null ? true : propertyTable.GetBoolProperty("CheckParserUpdatesAnalyses", true);
-			if (updatesAnalyses)
-			{
-				TotalChangedAnalyses.Visibility = Visibility.Collapsed;
-			}
 			parserReports.Sort((x, y) => y.Timestamp.CompareTo(x.Timestamp));
 			ParserReports = parserReports;
 			Listener = listener;

--- a/Src/LexText/ParserUI/ParserUI.csproj
+++ b/Src/LexText/ParserUI/ParserUI.csproj
@@ -80,7 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="ParserUIStrings.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>ParserUIStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>

--- a/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
+++ b/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
@@ -304,6 +304,24 @@ namespace SIL.FieldWorks.LexText.Controls {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Num Changed Analyses.
+        /// </summary>
+        public static string ksNumChangedAnalyses {
+            get {
+                return ResourceManager.GetString("ksNumChangedAnalyses", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of analyses that have changed since the last parse.
+        /// </summary>
+        public static string ksNumChangedAnalysesToolTip {
+            get {
+                return ResourceManager.GetString("ksNumChangedAnalysesToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disapproved Analyses.
         /// </summary>
         public static string ksNumDisapprovedAnalyses {
@@ -624,6 +642,24 @@ namespace SIL.FieldWorks.LexText.Controls {
         public static string ksTotalAnalysesToolTip {
             get {
                 return ResourceManager.GetString("ksTotalAnalysesToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Num Changed Analyses.
+        /// </summary>
+        public static string ksTotalChangedAnalyses {
+            get {
+                return ResourceManager.GetString("ksTotalChangedAnalyses", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The total number of changed analyses since the last parse.
+        /// </summary>
+        public static string ksTotalChangedAnalysesToolTip {
+            get {
+                return ResourceManager.GetString("ksTotalChangedAnalysesToolTip", resourceCulture);
             }
         }
         

--- a/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
+++ b/Src/LexText/ParserUI/ParserUIStrings.Designer.cs
@@ -655,7 +655,7 @@ namespace SIL.FieldWorks.LexText.Controls {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The total number of changed analyses since the last parse.
+        ///   Looks up a localized string similar to The total number of analyses that have changed since the last parse.
         /// </summary>
         public static string ksTotalChangedAnalysesToolTip {
             get {

--- a/Src/LexText/ParserUI/ParserUIStrings.resx
+++ b/Src/LexText/ParserUI/ParserUIStrings.resx
@@ -205,6 +205,12 @@
   <data name="ksNumAnalysesToolTip" xml:space="preserve">
     <value>The number of analyses produced by the parser</value>
   </data>
+  <data name="ksNumChangedAnalyses" xml:space="preserve">
+    <value>Num Changed Analyses</value>
+  </data>
+  <data name="ksNumChangedAnalysesToolTip" xml:space="preserve">
+    <value>The number of analyses that have changed since the last parse</value>
+  </data>
   <data name="ksNumDisapprovedAnalyses" xml:space="preserve">
     <value>Disapproved Analyses</value>
   </data>
@@ -285,6 +291,12 @@
   </data>
   <data name="ksTotalAnalysesToolTip" xml:space="preserve">
     <value>The total number of analyses in the words parsed</value>
+  </data>
+  <data name="ksTotalChangedAnalyses" xml:space="preserve">
+    <value>Num Changed Analyses</value>
+  </data>
+  <data name="ksTotalChangedAnalysesToolTip" xml:space="preserve">
+    <value>The total number of changed analyses since the last parse</value>
   </data>
   <data name="ksTotalDisapprovedAnalyses" xml:space="preserve">
     <value>Disapproved Analyses</value>

--- a/Src/LexText/ParserUI/ParserUIStrings.resx
+++ b/Src/LexText/ParserUI/ParserUIStrings.resx
@@ -296,7 +296,7 @@
     <value>Num Changed Analyses</value>
   </data>
   <data name="ksTotalChangedAnalysesToolTip" xml:space="preserve">
-    <value>The total number of changed analyses since the last parse</value>
+    <value>The total number of analyses that have changed since the last parse</value>
   </data>
   <data name="ksTotalDisapprovedAnalyses" xml:space="preserve">
     <value>Disapproved Analyses</value>


### PR DESCRIPTION
This implements https://jira.sil.org/browse/LT-22632.  It adds a column that reports the number of analyses that changed since the last time that a word was parsed.  This is only meaningful if Updates Word Analyses is disabled, so it hides the column if it is enabled.  This is useful if you are trying to speed up a grammar without changing any of the analyses.  Then you can
1) Parse a corpus to establish a baseline.
2) Disable Updates Word Analyses.
3) Make changes to the grammar.
4) Invoke Run tests on the corpus.
5) Verify that the number of changed analyses is zero for the corpus.
6) Verify that the corpus parses faster.
7) Go to step 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1024)
<!-- Reviewable:end -->
