### PR TITLE
LT-21402: Part 2 - Add DictionaryConfigured event

### DIFF
--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -84,10 +84,55 @@ namespace SIL.FieldWorks.XWorks
 		private bool _isHighlighted;
 
 		/// <summary>
-		/// Whether any changes have been saved, including changes to the Configs, which Config is the current Config, changes to Styles, etc.,
-		/// that require the preview to be updated.
+		/// The strongest refresh required by the changes saved so far (including changes to
+		/// the Configs, which Config is the current Config, changes to Styles, etc.).
 		/// </summary>
-		public bool MasterRefreshRequired { get; private set; }
+		public RefreshLevel RefreshRequired { get; private set; }
+
+		/// <summary>What the caller must refresh when the dialog closes.</summary>
+		public enum RefreshLevel
+		{
+			/// <summary>Nothing changed.</summary>
+			None,
+			/// <summary>Regenerate the generated dictionary content (the DictionaryConfigured event).</summary>
+			DictionaryContent,
+			/// <summary>Run the full master refresh (the MasterRefresh event); required when
+			/// settings rendered outside the generated dictionary content changed - styles,
+			/// or the global homograph configuration.</summary>
+			Master
+		}
+
+		/// <summary>Escalate the required refresh; a stronger requirement is never downgraded.</summary>
+		private void RequireRefresh(RefreshLevel level)
+		{
+			if (level > RefreshRequired)
+				RefreshRequired = level;
+		}
+
+		/// <summary>
+		/// The Styles dialog changed styles; they are rendered outside the generated
+		/// dictionary content, so regenerating that content is not enough. The full master
+		/// refresh is currently the only mechanism that reaches the other views; a narrower
+		/// invalidation could replace RefreshLevel.Master here if one is ever added.
+		/// </summary>
+		internal void HandleStylesDialogMadeChanges()
+		{
+			EnsureValidStylesInModel(_model, Cache); // in case the change was a rename or deletion
+			RefreshPreview(false);
+		}
+
+		/// <summary>
+		/// The Headword Numbers dialog updated the global homograph configuration singleton
+		/// (this happens even if the Configure dialog is later cancelled), which affects
+		/// headword rendering in views (e.g. the Browse Headword column) that a
+		/// dictionary-content regeneration does not reach. The full master refresh is
+		/// currently the only mechanism that reaches those views; a narrower invalidation
+		/// could replace RefreshLevel.Master here if one is ever added.
+		/// </summary>
+		internal void HandleHomographConfigurationChanged()
+		{
+			RequireRefresh(RefreshLevel.Master);
+		}
 
 		public enum ExclusionReasonCode
 		{
@@ -221,7 +266,7 @@ namespace SIL.FieldWorks.XWorks
 			if (isChangeInDictionaryModel)
 				m_isDirty = true;
 			else
-				MasterRefreshRequired = true;
+				RequireRefresh(RefreshLevel.Master);
 			//_propertyTable should be null only for unit tests which don't need styles
 			if (_propertyTable == null || _previewEntry == null || !_previewEntry.IsValidObject)
 				return;
@@ -372,7 +417,7 @@ namespace SIL.FieldWorks.XWorks
 					configurationManagerController.ConfigurationViewImported += () =>
 					{
 						SaveModel();
-						MasterRefreshRequired = false; // We're reloading the whole app, that's refresh enough
+						RefreshRequired = RefreshLevel.None; // We're reloading the whole app, that's refresh enough
 						View.Close();
 						Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", _propertyTable.GetWindow()));
 					};
@@ -497,7 +542,8 @@ namespace SIL.FieldWorks.XWorks
 				RefreshView();
 			};
 			SelectCurrentConfigurationAndRefresh();
-			MasterRefreshRequired = m_isDirty = false;
+			RefreshRequired = RefreshLevel.None;
+			m_isDirty = false;
 		}
 
 		/// <summary>
@@ -630,7 +676,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			// This property must be set *after* saving, because the initial save changes the FilePath
 			DictionaryConfigurationListener.SetCurrentConfiguration(_propertyTable, _model.FilePath, false);
