### PR TITLE
LT-21402: Part 3 - Move MasterRefresh to Pub/Sub (Insert/Delete)

### DIFF
--- a/Src/Common/FwUtils/EventConstants.cs
+++ b/Src/Common/FwUtils/EventConstants.cs
@@ -32,6 +32,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 		public const string PrepareToRefresh = "PrepareToRefresh";
 		public const string RecordNavigation = "RecordNavigation";
 		public const string RefreshCurrentList = "RefreshCurrentList";
+		public const string RefreshCurrentView = "RefreshCurrentView";
 		public const string RefreshInterlin = "RefreshInterlin";
 		public const string RefreshPopupWindowFonts = "RefreshPopupWindowFonts";
 		public const string ReloadAreaTools = "ReloadAreaTools";

--- a/Src/LexText/LexTextControls/EntryDlgListener.cs
+++ b/Src/LexText/LexTextControls/EntryDlgListener.cs
@@ -96,8 +96,15 @@ namespace SIL.FieldWorks.LexText.Controls
 					bool newby;
 					dlg.GetDialogInfo(out entry, out newby);
 					// No need for a PropChanged here because InsertEntryDlg takes care of that. (LT-3608)
+					// Two-stage refresh: if the active content control can satisfy the request by
+					// regenerating its own content (the XHTML document views), skip the full refresh.
+					var refreshRequest = new ReturnObject(null);
+					Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshCurrentView, refreshRequest, m_propertyTable.GetWindow()));
+					if (!refreshRequest.ReturnValue)
+					{
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
+					}
 #pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("MasterRefresh", null);
 					m_mediator.SendMessage("JumpToRecord", entry.Hvo);
 #pragma warning restore 618
 				}

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -1547,9 +1547,14 @@ namespace SIL.FieldWorks.XWorks
 							}
 						}
 					}
-#pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("MasterRefresh", null);
-#pragma warning restore 618
+					// Two-stage refresh: if the active content control can satisfy the request by
+					// regenerating its own content (the XHTML document views), skip the full refresh.
+					var refreshRequest = new ReturnObject(null);
+					Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshCurrentView, refreshRequest, m_propertyTable.GetWindow()));
+					if (!refreshRequest.ReturnValue)
+					{
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
+					}
 				}
 			}
 		}

--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -82,6 +82,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 			}
 			Subscriber.Subscribe(EventConstants.DictionaryConfigured, RefreshAllContent, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.RefreshCurrentView, RefreshCurrentView, m_propertyTable.GetWindow());
 		}
 
 		protected override void Dispose(bool disposing)
@@ -93,6 +94,7 @@ namespace SIL.FieldWorks.XWorks
 			if (disposing)
 			{
 				Subscriber.Unsubscribe(EventConstants.DictionaryConfigured, RefreshAllContent);
+				Subscriber.Unsubscribe(EventConstants.RefreshCurrentView, RefreshCurrentView);
 			}
 			base.Dispose(disposing);
 		}
@@ -1321,6 +1323,27 @@ namespace SIL.FieldWorks.XWorks
 		public void OnMasterRefresh(object sender)
 		{
 			RefreshAllContent(null);
+		}
+
+		/// <summary>
+		/// First stage of a sender's two-stage refresh request: while this view is the active
+		/// content control it claims the request and satisfies it by regenerating its own
+		/// content, so the sender skips the full master refresh.
+		/// </summary>
+		private void RefreshCurrentView(object obj)
+		{
+			if (!(obj is ReturnObject retObj))
+			{
+				Debug.Assert(false, "Received unexpected object type.");
+				return;
+			}
+			// Return if already handled by another Subscriber.
+			if (retObj.ReturnValue)
+			{
+				return;
+			}
+			RefreshAllContent(null);
+			retObj.ReturnValue = true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary

Converts the last two synchronous MasterRefresh senders —
`InsertEntryDlgListener.DialogInsertItemInVector` (Insert Entry) and
`RecordClerk.OnDeleteRecord` (Delete Record) — completing the synchronous half of the
LT-21402 migration (follows #1033 and #1038).

These two were deliberately excluded from Part 1: both commands update the cache directly
(UOW + PropChanged), so when an XHTML document view is active, the Mediator's
High-priority stop-when-handled intercept correctly satisfied the refresh with a fast
content-only reload; the full master refresh was only needed in the other tools.
Converting them to a plain `Publish(MasterRefresh)` would have turned that fast, correct
reload into a needless full refresh.

## Design: two-stage refresh request

Pub/Sub has no priority or stop-when-handled, so the intercept is replaced with a
two-stage request, using the same `ReturnObject` idiom as the `DialogInsertItemInVector`
conversions (see `RecordClerk.OnInsertItemInVector`):

- New event **`RefreshCurrentView`**. The sender publishes it (window-scoped) with a
  `ReturnObject`; a subscriber that can satisfy the request by regenerating its own
  content sets `ReturnValue`. If no subscriber claims the request, the sender publishes
  `MasterRefresh` instead.
- `XhtmlDocView` subscribes while it exists (Init/Dispose) — i.e. exactly while its tool
  is the active content control — so the subscription lifetime does the routing that
  colleague priority used to do.
- `XhtmlRecordDocView` (the Lexicon Edit preview pane) deliberately does **not**
  subscribe: in Lexicon Edit these commands do the full refresh today, and that is
  preserved.

Behavior is unchanged: content-only reload when a Dictionary, Reversal Indexes, or
Classified Dictionary document view is active; full master refresh everywhere else.

The `JumpToRecord` send next to the Insert Entry site stays on the Mediator; that message
is a separate conversion.

## Remaining MasterRefresh work (future PRs)

Still on the Mediator: the F5/CmdRefresh menu command (which can reuse this two-stage
pattern when converted), four deferred `BroadcastMessage` senders, and one `PostMessage`
sender — each needs per-site timing analysis before conversion.

## Testing

- Build clean; no automated-test changes (dispatch-only change; behavior covered by
  manual tests).
- Manual: Insert Entry and Delete Record from the Dictionary view (content-only reload,
  `FwXWindow.OnMasterRefresh` not invoked, jump-to-new-entry intact) and from Lexicon
  Edit (full refresh, unchanged); reversal document view delete; multi-window scoping
  (single dispatch, focus retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1039)
<!-- Reviewable:end -->
