### PR TITLE
Fix LT-22633

### DIFF
--- a/DistFiles/Language Explorer/Configuration/Words/Analyses/TraceParse/InitialDocument.htm
+++ b/DistFiles/Language Explorer/Configuration/Words/Analyses/TraceParse/InitialDocument.htm
@@ -1,6 +1,6 @@
 <html>
    <head>
-	  <title>The results of tyring a word will appear here</title>
+	  <title>The results of trying a word will appear here</title>
    </head>
    <body>
 	  <p>The results of trying a word will appear here when you click on the &ldquo;Try it&rdquo; button (or hit the Enter key).</p>

--- a/Src/LexText/ParserUI/TryAWordDlg.cs
+++ b/Src/LexText/ParserUI/TryAWordDlg.cs
@@ -366,6 +366,12 @@ namespace SIL.FieldWorks.LexText.Controls
 		#endregion
 		private void OnDomKeyPress(object sender, DomKeyEventArgs e)
 		{
+			if (!String.IsNullOrEmpty(m_htmlControl?.Browser?.DocumentTitle))
+			{
+				// Opening or closing the Find dialog only makes sense when showing parsing output.
+				// The initial and while tracing pages have titles; the parsing output page does not.
+				return;
+			}
 			var ctrl = e.CtrlKey;
 			if (ctrl && (char)e.KeyChar == 'f')
 			{

--- a/Src/xWorks/GeneratedHtmlViewer.cs
+++ b/Src/xWorks/GeneratedHtmlViewer.cs
@@ -1150,6 +1150,13 @@ namespace SIL.FieldWorks.XWorks
 			{
 				if (geckoBrowser == null)
 					throw new ApplicationException();
+				if (geckoBrowser.Window == null)
+				{
+					// This can happen when the user leaves the FLEx web browser-based tool
+					// while the find dialog is still open.  Close it and quit.
+					Close();
+					return;
+				}
 				using (var executor = new AutoJSContext(geckoBrowser.Window))
 				{
 					// Javascript query to execute in the browser


### PR DESCRIPTION
We have two places where we display information in a web browser. We allow users to invoke a Find dialog so they can more easily find what they are looking for.  There were two places where invoking the Find dilaog could cause a crash.  The reporter for LT-22633 found one of them.

The fix in GeneratedHtmlViewer.cs is for the case the reporter found.

The fix in TryAWordDlg.cs is for the other case I found. The simplest solution for it is to only allow the user to invoke the Find dialog when TryAWord is showing a parsing result page.  There is no need to let the user look for something with either the initial message page or the while trrying page.

There was a typo in the InitialDocument.htm title which is fixed (not that this is crucial...).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1025)
<!-- Reviewable:end -->
