### PR TITLE
Fix LT-22633 match case box checked

### DIFF
--- a/Src/xWorks/GeneratedHtmlViewer.cs
+++ b/Src/xWorks/GeneratedHtmlViewer.cs
@@ -1083,6 +1083,11 @@ namespace SIL.FieldWorks.XWorks
 			}
 			private void matchCase_CheckedChanged(object sender, EventArgs e)
 			{
+				if (geckoBrowser?.Window == null)
+				{
+					Close();
+					return;
+				}
 				InvokeSearch(SearchText, matchCase.Checked);
 				using (var executor = new AutoJSContext(geckoBrowser.Window))
 				{


### PR DESCRIPTION
This is similar to the fix in https://github.com/sillsdev/FieldWorks/pull/1025.  I forgot to test the case where just the "March case" checkbox is checked while looking at the Problems view: since the view is no longer on the Grammar Sketch, the web bowser's window is null.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1030)
<!-- Reviewable:end -->
