### PR TITLE
Add Initialize dependency to uploadUpdatesForTranslation

### DIFF
--- a/Build/Localize.targets
+++ b/Build/Localize.targets
@@ -72,7 +72,7 @@
 	<!-- Update localizable files in Crowdin -->
 	<Target
 		Name="uploadUpdatesForTranslation"
-		DependsOnTargets="CopyLcmResxFiles;InstallOvercrowdin"
+		DependsOnTargets="Initialize;CopyLcmResxFiles;InstallOvercrowdin"
 	>
 		<ItemGroup>
 			<OldXliffs Include="$(ListsDirectory)/*.xlf" />


### PR DESCRIPTION
## Summary

`uploadUpdatesForTranslation` (`Build/Localize.targets`) runs the `XmlToPo`
task directly, which reads the generated `Build/GlobalInclude.properties`
(via `XmlToPo.GetFieldWorksVersion`) to stamp the `.pot` header. That file is
produced by the `GenerateVersionFiles` target, reachable through `Initialize`.

The target's `DependsOnTargets` was `CopyLcmResxFiles;InstallOvercrowdin` —
missing `Initialize` — so on a tree that has not run a full build, the task
fails with:

> System.IO.FileNotFoundException: Could not find file
> '...\Build\GlobalInclude.properties'.

The sibling `localize-source` target already depends on `Initialize`
(`MakeDirs;GenerateVersionFiles`). This adds the same dependency to
`uploadUpdatesForTranslation` so the version file exists before `XmlToPo` runs.

## Change

- `Build/Localize.targets`: `DependsOnTargets` for `uploadUpdatesForTranslation`
  gains `Initialize` (now `Initialize;CopyLcmResxFiles;InstallOvercrowdin`).

## Notes for reviewers

- `Initialize` also runs `MakeDirs` (cheap, idempotent).
- `SetupInclude.targets` has a comment warning against depending on
  `GenerateVersionFiles` in one spot because it writes `bldinc.h` into
  `Output/Common` (deleted by `CleanAll`). Depending on `Initialize` is the
  established pattern used by `localize-source`, so this is consistent, but
  worth a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- - -

Devin review: https://app.devin.ai/review/sillsdev/FieldWorks/pull/1043

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1043)
<!-- Reviewable:end -->