-			MasterRefreshRequired = true;
+			RequireRefresh(RefreshLevel.DictionaryContent);
 			m_isDirty = false;
 		}
 
@@ -654,11 +700,8 @@ namespace SIL.FieldWorks.XWorks
 			{
 				DetailsController = new DictionaryDetailsController(new DetailsView(), _propertyTable);
 				DetailsController.DetailsModelChanged += (sender, e) => RefreshPreview();
-				DetailsController.StylesDialogMadeChanges += (sender, e) =>
-				{
-					EnsureValidStylesInModel(_model, Cache); // in case the change was a rename or deletion
-					RefreshPreview(false);
-				};
+				DetailsController.StylesDialogMadeChanges += (sender, e) => HandleStylesDialogMadeChanges();
+				DetailsController.HomographConfigurationChanged += (sender, e) => HandleHomographConfigurationChanged();
 				DetailsController.SelectedNodeChanged += (sender, e) =>
 				{
 					var nodeToSelect = sender as ConfigurableDictionaryNode;

--- a/Src/xWorks/DictionaryConfigurationListener.cs
+++ b/Src/xWorks/DictionaryConfigurationListener.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using System.Xml;
 using SIL.Extensions;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.FieldWorks.Common.RootSites;
 using SIL.FieldWorks.Common.Widgets;
 using SIL.LCModel;
@@ -216,7 +217,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <returns></returns>
 		public bool OnConfigureDictionary(object commandObject)
 		{
-			bool refreshNeeded;
+			DictionaryConfigurationController.RefreshLevel refreshRequired;
 			using (var dlg = new DictionaryConfigurationDlg(m_propertyTable))
 			{
 				var clerk = m_propertyTable.GetValue<RecordClerk>("ActiveClerk", null);
@@ -224,13 +225,18 @@ namespace SIL.FieldWorks.XWorks
 				dlg.Text = String.Format(xWorksStrings.ConfigureTitle, GetDictionaryConfigurationType(m_propertyTable));
 				dlg.HelpTopic = GetConfigDialogHelpTopic(m_propertyTable);
 				dlg.ShowDialog(m_propertyTable.GetValue<IWin32Window>("window"));
-				refreshNeeded = controller.MasterRefreshRequired;
+				refreshRequired = controller.RefreshRequired;
 			}
-			if (refreshNeeded)
+			switch (refreshRequired)
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+				case DictionaryConfigurationController.RefreshLevel.Master:
+					// Styles or the global homograph configuration changed; those are rendered
+					// outside the generated dictionary content, so run the full refresh.
+					Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
+					break;
+				case DictionaryConfigurationController.RefreshLevel.DictionaryContent:
+					Publisher.Publish(new PublisherParameterObject(EventConstants.DictionaryConfigured, null, m_propertyTable.GetWindow()));
+					break;
 			}
 			return true; // message handled
 		}

--- a/Src/xWorks/DictionaryDetailsController.cs
+++ b/Src/xWorks/DictionaryDetailsController.cs
@@ -54,6 +54,9 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>Fired whenever the Styles dialog makes changes that require the dictionary preview to be refreshed</summary>
 		public event EventHandler StylesDialogMadeChanges;
 
+		/// <summary>Fired when the Headword Numbers dialog changes the global homograph configuration</summary>
+		public event EventHandler HomographConfigurationChanged;
+
 		/// <summary>Fired whenever the selected node is changed, so that the node tree can be refreshed</summary>
 		public event EventHandler SelectedNodeChanged;
 
@@ -878,6 +881,10 @@ namespace SIL.FieldWorks.XWorks
 				if (dlg.ShowDialog(View.TopLevelControl) != DialogResult.OK)
 					return;
 				controller.Save();
+				// Save() exports the settings to the global HomographConfiguration singleton,
+				// which affects headword rendering outside the generated dictionary content.
+				if (HomographConfigurationChanged != null)
+					HomographConfigurationChanged(m_node, new EventArgs());
 				RefreshPreview();
 			}
 		}

