### PR TITLE
LT-22652: Automatically update strings in Crowdin

### DIFF
--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -44,12 +44,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  debug_build_and_test:
+  build_and_test:
     env:
       CROWDIN_API_KEY: ${{ secrets.FLEX_CROWDIN_API }}
       LcmRootDir: ${{ github.workspace }}/Localizations/LCMRepo
       FILESTOSIGNLATER: ./signExternally
-    name: Build Debug and run Tests
+    name: Build installer and run tests
     runs-on: windows-2022
     steps:
       - name: Compute build number

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -47,7 +47,7 @@ jobs:
   debug_build_and_test:
     env:
       CROWDIN_API_KEY: ${{ secrets.FLEX_CROWDIN_API }}
-      LcmRootDir: ${{ github.workspace }}/Localizations/LCM
+      LcmRootDir: ${{ github.workspace }}/Localizations/LCMRepo
       FILESTOSIGNLATER: ./signExternally
     name: Build Debug and run Tests
     runs-on: windows-2022
@@ -101,7 +101,7 @@ jobs:
           repository: 'sillsdev/liblcm'
           ref: ${{ github.event.inputs.installer_ref || 'master' }}
           fetch-depth: 0
-          path: 'Localizations/LCM'
+          path: 'Localizations/LCMRepo'
 
       - name: Ensure .NET Framework 4.8 targeting pack
         shell: pwsh

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -99,7 +99,7 @@ jobs:
         id: liblcm-checkout
         with:
           repository: 'sillsdev/liblcm'
-          ref: ${{ github.event.inputs.installer_ref || 'master' }}
+          ref: ${{ github.event.inputs.lcm_ref || 'master' }}
           fetch-depth: 0
           path: 'Localizations/LCMRepo'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -206,7 +206,7 @@ jobs:
 
           Invoke-ShallowClone -RepoUrl 'https://github.com/sillsdev/FwHelps.git' -Destination 'DistFiles/Helps'
           Invoke-ShallowClone -RepoUrl 'https://github.com/sillsdev/FwLocalizations.git' -Destination 'Localizations'
-          Invoke-ShallowClone -RepoUrl 'https://github.com/sillsdev/liblcm.git' -Destination 'Localizations/LCM'
+          Invoke-ShallowClone -RepoUrl 'https://github.com/sillsdev/liblcm.git' -Destination 'Localizations/LCMRepo'
 
       # ================================================================
       # SERENA MCP SETUP - for agent code intelligence

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -54,7 +54,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  debug_build_and_test:
+  upload_strings_build_and_test:
     permissions:
       contents: read
     env:
@@ -63,7 +63,7 @@ jobs:
       FILESTOSIGNLATER: ./signExternally
       GH_TOKEN: ${{ github.token }}
       BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1452' }}
-    name: Build Debug and run Tests
+    name: Upload strings for l10n, Build, and run Tests
     runs-on: windows-2022
     steps:
       - name: Compute build number for archival
@@ -219,6 +219,13 @@ jobs:
               }
               New-ItemProperty -Path $path -Name $valueName -Value $expectedValue -Type String -Force
           }
+
+      - name: Upload strings for translation
+        id: upload
+        if: github.event_name == 'push'
+        shell: powershell
+        run: |
+          .\build.ps1 -Target uploadUpdatesForTranslation | Tee-Object -FilePath uploadStrings.log
 
       - name: Build
         id: build

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -59,7 +59,7 @@ jobs:
       contents: read
     env:
       CROWDIN_API_KEY: ${{ secrets.FLEX_CROWDIN_API }}
-      LcmRootDir: ${{ github.workspace }}/Localizations/LCM
+      LcmRootDir: ${{ github.workspace }}/Localizations/LCMRepo
       FILESTOSIGNLATER: ./signExternally
       GH_TOKEN: ${{ github.token }}
       BASE_BUILD_NUMBER: ${{ inputs.base_build_number || '1452' }}
@@ -116,7 +116,7 @@ jobs:
           repository: 'sillsdev/liblcm'
           ref: ${{ github.event.inputs.lcm_ref || 'master' }}
           fetch-depth: 0
-          path: 'Localizations/LCM'
+          path: 'Localizations/LCMRepo'
 
       - name: Ensure .NET Framework 4.8 targeting pack
         shell: pwsh

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -225,7 +225,7 @@ jobs:
         if: github.event_name == 'push'
         shell: powershell
         run: |
-          .\build.ps1 -Target uploadUpdatesForTranslation | Tee-Object -FilePath uploadStrings.log
+          .\build.ps1 -Target uploadUpdatesForTranslation -Configuration Release *>&1 | Tee-Object -FilePath uploadStrings.log
 
       - name: Build
         id: build

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -222,10 +222,14 @@ jobs:
 
       - name: Upload strings for translation
         id: upload
