### PR TITLE
Patch on base build 1452

### DIFF
--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -39,11 +39,11 @@ on:
 # on Jenkins-built bases.
       base_release:
         description: 'The github release for the base build artifacts (separate only for bootstrapping; should be removed after 9.3 is the stable)'
-        default: 'build-1448' # When updating this, update base_build_number and their fallbacks below, too.
+        default: 'build-1452' # When updating this, update base_build_number and their fallbacks below, too.
       base_build_number:
         description: 'The base build number'
         required: false
-        default: '1448'
+        default: '1452'
       make_release:
         description: 'Should the release be pushed to s3 - use false for test builds'
         required: false
@@ -62,7 +62,7 @@ jobs:
       LcmRootDir: ${{ github.workspace }}/Localizations/LCM
       FILESTOSIGNLATER: ./signExternally
       GH_TOKEN: ${{ github.token }}
-      BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1448' }}
+      BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1452' }}
     name: Build Debug and run Tests
     runs-on: windows-2022
     steps:
@@ -170,7 +170,7 @@ jobs:
       - name: Import Base Build Artifacts
         shell: pwsh
         run: |
-          $release = "${{ inputs.base_release || 'build-1448' }}"
+          $release = "${{ inputs.base_release || 'build-1452' }}"
           $repo    = "${{ github.repository }}"
 
           Write-Host "Downloading artifacts for release $release from $repo"


### PR DESCRIPTION
## Summary

Bump the patch-installer-cd base-build defaults from build **1448** to build **1452**, the latest base build (published 2026-07-23, cut from `release/9.3.10`).

Updates all four references, per the workflow's own comment:
- `base_release` input default → `build-1452`
- `base_build_number` input default → `1452`
- `BASE_BUILD_NUMBER` env fallback (used by push/scheduled runs)
- `base_release` fallback in the Import Base Build Artifacts step

## Verification

- `gh release list` confirms `build-1452` is the newest base build release.
- `gh release view build-1452` confirms the release carries both assets the workflow downloads: `BuildDir.zip` and `ProcRunner.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1028)
<!-- Reviewable:end -->