--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -81,6 +81,20 @@ namespace SIL.FieldWorks.XWorks
 					browser.DomMouseScroll += OnMouseWheel;
 				}
 			}
+			Subscriber.Subscribe(EventConstants.DictionaryConfigured, RefreshAllContent, m_propertyTable.GetWindow());
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// Must not be run more than once.
+			if (IsDisposed)
+				return;
+
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DictionaryConfigured, RefreshAllContent);
+			}
+			base.Dispose(disposing);
 		}
 
 		private void OnMouseWheel(object sender, DomMouseEventArgs domMouseEventArgs)
@@ -626,7 +640,7 @@ namespace SIL.FieldWorks.XWorks
 			var mediator = tagObjects[1] as Mediator;
 			var nodeId = tagObjects[2] as string;
 			var guid = (Guid)tagObjects[3];
-			bool refreshNeeded;
+			DictionaryConfigurationController.RefreshLevel refreshRequired;
 			using (var dlg = new DictionaryConfigurationDlg(propertyTable))
 			{
 				var cache = propertyTable.GetValue<LcmCache>("cache");
@@ -641,13 +655,18 @@ namespace SIL.FieldWorks.XWorks
 				dlg.Text = String.Format(xWorksStrings.ConfigureTitle, DictionaryConfigurationListener.GetDictionaryConfigurationType(propertyTable));
 				dlg.HelpTopic = DictionaryConfigurationListener.GetConfigDialogHelpTopic(propertyTable);
 				dlg.ShowDialog(propertyTable.GetValue<IWin32Window>("window"));
-				refreshNeeded = controller.MasterRefreshRequired;
+				refreshRequired = controller.RefreshRequired;
 			}
-			if (refreshNeeded)
+			switch (refreshRequired)
 			{
-#pragma warning disable 618 // suppress obsolete warning
-				mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+				case DictionaryConfigurationController.RefreshLevel.Master:
+					// Styles or the global homograph configuration changed; those are rendered
+					// outside the generated dictionary content, so run the full refresh.
+					Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, propertyTable.GetWindow()));
+					break;
+				case DictionaryConfigurationController.RefreshLevel.DictionaryContent:
+					Publisher.Publish(new PublisherParameterObject(EventConstants.DictionaryConfigured, null, propertyTable.GetWindow()));
+					break;
 			}
 		}
 
@@ -1133,7 +1152,7 @@ namespace SIL.FieldWorks.XWorks
 					break;
 				case "ShowFailingItems-lexiconClassifiedDictionary":
 					// When this property changes, we just need to refresh the current page.
-					OnMasterRefresh(this);
+					RefreshAllContent(null);
 					break;
 				default:
 					// Not sure what other properties might change, but I'm not doing anything.
@@ -1153,7 +1172,7 @@ namespace SIL.FieldWorks.XWorks
 			var currentPageRange = new Tuple<int, int>(int.Parse(currentPage.Attributes["startIndex"].NodeValue), int.Parse(currentPage.Attributes["endIndex"].NodeValue));
 			if (currentObjectIndex < currentPageRange.Item1 || currentObjectIndex > currentPageRange.Item2)
 			{
-				OnMasterRefresh(this); // Reload the page
+				RefreshAllContent(null); // Reload the page
 			}
 		}
 
@@ -1293,7 +1312,22 @@ namespace SIL.FieldWorks.XWorks
 
 		#endregion
 
+		/// <summary>
+		/// Mediator handler for the user Refresh command (F5/CmdRefresh) and for the deferred
+		/// MasterRefresh broadcasts not yet converted to Pub/Sub. This view is a High-priority
+		/// colleague, so for stop-when-handled sends it intercepts MasterRefresh and regenerates
+		/// only its own content instead of running the window's full refresh (LT-16365).
+		/// </summary>
 		public void OnMasterRefresh(object sender)
