### PR TITLE
LT-21402: Part 1 - Move MasterRefresh to Pub/Sub

### DIFF
--- a/Src/FdoUi/FdoUiCore.cs
+++ b/Src/FdoUi/FdoUiCore.cs
@@ -1166,9 +1166,7 @@ namespace SIL.FieldWorks.FdoUi
 					{
 						ReallyMergeUnderlyingObject(dlg.Hvo, fLoseNoTextData);
 						// Refresh in case "Sense Number" was 0 in the target and non-0 in the source (LT-22155).
-#pragma warning disable 618 // suppress obsolete warning
-						m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 					}
 				}
 			}

--- a/Src/LexText/Interlinear/InterlinearSfmImportWizard.cs
+++ b/Src/LexText/Interlinear/InterlinearSfmImportWizard.cs
@@ -16,6 +16,7 @@ using SIL.LCModel.Core.WritingSystems;
 using SIL.FieldWorks.Common.Controls;
 using SIL.FieldWorks.Common.Controls.FileDialog;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.FieldWorks.Common.RootSites;
 using SIL.LCModel;
 using SIL.LCModel.Infrastructure;
@@ -586,9 +587,7 @@ namespace SIL.FieldWorks.IText
 					Close();
 				}
 			}
-#pragma warning disable 618 // suppress obsolete warning
-			m_mediator.SendMessage("MasterRefresh", ActiveForm);
-#pragma warning restore 618
+			Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 			if (m_firstNewText != null)
 			{
 				// try to select it.

--- a/Src/LexText/LexTextDll/LexTextApp.cs
+++ b/Src/LexText/LexTextDll/LexTextApp.cs
@@ -420,9 +420,7 @@ namespace SIL.FieldWorks.XWorks.LexText
 							 dlg is LiftImportDlg || dlg is CombineImportDlg)
 					{
 						// Make everything we've imported visible.
-#pragma warning disable 618 // suppress obsolete warning
-						wndActive.Mediator.SendMessage("MasterRefresh", wndActive);
-#pragma warning restore 618
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, wndActive));
 					}
 				}
 			}

--- a/Src/LexText/Lexicon/ReversalListener.cs
+++ b/Src/LexText/Lexicon/ReversalListener.cs
@@ -731,9 +731,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			}
 			// Without this, stale data can still display in the BulkEditSenses tool if you
 			// recreate the deleted reversal index.
-#pragma warning disable 618 // suppress obsolete warning
-			m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+			Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 		}
 
 		internal static IReversalIndex ReversalIndexAfterDeletion(LcmCache cache, out int cobjNew)

--- a/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterInflFeatDlgListener.cs
@@ -123,13 +123,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 #pragma warning disable 618 // suppress obsolete warning
 						m_mediator.BroadcastMessageUntilHandled("JumpToRecord", dlg.SelectedFeatDefn.Hvo);
 #pragma warning restore 618
-						// LT-6412: this call will now cause the Mediator to be disposed while it is busy processing
-						// this call, so there is code in the Mediator to handle in the middle of a msg the case
-						// where the object is nolonger valid.  This has happend before and was being handled, this
-						// call "SendMessageToAllNow" has not had the code to handle the exception, so it was added.
-#pragma warning disable 618 // suppress obsolete warning
-						m_mediator.SendMessageToAllNow("MasterRefresh", cache.LangProject.MsFeatureSystemOA);
-#pragma warning restore 618
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 						break;
 				}
 			}

--- a/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
+++ b/Src/LexText/Morphology/MasterPhonFeatDlgListener.cs
@@ -135,13 +135,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 							m_mediator.BroadcastMessageUntilHandled("JumpToRecord", dlg.SelectedFeatDefn.Hvo);
 #pragma warning restore 618
 						}
-						// LT-6412: this call will now cause the Mediator to be disposed while it is busy processing
-						// this call, so there is code in the Mediator to handle in the middle of a msg the case
-						// where the object is nolonger valid.  This has happend before and was being handled, this
-						// call "SendMessageToAllNow" has not had the code to handle the exception, so it was added.
-#pragma warning disable 618 // suppress obsolete warning
-						m_mediator.SendMessageToAllNow("MasterRefresh", cache.LangProject.PhFeatureSystemOA);
-#pragma warning restore 618
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 						break;
 				}
 			}

--- a/Src/LexText/Morphology/RespellerDlg.cs
+++ b/Src/LexText/Morphology/RespellerDlg.cs
@@ -519,9 +519,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		{
 			if (ChangesWereMade)
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 			}
 			Close();
 		}

--- a/Src/xWorks/DTMenuHandler.cs
+++ b/Src/xWorks/DTMenuHandler.cs
@@ -626,9 +626,7 @@ namespace SIL.FieldWorks.XWorks
 				if (m_moveObj is IMoInflAffixSlot slot)
 				{
 					MoveSlot(slot, selectedPOS);
-#pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+					Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 				}
 				if (m_moveObj is IMoInflAffixTemplate template)
 				{

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -307,6 +307,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			Subscriber.Subscribe(EventConstants.JumpToPopupLexEntry, JumpToPopupLexEntry, this);
 			Subscriber.Subscribe(EventConstants.ConfigureCustomFields, ConfigureCustomFields, this);
+			Subscriber.Subscribe(EventConstants.MasterRefresh, OnMasterRefresh, this);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -435,6 +436,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				Subscriber.Unsubscribe(EventConstants.JumpToPopupLexEntry, JumpToPopupLexEntry);
 				Subscriber.Unsubscribe(EventConstants.ConfigureCustomFields, ConfigureCustomFields);
+				Subscriber.Unsubscribe(EventConstants.MasterRefresh, OnMasterRefresh);
 
 				if (m_viewHelper != null)
 					m_viewHelper.Dispose();
@@ -2014,9 +2016,7 @@ namespace SIL.FieldWorks.XWorks
 				var phonologyServices = new PhonologyServices(Cache);
 				phonologyServices.DeletePhonology();
 				phonologyServices.ImportPhonologyFromXml(filename);
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, this));
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Moved the easy SendMessage() and SendMessageToAllNow() calls that only execute while there is a single listener; FwXWindow.OnMasterRefresh(). The other existing listener, XhtmlDocView.OnMasterRefresh(), is not available from these workflows.
This change also moved two SendMessage() calls that can execute when both listeners are available, but the XhtmlDocView listener was incorrectly executing. This change fixes the following bug that existed when an import was run while a Dictionary or Reversal document view was active:
1. Open a project with a couple entries
2. Switch to Lexicon -> Dictionary View
3. File -> Import -> Lift Lexicon...
4. Import a lift file that contains a couple other entries and select OK.
Prior to this commit, the Dictionary View was not updating to display the imported entries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1033)
<!-- Reviewable:end -->
