### PR TITLE
Fix LT-22578: dialog window Z order issues

### DIFF
--- a/Src/Common/Controls/DetailControls/ChooserCommand.cs
+++ b/Src/Common/Controls/DetailControls/ChooserCommand.cs
@@ -33,6 +33,15 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			m_slot = slot;
 		}
 
+		/// <summary>
+		/// This command opens the modal New Entry dialog, so have the chooser keep the main window
+		/// active as it hides, to avoid another application flashing in front first.
+		/// </summary>
+		public override bool KeepOwnerActiveWhenHiding
+		{
+			get { return true; }
+		}
+
 		//methods
 
 		public override ObjectLabel Execute()

--- a/Src/Common/Controls/DetailControls/DetailControlsTests/ChooserCommandKeepOwnerActiveWhenHidingTests.cs
+++ b/Src/Common/Controls/DetailControls/DetailControlsTests/ChooserCommandKeepOwnerActiveWhenHidingTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using NUnit.Framework;
+
+namespace SIL.FieldWorks.Common.Framework.DetailControls
+{
+	/// <summary>
+	/// Guards the KeepOwnerActiveWhenHiding opt-in contract for the affix chooser commands
+	/// (LT-22578). A chooser command whose Execute() opens another modal dialog must return true
+	/// so ReallySimpleListChooser.HideForCommand re-activates the FLEx main window as the chooser
+	/// hides; without it an unrelated application can flash in front while the new dialog loads. A
+	/// command that opens no dialog must stay false (the base default). The flag is the only part
+	/// of the fix that is deterministic and UI-free; the actual owner activation and window
+	/// Z-order require a live message pump and are verified manually.
+	/// </summary>
+	[TestFixture]
+	public class ChooserCommandKeepOwnerActiveWhenHidingTests
+	{
+		/// <summary>
+		/// Opens the modal New Entry dialog (InsertEntryDlg), so it must opt in.
+		/// </summary>
+		[Test]
+		public void MakeInflAffixEntryChooserCommand_OptsIn()
+		{
+			var command = new MakeInflAffixEntryChooserCommand(
+				null, true, "label", true, null, null, null);
+			Assert.That(command.KeepOwnerActiveWhenHiding, Is.True);
+		}
+
+		/// <summary>
+		/// Creates a slot without opening a dialog, so it keeps the base default of false. This
+		/// also exercises the base ChooserCommand default (this command does not override it).
+		/// </summary>
+		[Test]
+		public void MakeInflAffixSlotChooserCommand_DoesNotOptIn()
+		{
+			var command = new MakeInflAffixSlotChooserCommand(
+				null, true, "label", 0, false, null, null);
+			Assert.That(command.KeepOwnerActiveWhenHiding, Is.False);
+		}
+	}
+}

--- a/Src/Common/Controls/XMLViews/ChooserCommandBase.cs
+++ b/Src/Common/Controls/XMLViews/ChooserCommandBase.cs
@@ -97,6 +97,20 @@ namespace SIL.FieldWorks.Common.Controls
 				m_fShouldCloseBeforeExecuting = value;
 			}
 		}
+
+		/// <summary>
+		/// When true, the chooser re-enables its owner window just before hiding itself to run this
+		/// command. Execute() for such a command opens another modal dialog, which re-disables the
+		/// owner; re-enabling it first makes the OS return activation to the FLEx main window when
+		/// the chooser hides, instead of momentarily revealing an unrelated application's window.
+		/// Defaults to false so behavior is unchanged for every command that does not opt in. See
+		/// the "Create new inflectional affix" flow (LT-22578).
+		/// </summary>
+		public virtual bool KeepOwnerActiveWhenHiding
+		{
+			get { return false; }
+		}
+
 		/// <summary>
 		/// The entire text of the label that will appear in the chooser
 		/// </summary>

--- a/Src/Common/Controls/XMLViews/ReallySimpleListChooser.cs
+++ b/Src/Common/Controls/XMLViews/ReallySimpleListChooser.cs
@@ -2281,6 +2281,27 @@ namespace SIL.FieldWorks.Common.Controls
 		}
 		#endregion
 