+		{
+			RefreshAllContent(null);
+		}
+
+		/// <summary>
+		/// Regenerate this view's XHTML content, ensuring the selected publication is valid for
+		/// the current configuration. Subscribed to the Pub/Sub DictionaryConfigured event.
+		/// </summary>
+		private void RefreshAllContent(object _)
 		{
 			var currentConfig = GetCurrentConfiguration(false);
 			var currentPublication = GetCurrentPublication();
@@ -1309,7 +1343,7 @@ namespace SIL.FieldWorks.XWorks
 
 		public bool RefreshDisplay()
 		{
-			OnMasterRefresh(this);
+			RefreshAllContent(null);
 			return true;
 		}
 

--- a/Src/xWorks/XhtmlRecordDocView.cs
+++ b/Src/xWorks/XhtmlRecordDocView.cs
@@ -4,6 +4,7 @@
 
 using Gecko;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.Utils;
@@ -75,6 +76,29 @@ namespace SIL.FieldWorks.XWorks
 			m_fullyInitialized = true;
 			// Add ourselves as a listener for changes to the item we are displaying
 			Clerk.VirtualListPublisher.AddNotification(this);
+			Subscriber.Subscribe(EventConstants.DictionaryConfigured, RefreshPreviewContent, m_propertyTable.GetWindow());
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// Must not be run more than once.
+			if (IsDisposed)
+				return;
+
+			if (disposing)
+			{
+				Subscriber.Unsubscribe(EventConstants.DictionaryConfigured, RefreshPreviewContent);
+			}
+			base.Dispose(disposing);
+		}
+
+		/// <summary>
+		/// Regenerate the preview for the current record. Subscribed to the Pub/Sub
+		/// DictionaryConfigured event so the preview reflects configuration changes.
+		/// </summary>
+		private void RefreshPreviewContent(object _)
+		{
+			ShowRecord();
 		}
 
 		/// <summary>

--- a/Src/xWorks/xWorksTests/DictionaryConfigurationControllerTests.cs
+++ b/Src/xWorks/xWorksTests/DictionaryConfigurationControllerTests.cs
@@ -1679,7 +1679,8 @@ namespace SIL.FieldWorks.XWorks
 				//SUT
 				dcc.View.TreeControl.Tree.TopNode.Checked = false;
 				((TestConfigurableDictionaryView)dcc.View).DoSaveModel();
-				Assert.That(dcc.MasterRefreshRequired, Is.True, "Should have saved changes and required a Master Refresh");
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.DictionaryContent),
+					"Should have saved changes and required a refresh of the dictionary content");
 				DeleteConfigurationTestModelFiles(dcc);
 			}
 		}
@@ -1701,7 +1702,8 @@ namespace SIL.FieldWorks.XWorks
 				var dcc = new DictionaryConfigurationController(testView, m_propertyTable, null, entryWithHeadword);
 				//SUT
 				dcc.View.TreeControl.Tree.TopNode.Checked = false;
-				Assert.That(dcc.MasterRefreshRequired, Is.False, "Should not have saved changes--user did not click OK or Apply");
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.None),
+					"Should not have saved changes--user did not click OK or Apply");
 				DeleteConfigurationTestModelFiles(dcc);
 			}
 		}
@@ -1723,7 +1725,87 @@ namespace SIL.FieldWorks.XWorks
 				var dcc = new DictionaryConfigurationController(testView, m_propertyTable, null, entryWithHeadword);
 				//SUT
 				((TestConfigurableDictionaryView)dcc.View).DoSaveModel();
