### PR TITLE
LT-22572: Add IsDisposed check (cherry-pick to release/9.3.10)

### DIFF
--- a/Src/xWorks/XWorksViewBase.cs
+++ b/Src/xWorks/XWorksViewBase.cs
@@ -208,7 +208,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="clerk"></param>
 		internal void UpdateClerkEditable(RecordClerk clerk)
 		{
-			if (clerk != null)
+			if (clerk?.IsDisposed == false)
 			{
 				clerk.Editable = XmlUtils.GetOptionalBooleanAttributeValue(
 					m_configurationParameters,


### PR DESCRIPTION
Cherry-pick of 321ba8716 (#1026) from `main` to `release/9.3.10`.

Fixes three Jira defects with one IsDisposed check in `XWorksViewBase.UpdateClerkEditable`:
- [LT-22572](https://jira.sil.org/browse/LT-22572)
- [LT-22573](https://jira.sil.org/browse/LT-22573)
- [LT-22574](https://jira.sil.org/browse/LT-22574)

The regression was introduced with commit fd245f0c, which is present on `release/9.3.10`, so the fix applies there. The pick was clean (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1027)
<!-- Reviewable:end -->