+        continue-on-error: true
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: powershell
         run: |
           .\build.ps1 -Target uploadUpdatesForTranslation -Configuration Release *>&1 | Tee-Object -FilePath uploadStrings.log
+          if ($LASTEXITCODE -ne 0) {
+              echo "::warning::Upload strings failed with exit code $LASTEXITCODE. See log for details."
+          }
 
       - name: Build
         id: build

--- a/.github/workflows/patch-installer-cd.yml
+++ b/.github/workflows/patch-installer-cd.yml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload strings for translation
         id: upload
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: powershell
         run: |
           .\build.ps1 -Target uploadUpdatesForTranslation -Configuration Release *>&1 | Tee-Object -FilePath uploadStrings.log

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -176,7 +176,7 @@ Write-Host "`n--- Checking Helper Repositories ---" -ForegroundColor Yellow
 $helperRepos = @(
 	@{ Name = "FwHelps"; Path = "DistFiles/Helps"; Required = $true },
 	@{ Name = "FwLocalizations"; Path = "Localizations"; Required = $true },
-	@{ Name = "liblcm"; Path = "Localizations/LCM"; Required = $true }
+	@{ Name = "liblcm"; Path = "Localizations/LCMRepo"; Required = $true }
 )
 
 $missingRepos = @()

--- a/Docs/installer-build-guide.md
+++ b/Docs/installer-build-guide.md
@@ -129,12 +129,13 @@ The automated build process is defined in two GitHub Actions workflows:
 ### Patch Installer Workflow (`.github/workflows/patch-installer-cd.yml`)
 
 **Triggers:**
-- Push to `release/9.3` branch
+- Push to certain branches
 - Scheduled: Every Monday at 03:30 UTC
 - Manual: `workflow_dispatch` with parameters
 
 **Key Steps:**
 1. Checkout repos (same as base installer)
+1. Upload updated strings for translation
 2. Download base build artifacts from GitHub Release
 3. Set registry key for WiX temp file handling
 4. Build patch using `msbuild Build/InstallerBuild.proj /t:BuildPatchInstaller`

--- a/Docs/installer-build-guide.md
+++ b/Docs/installer-build-guide.md
@@ -50,7 +50,7 @@ cd fieldworks
 # Clone required helper repositories
 git clone https://github.com/sillsdev/FwHelps.git DistFiles/Helps
 git clone https://github.com/sillsdev/FwLocalizations.git Localizations
-git clone https://github.com/sillsdev/liblcm.git Localizations/LCM
+git clone https://github.com/sillsdev/liblcm.git Localizations/LCMRepo
 ```
 
 ## Building a Base Installer

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -203,7 +203,7 @@ if ($InstallerDeps) {
 	}
 
 	# Special case: liblcm goes inside Localizations
-	$lcmTarget = Join-Path $scriptDir "Localizations/LCM"
+	$lcmTarget = Join-Path $scriptDir "Localizations/LCMRepo"
 	$localizationsPath = Join-Path $scriptDir "Localizations"
 	if ((Test-Path $localizationsPath) -and -not (Test-Path $lcmTarget)) {
 		if ($isWorktree) {
@@ -215,9 +215,9 @@ if ($InstallerDeps) {
 				}
 			}
 			if (Test-Path $sharedLcm) {
-				if ($PSCmdlet.ShouldProcess("Localizations/LCM", "Create junction to $sharedLcm")) {
+				if ($PSCmdlet.ShouldProcess("Localizations/LCMRepo", "Create junction to $sharedLcm")) {
 					New-Item -ItemType Junction -Path $lcmTarget -Target $sharedLcm -Force | Out-Null
-					Write-Host "[OK] Created junction: Localizations/LCM -> $sharedLcm" -ForegroundColor Green
+					Write-Host "[OK] Created junction: Localizations/LCMRepo -> $sharedLcm" -ForegroundColor Green
 				}
 			}
 		} else {

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -230,7 +230,7 @@ if ($InstallerDeps) {
 			}
 		}
 	} elseif (Test-Path $lcmTarget) {
-		Write-Host "[OK] Localizations/LCM already exists" -ForegroundColor Green
+		Write-Host "[OK] Localizations/LCMRepo already exists" -ForegroundColor Green
 	}
 }
 


### PR DESCRIPTION
Update Crowdin source strings as soon as they are updated in FLEx. Doing so requires Crowdin access, and developers frequently forget.

FUTURE WORK: automate list export

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1046)
<!-- Reviewable:end -->