-				Assert.That(dcc.MasterRefreshRequired, Is.False, "Should not have saved changes--none to save");
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.None),
+					"Should not have saved changes--none to save");
+				DeleteConfigurationTestModelFiles(dcc);
+			}
+		}
+
+		[Test]
+		public void StylesDialogChangesRequireMasterRefresh()
+		{
+			var headwordNode = new ConfigurableDictionaryNode();
+			var entryNode = new ConfigurableDictionaryNode { Children = new List<ConfigurableDictionaryNode> { headwordNode } };
+			m_model.Parts = new List<ConfigurableDictionaryNode> { entryNode };
+			CssGeneratorTests.PopulateFieldsForTesting(m_model);
+			using (var testView = new TestConfigurableDictionaryView())
+			{
+				var entryWithHeadword = CreateLexEntryWithHeadword();
+
+				m_propertyTable.SetProperty("currentContentControl", "lexiconDictionary", false);
+				Cache.ProjectId.Path = Path.Combine(FwDirectoryFinder.SourceDirectory, "xWorks/xWorksTests/TestData/");
+
+				var dcc = new DictionaryConfigurationController(testView, m_propertyTable, null, entryWithHeadword);
+				//SUT
+				dcc.HandleStylesDialogMadeChanges();
+				// Styles are rendered outside the generated dictionary content, so this must never
+				// weaken to DictionaryContent/None. Master is currently the only stronger level; if a
+				// narrower invalidation that still reaches the other views is ever added, it is fine
+				// to update this assertion deliberately.
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.Master),
+					"Styles changes must refresh more than the generated dictionary content");
+				DeleteConfigurationTestModelFiles(dcc);
+			}
+		}
+
+		[Test]
+		public void HomographConfigurationChangesRequireMasterRefresh()
+		{
+			var headwordNode = new ConfigurableDictionaryNode();
+			var entryNode = new ConfigurableDictionaryNode { Children = new List<ConfigurableDictionaryNode> { headwordNode } };
+			m_model.Parts = new List<ConfigurableDictionaryNode> { entryNode };
+			CssGeneratorTests.PopulateFieldsForTesting(m_model);
+			using (var testView = new TestConfigurableDictionaryView())
+			{
+				var entryWithHeadword = CreateLexEntryWithHeadword();
+
+				m_propertyTable.SetProperty("currentContentControl", "lexiconDictionary", false);
+				Cache.ProjectId.Path = Path.Combine(FwDirectoryFinder.SourceDirectory, "xWorks/xWorksTests/TestData/");
+
+				var dcc = new DictionaryConfigurationController(testView, m_propertyTable, null, entryWithHeadword);
+				//SUT
+				dcc.HandleHomographConfigurationChanged();
+				// Homograph numbers are rendered outside the generated dictionary content (e.g. the
+				// Browse Headword column), so this must never weaken to DictionaryContent/None. Master
+				// is currently the only stronger level; if a narrower invalidation that still reaches
+				// those views is ever added, it is fine to update this assertion deliberately.
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.Master),
+					"Homograph configuration changes must refresh more than the generated dictionary content");
+				DeleteConfigurationTestModelFiles(dcc);
+			}
+		}
+
+		[Test]
+		public void SavingAfterHomographConfigurationChangeDoesNotDowngradeRefreshLevel()
+		{
+			var headwordNode = new ConfigurableDictionaryNode();
+			var entryNode = new ConfigurableDictionaryNode { Children = new List<ConfigurableDictionaryNode> { headwordNode } };
+			m_model.Parts = new List<ConfigurableDictionaryNode> { entryNode };
+			CssGeneratorTests.PopulateFieldsForTesting(m_model);
+			using (var testView = new TestConfigurableDictionaryView())
+			{
+				var entryWithHeadword = CreateLexEntryWithHeadword();
+
+				m_propertyTable.SetProperty("currentContentControl", "lexiconDictionary", false);
+				Cache.ProjectId.Path = Path.Combine(FwDirectoryFinder.SourceDirectory, "xWorks/xWorksTests/TestData/");
+
+				var dcc = new DictionaryConfigurationController(testView, m_propertyTable, null, entryWithHeadword);
+				//SUT
+				dcc.HandleHomographConfigurationChanged();
+				dcc.View.TreeControl.Tree.TopNode.Checked = false;
+				((TestConfigurableDictionaryView)dcc.View).DoSaveModel();
+				Assert.That(dcc.RefreshRequired, Is.EqualTo(DictionaryConfigurationController.RefreshLevel.Master),
+					"Saving the configuration afterwards must not downgrade the required refresh to a weaker level");
 				DeleteConfigurationTestModelFiles(dcc);
 			}
 		}


### PR DESCRIPTION
## Summary

