### PR TITLE
LT-22644: Remove duplicate Master Refresh calls

### DIFF
--- a/Src/xWorks/FwXApp.cs
+++ b/Src/xWorks/FwXApp.cs
@@ -58,20 +58,16 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// This is the one (and should be only) handler for the user Refresh command.
-		/// Refresh wants to first clean up the cache, then give things like Clerks a
-		/// chance to reload stuff (calling the old OnRefresh methods), then give
-		/// windows a chance to redisplay themselves.
+		/// Refresh all main windows. This method is almost an exact duplicate of
+		/// FwXWindow.OnMasterRefresh(), but differing since this class overrides
+		/// ActiveForm. (Possible merge them into a single method.)
+		/// This method is intentionally NOT named OnMasterRefresh(), to prevent it from
+		/// being called by the Mediator's reflection dispatch. (LT-22644)
 		/// </summary>
-		public void OnMasterRefresh(object sender)
+		public void RefreshAllWindows()
 		{
-			// TODO: This is no longer called by the PropertyTable, since this class
-			// is no longer an xcore colleague. But, it can't be removed either,
-			// since it is used by another method on this clsss. :-(
 			CheckDisposed();
 
-			// Susanna asked that refresh affect only the currently active project, which is
-			// what the string and List variables below attempt to handle.  See LT-6444.
 			FwXWindow activeWnd = ActiveForm as FwXWindow;
 
 			List<FwXWindow> rgxw = new List<FwXWindow>();

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -101,13 +101,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			CheckDisposed();
 
-			// Susanna asked that refresh affect only the currently active project, which is
-			// what the string and List variables below attempt to handle.  See LT-6444.
 			FwXWindow activeWnd = ActiveForm as FwXWindow;
-
-			LcmCache activeCache = null;
-			if (activeWnd != null)
-				activeCache = activeWnd.Cache;
 
 			List<FwXWindow> rgxw = new List<FwXWindow>();
 			foreach (IFwMainWnd wnd in m_app.MainWindows)
@@ -115,11 +109,8 @@ namespace SIL.FieldWorks.XWorks
 				FwXWindow xwnd = wnd as FwXWindow;
 				if (xwnd != null)
 				{
-					if (activeCache == null || xwnd.Cache == activeCache)
-					{
-						xwnd.PrepareToRefresh();
-						rgxw.Add(xwnd);
-					}
+					xwnd.PrepareToRefresh();
+					rgxw.Add(xwnd);
 				}
 			}
 			if (activeWnd != null)
@@ -1336,7 +1327,7 @@ namespace SIL.FieldWorks.XWorks
 			// any writing systems are removed that a rootsite is currently displaying
 			if (m_app is FwXApp)
 			{
-				((FwXApp)m_app).OnMasterRefresh(null);
+				((FwXApp)m_app).RefreshAllWindows();
 			}
 
 			ReversalIndexServices.CreateOrRemoveReversalIndexConfigurationFiles(m_app.Cache.ServiceLocator.WritingSystemManager,
@@ -1350,7 +1341,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			if (m_app is FwXApp)
 			{
-				((FwXApp)m_app).OnMasterRefresh(null);
+				((FwXApp)m_app).RefreshAllWindows();
 			}
 		}
 
@@ -1675,9 +1666,9 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Called in FwXApp.OnMasterRefresh BEFORE clearing the cache, typically to
-		/// save any work in progress.
-		/// REVIEW (Hasso) 2023.07: 2/3 production callers call this in a foreach loop in OnMasterRefresh. There has to be a more efficient way.
+		/// Called during a master refresh (OnMasterRefresh / FwXApp.RefreshAllWindows)
+		/// BEFORE clearing the cache, typically to save any work in progress.
+		/// REVIEW (Hasso) 2023.07: 2/3 production callers call this in a foreach loop. There has to be a more efficient way.
 		/// </summary>
 		public void PrepareToRefresh()
 		{
@@ -1690,7 +1681,8 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Called in FwXApp.OnMasterRefresh AFTER clearing the cache, to reset everything.
+		/// Called during a master refresh (OnMasterRefresh / FwXApp.RefreshAllWindows)
+		/// AFTER clearing the cache, to reset everything.
 		/// </summary>
 		/// <returns></returns>
 		public bool FinishRefresh()
@@ -1880,7 +1872,7 @@ namespace SIL.FieldWorks.XWorks
 			if (m_delegate.ShowStylesDialog(paraStyleName, charStyleName, setPropsToFactorySettings))
 			{
 				// Need to refresh to reload the cache.  See LT-6265.
-				(m_app as FwXApp).OnMasterRefresh(null);
+				(m_app as FwXApp).RefreshAllWindows();
 
 				// Refresh the fonts on popup windows.
 				Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshPopupWindowFonts, null, this));


### PR DESCRIPTION
In FwXApp, renamed OnMasterRefresh() to RefreshAllWindows() so that it is not called from the Mediator.

Background:
Six code paths dispatch the MasterRefresh Mediator message in a mode that does not stop at the first handler
(SendMessageToAllNow or BroadcastMessage). In these paths the message was handled twice — once by FwXWindow.OnMasterRefresh() and again by FwXApp.OnMasterRefresh().

The call in FwXApp appears to be unintentional. There was a comment indicating that this class is no longer an xcore colleague and that the method only remains because there were some direct callers. Even though FwXApp is no longer directly a IxCoreColleague, LexTextApp derives from FwXApp and it is a IxCoreColleague, which resulted in the FwXApp.OnMasterRefresh() being called.

Notes:
- I removed the activeCache code from FwXWindow.OnMasterRefresh() since there has been only one cache per app for the past several years.
- I think FwXWindow.OnMasterRefresh() and FwXApp.RefreshAllWindows() now only differ because FwXApp overrides ActiveForm(). Possible in a future commit, merge these into one method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1031)
<!-- Reviewable:end -->