+		/// <summary>
+		/// Hide the chooser before running <paramref name="cmd"/>. When the command opts in via
+		/// KeepOwnerActiveWhenHiding (its Execute() opens another modal dialog), re-enable and then
+		/// re-activate our owner around the hide. While the chooser is modal the OS has disabled the
+		/// owner, so hiding alone would hand the foreground to another application (the next window
+		/// by z-order) instead of back to the FLEx main window, causing a brief flash. Re-enabling is
+		/// not enough on its own; the Activate() is what pulls FLEx forward, and it is not blocked by
+		/// the foreground lock because we are still the foreground process here (LT-22578).
+		/// </summary>
+		private void HideForCommand(ChooserCommand cmd)
+		{
+			if (cmd != null && cmd.KeepOwnerActiveWhenHiding && Owner != null)
+			{
+				Owner.Enabled = true;
+				Visible = false;
+				Owner.Activate();
+				return;
+			}
+			Visible = false;
+		}
+
 		private void HandleCommmandChoice(ChooserCommandNode node)
 		{
 			if (node != null)
@@ -2289,7 +2310,7 @@ namespace SIL.FieldWorks.Common.Controls
 				if (cmd != null)
 				{
 					if (cmd.ShouldCloseBeforeExecuting)
-						Visible = false;
+						HideForCommand(cmd);
 					m_chosenLabel = cmd.Execute();
 				}
 			}
@@ -2300,7 +2321,7 @@ namespace SIL.FieldWorks.Common.Controls
 			Persist();
 			if (m_linkCmd != null)
 			{
-				Visible = false;
+				HideForCommand(m_linkCmd);
 				m_chosenLabel = m_linkCmd.Execute();
 				m_fLinkExecuted = true;
 			}

--- a/Src/LexText/Lexicon/EntrySequenceReferenceLauncher.cs
+++ b/Src/LexText/Lexicon/EntrySequenceReferenceLauncher.cs
@@ -126,7 +126,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 					chooser.InitializeExtras(null, Mediator, m_propertyTable);
 					chooser.AddLink(LexEdStrings.ksAddAComponent, ReallySimpleListChooser.LinkType.kDialogLink,
 						new AddPrimaryLexemeChooserCommand(m_cache, false, null, m_mediator, m_propertyTable, m_obj, FindForm()));
-					DialogResult res = chooser.ShowDialog();
+					DialogResult res = chooser.ShowDialog(FindForm());
 					if (DialogResult.Cancel == res)
 						return;
 					if (chooser.ChosenObjects != null)
@@ -204,7 +204,7 @@ namespace SIL.FieldWorks.XWorks.LexEd
 				// Step 3 of LT-11155:
 				chooser.AddLink(LexEdStrings.ksAddAComplexForm, ReallySimpleListChooser.LinkType.kDialogLink,
 					new AddComplexFormChooserCommand(m_cache, false, null, m_mediator, m_propertyTable, m_obj, FindForm()));
-				DialogResult res = chooser.ShowDialog();
+				DialogResult res = chooser.ShowDialog(FindForm());
 				if (DialogResult.Cancel == res)
 					return;
 				var chosenObjects = chooser.ChosenObjects;
@@ -353,6 +353,15 @@ namespace SIL.FieldWorks.XWorks.LexEd
 			m_parentWindow = parentWindow;
 		}
 
+		/// <summary>
+		/// This command opens the modal LinkEntryOrSenseDlg, so have the chooser keep the main
+		/// window active as it hides, to avoid another application flashing in front first.
+		/// </summary>
+		public override bool KeepOwnerActiveWhenHiding
+		{
+			get { return true; }
+		}
+
 		public override ObjectLabel Execute()
 		{
 			ObjectLabel result = null;
@@ -424,6 +433,15 @@ namespace SIL.FieldWorks.XWorks.LexEd
 
 			}
 			m_parentWindow = parentWindow;