The Configure Dictionary dialog senders did not really mean "MasterRefresh"; they meant
"the dictionary configuration (or its styles) changed — regenerate any view that renders
generated dictionary content". Under the Mediator that intent was routed by dispatch
tricks: in the XHTML document views (Dictionary, Reversal Indexes, Classified Dictionary)
`XhtmlDocView`'s High-priority stop-when-handled intercept turned the message into a cheap
content-only regeneration, while in Lexicon Edit/Browse the window ran a full master
refresh whose only needed effect was that the dictionary preview pane regenerated as a
side effect.

Pub/Sub has no priority or stop-when-handled, so this PR names the intent,
**`DictionaryConfigured`**, as its own event instead.

## Changes

- The two senders — `DictionaryConfigurationListener.OnConfigureDictionary`
  (Tools → Configure) and `XhtmlDocView.RunConfigureDialogAt` (right-click Configure) —
  publish `DictionaryConfigured` (window-scoped) when configuration changes were saved.
- `XhtmlDocView`: the `OnMasterRefresh` handler body is renamed to `RefreshAllContent`
  and subscribed to `DictionaryConfigured` (Init/Dispose). A thin public
  `OnMasterRefresh()` wrapper remains so the Mediator still reaches the view for F5 and
  for the broadcast calls not yet converted to Pub/Sub.
- `XhtmlRecordDocView` (the Lexicon Edit dictionary preview pane) subscribes a new
  `RefreshPreviewContent` handler, so the preview still updates now that Configure
  Dictionary no longer triggers a full refresh. Closing the dialog from Lexicon Edit is
  therefore much cheaper: the preview regenerates directly instead of riding on a
  full-application refresh.
- Changes made through the dialog's **sub-dialogs** to settings rendered *outside* the
  generated dictionary content — styles, and the global homograph configuration
  (Headword Numbers) — still require the full master refresh (e.g. the Browse view's
  Headword column shows homograph numbers). To track this, the controller's
  `MasterRefreshRequired` bool is replaced by a `RefreshRequired` enum
  (`None` / `DictionaryContent` / `Master`) that only escalates; the senders publish
  `MasterRefresh` or `DictionaryConfigured` accordingly. The full master refresh is
  currently the only mechanism that reaches the affected views; a narrower invalidation
  could replace the `Master` level for these causes if one is ever added.

## Bugs fixed

- **Stale homograph numbers after cancelling Configure Dictionary:** the Headword Numbers
  dialog updates the global homograph configuration immediately, so cancelling the
  Configure dialog afterwards left stale homograph numbers everywhere; the escalated flag
  survives the cancel and the refresh now runs.
- **Stale hidden views after styles/homograph changes from document views:** the old
  High-priority intercept did only the content regeneration; these changes now do the
  full refresh from every tool.

## Note for reviewers familiar with the PubSub branch

Much of this work was pulled from PubSub-branch commit 5786f6f3. **Unlike that commit,
the views do not also subscribe to `MasterRefresh` itself** — the full refresh already
regenerates them via the `RefreshDisplay` walk, so those subscriptions would have doubled
the (expensive) content generation on every full refresh with a doc view open.

## Behavior notes

- Window-scoped: with multiple windows open, only the window that ran the dialog
  regenerates; others catch up on their next refresh. (The document-view case already
  behaved this way; this makes the Lexicon Edit case consistent with it.)

## Testing

- All automated tests pass; `DictionaryConfigurationControllerTests` green at 94,
  including three new tests pinning the styles and homograph paths to
  `RefreshLevel.Master` and guarding the no-downgrade escalation.
- Manual tests: Configure Dictionary from all five tools (doc views regenerate; Lexicon
  Edit preview updates without full refresh; Browse no-ops for pure config edits);
  right-click Configure from both the Dictionary view and the Lexicon Edit preview pane;
  homograph changes from Lexicon Edit / Browse / with outer-dialog Cancel (full refresh,
  Headword column updates); styles definition change via the dialog (full refresh on
  dialog close); F5 regression in both doc views and Lexicon Edit; custom-fields
  broadcast regression; multi-window scoping; tool-switch subscription lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1038)
<!-- Reviewable:end -->