+		}
+
+		/// <summary>
+		/// This command opens the modal EntryGoDlg, so have the chooser keep the main window
+		/// active as it hides, to avoid another application flashing in front first.
+		/// </summary>
+		public override bool KeepOwnerActiveWhenHiding
+		{
+			get { return true; }
 		}
 
 		public override ObjectLabel Execute()

--- a/Src/LexText/Lexicon/LexEdDllTests/EntrySequenceChooserCommandKeepOwnerActiveWhenHidingTests.cs
+++ b/Src/LexText/Lexicon/LexEdDllTests/EntrySequenceChooserCommandKeepOwnerActiveWhenHidingTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using NUnit.Framework;
+using SIL.FieldWorks.XWorks.LexEd;
+
+namespace LexEdDllTests
+{
+	/// <summary>
+	/// Guards the KeepOwnerActiveWhenHiding opt-in contract for the Lexicon "Add a Component" and
+	/// "Add a Complex Form" chooser commands (LT-22578). Both are launched from a chooser that
+	/// hides itself and then open a modal dialog (LinkEntryOrSenseDlg / EntryGoDlg), so both must
+	/// opt in to keep an unrelated application from flashing in front while the dialog loads. See
+	/// ChooserCommandKeepOwnerActiveWhenHidingTests (DetailControls) for the affix equivalents and
+	/// the rationale for why only the opt-in flag is unit-tested.
+	/// </summary>
+	[TestFixture]
+	public class EntrySequenceChooserCommandKeepOwnerActiveWhenHidingTests
+	{
+		/// <summary>
+		/// "Add a Component" opens the modal LinkEntryOrSenseDlg, so it must opt in.
+		/// </summary>
+		[Test]
+		public void AddPrimaryLexemeChooserCommand_OptsIn()
+		{
+			var command = new AddPrimaryLexemeChooserCommand(
+				null, false, "label", null, null, null, null);
+			Assert.That(command.KeepOwnerActiveWhenHiding, Is.True);
+		}
+
+		/// <summary>
+		/// "Add a Complex Form" opens the modal EntryGoDlg, so it must opt in.
+		/// </summary>
+		[Test]
+		public void AddComplexFormChooserCommand_OptsIn()
+		{
+			var command = new AddComplexFormChooserCommand(
+				null, false, "label", null, null, null, null);
+			Assert.That(command.KeepOwnerActiveWhenHiding, Is.True);
+		}
+	}
+}

--- a/Src/LexText/Morphology/InflAffixTemplateControl.cs
+++ b/Src/LexText/Morphology/InflAffixTemplateControl.cs
@@ -412,7 +412,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 
 			using (var chooser = MakeChooserWithExtantMsas(m_slot, cmd as XCore.Command))
 			{
-				chooser.ShowDialog(this);
+				// Own the chooser to the top-level main window, not `this` child control.
+				chooser.ShowDialog(m_propertyTable.GetValue<Form>("window"));
 				if (chooser.DialogResult == DialogResult.OK)
 				{
 					if (chooser.ChosenObjects != null && chooser.ChosenObjects.Count() > 0)


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
https://jira.sil.org/browse/LT-22578. ShowDialog calls needed to properly pass an owner parameter for the windows to behave as expected. This has been done in https://github.com/sillsdev/FieldWorks/pull/1023 but this did not entirely correct the behavior. The dialog properly had a parent, but while the application was preparing to open the target dialog, another application could temporarily appear on top of the main FieldWorks window. This change fixes behavior so no other application windows get top-level focus before the target dialog is shown.

The issue was reported for "Create new inflectional affix" dialog but I found that this also affected two others, which now also have the shared fix applied. They are:

- Lexicon Edit → Show Subentry under → "..." → Add a Component
- Lexicon Edit → Subentries *and/or* Referenced Complex Forms → "..." → Add a Complex Form

## CI-ready checklist

- [ ] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1041)
<!-- Reviewable:end -->
