### PR TITLE
Fix the failing LexOptionsDlg InitializeUIModeControls shift test

### DIFF
--- a/Src/LexText/LexTextControls/LexOptionsDlg.Designer.cs
+++ b/Src/LexText/LexTextControls/LexOptionsDlg.Designer.cs
@@ -52,7 +52,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			this.m_chDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.m_tabInterface = new System.Windows.Forms.TabPage();
 			this.m_autoOpenCheckBox = new System.Windows.Forms.CheckBox();
-			this.label4 = new System.Windows.Forms.Label();
+			this.m_labelAdvanced = new System.Windows.Forms.Label();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.m_userInterfaceChooser = new SIL.FieldWorks.Common.Widgets.UserInterfaceChooser();
 			this.label3 = new System.Windows.Forms.Label();
@@ -170,7 +170,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			// 
 			resources.ApplyResources(this.m_tabInterface, "m_tabInterface");
 			this.m_tabInterface.Controls.Add(this.m_autoOpenCheckBox);
-			this.m_tabInterface.Controls.Add(this.label4);
+			this.m_tabInterface.Controls.Add(this.m_labelAdvanced);
 			this.m_tabInterface.Controls.Add(this.groupBox1);
 			this.m_tabInterface.Name = "m_tabInterface";
 			this.m_tabInterface.UseVisualStyleBackColor = true;
@@ -181,10 +181,10 @@ namespace SIL.FieldWorks.LexText.Controls
 			this.m_autoOpenCheckBox.Name = "m_autoOpenCheckBox";
 			this.m_autoOpenCheckBox.UseVisualStyleBackColor = true;
 			// 
-			// label4
+			// m_labelAdvanced
 			// 
-			resources.ApplyResources(this.label4, "label4");
-			this.label4.Name = "label4";
+			resources.ApplyResources(this.m_labelAdvanced, "m_labelAdvanced");
+			this.m_labelAdvanced.Name = "m_labelAdvanced";
 			// 
 			// groupBox1
 			// 
@@ -303,7 +303,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		private System.Windows.Forms.ColumnHeader m_chDescription;
 		private System.Windows.Forms.TabPage m_tabInterface;
 		private System.Windows.Forms.CheckBox m_autoOpenCheckBox;
-		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.Label m_labelAdvanced;
 		private System.Windows.Forms.GroupBox groupBox1;
 		private Common.Widgets.UserInterfaceChooser m_userInterfaceChooser;
 		private System.Windows.Forms.Label label3;

--- a/Src/LexText/LexTextControls/LexOptionsDlg.cs
+++ b/Src/LexText/LexTextControls/LexOptionsDlg.cs
@@ -494,15 +494,15 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_uiModeBetaWarning.Location = new System.Drawing.Point(pad, m_uiModeChooser.Bottom + pad);
 			m_uiModeGroup.Height = m_uiModeBetaWarning.Bottom + pad;
 
-			var delta = m_uiModeGroup.Bottom + pad - label4.Top;
+			var delta = m_uiModeGroup.Bottom + pad - m_labelAdvanced.Top;
 			if (delta > 0)
 			{
-				// label4 and m_autoOpenCheckBox sit on the Interface tab page and are top-anchored, so
-				// push them down manually to clear the injected UI-mode group. tabControl1 (Top+Bottom-
+				// m_labelAdvanced and m_autoOpenCheckBox sit on the Interface tab page and are top-anchored,
+				// so push them down manually to clear the injected UI-mode group. tabControl1 (Top+Bottom-
 				// anchored) and the OK/Cancel/Help buttons (Bottom-anchored) live on the form and are
 				// resized/repositioned automatically when the form grows, so they must NOT be moved by
 				// hand -- doing both shifts them by 2*delta and drops the buttons off the bottom edge.
-				label4.Top += delta;
+				m_labelAdvanced.Top += delta;
 				m_autoOpenCheckBox.Top += delta;
 				Height += delta;
 			}

--- a/Src/LexText/LexTextControls/LexOptionsDlg.resx
+++ b/Src/LexText/LexTextControls/LexOptionsDlg.resx
@@ -535,16 +535,16 @@ These anonymous statistics will help with future development.</value>
   <data name="&gt;&gt;m_autoOpenCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
+  <data name="&gt;&gt;m_labelAdvanced.Name" xml:space="preserve">
+    <value>m_labelAdvanced</value>
   </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.Parent" xml:space="preserve">
     <value>m_tabInterface</value>
   </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
@@ -617,34 +617,34 @@ always open the last edited project automatically</value>
   <data name="&gt;&gt;m_autoOpenCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+  <data name="m_labelAdvanced.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="m_labelAdvanced.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="m_labelAdvanced.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 116</value>
   </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="m_labelAdvanced.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 13</value>
   </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+  <data name="m_labelAdvanced.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
+  <data name="m_labelAdvanced.Text" xml:space="preserve">
     <value>Advanced:</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
+  <data name="&gt;&gt;m_labelAdvanced.Name" xml:space="preserve">
+    <value>m_labelAdvanced</value>
   </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.Parent" xml:space="preserve">
     <value>m_tabInterface</value>
   </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;m_labelAdvanced.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="&gt;&gt;m_userInterfaceChooser.Name" xml:space="preserve">

--- a/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
@@ -67,7 +67,7 @@ namespace LexTextControlsTests
 		/// <summary>
 		/// Regression test for a "double-shift" layout bug: InitializeUIModeControls() injects a new
 		/// GroupBox into an already-laid-out Interface tab and must grow the Form to make room. Controls
-		/// below the injection point that are top-anchored (label4, m_autoOpenCheckBox) don't move on
+		/// below the injection point that are top-anchored (m_labelAdvanced, m_autoOpenCheckBox) don't move on
 		/// their own, so the code moves them by hand. Controls that are bottom-anchored (tabControl1,
 		/// the OK/Cancel/Help buttons) already move/resize automatically as a side effect of Form.Height
 		/// growing — a prior version of this code ALSO manually re-added the same delta to those, which
@@ -81,7 +81,7 @@ namespace LexTextControlsTests
 			using (var dlg = new TestableLexOptionsDlg())
 			{
 				var uiModeGroup = FindControlRecursive(dlg, "m_uiModeGroup");
-				var label4 = FindControlRecursive(dlg, "label4");
+				var labelAdvanced = FindControlRecursive(dlg, "m_labelAdvanced");
 				var autoOpenCheckBox = FindControlRecursive(dlg, "m_autoOpenCheckBox");
 				var tabControl1 = FindControlRecursive(dlg, "tabControl1");
 				var btnOK = FindControlRecursive(dlg, "m_btnOK");
@@ -89,29 +89,30 @@ namespace LexTextControlsTests
 				var btnHelp = FindControlRecursive(dlg, "m_btnHelp");
 
 				Assert.That(uiModeGroup, Is.Not.Null);
-				Assert.That(label4, Is.Not.Null);
+				Assert.That(labelAdvanced, Is.Not.Null);
 				Assert.That(autoOpenCheckBox, Is.Not.Null);
 				Assert.That(tabControl1, Is.Not.Null);
 				Assert.That(btnOK, Is.Not.Null);
 				Assert.That(btnCancel, Is.Not.Null);
 				Assert.That(btnHelp, Is.Not.Null);
 
-				var originalLabel4Top = ReadLexOptionsDlgResxPoint("label4.Location").Y;
+				var originalLabelAdvancedTop = ReadLexOptionsDlgResxPoint("m_labelAdvanced.Location").Y;
 				var originalAutoOpenTop = ReadLexOptionsDlgResxPoint("m_autoOpenCheckBox.Location").Y;
 				var originalTabControlHeight = ReadLexOptionsDlgResxSize("tabControl1.Size").Height;
 				var originalBtnOkTop = ReadLexOptionsDlgResxPoint("m_btnOK.Location").Y;
 				var originalBtnCancelTop = ReadLexOptionsDlgResxPoint("m_btnCancel.Location").Y;
 				var originalBtnHelpTop = ReadLexOptionsDlgResxPoint("m_btnHelp.Location").Y;
 
-				// The delta InitializeUIModeControls() computed to make room for the injected group box,
-				// derived from the group box's own (live) bottom edge rather than hardcoded, so this test
-				// doesn't need updating if m_uiModeGroup's own size/position ever changes.
-				var delta = uiModeGroup.Bottom + 8 - originalLabel4Top;
+				// One shift, measured from a control InitializeUIModeControls moves by hand. Deriving it
+				// from observed layout rather than recomputing the padding formula keeps this test about
+				// the relationship -- every affected control moves exactly once -- not the arithmetic.
+				var delta = labelAdvanced.Top - originalLabelAdvancedTop;
 				Assert.That(delta, Is.GreaterThan(0),
 					"precondition: the injected group box must actually require extra room for this test to exercise the shift logic");
+				Assert.That(uiModeGroup.Bottom, Is.LessThanOrEqualTo(labelAdvanced.Top),
+					"the injected group must clear the control it pushed down");
 
-				// Top-anchored controls: moved by hand, must shift by exactly delta.
-				Assert.That(label4.Top, Is.EqualTo(originalLabel4Top + delta));
+				// The other hand-moved, top-anchored control must shift by the same single delta.
 				Assert.That(autoOpenCheckBox.Top, Is.EqualTo(originalAutoOpenTop + delta));
 
 				// Bottom-anchored controls: WinForms repositions/resizes these automatically as a side


### PR DESCRIPTION
Measure the shift delta from m_labelAdvanced's observed move instead of recomputing it with a hardcoded padding literal, this will keep the test from drifting from the actual code. Add an assertion that the injected group box clears m_labelAdvanced to keep proof the shift was sufficient, and drop the label position check.

Also rename the Advanced heading from label4 to m_labelAdvanced so the layout code names the control it moves.

## Why the test was failing

PR #964 changed InitializeUIModeControls to derive its padding from the dialog font (`Font.Height / 2`) instead of a literal 8, but the test kept recomputing its expected positions with the old literal. Wherever `Font.Height / 2 != 8` the expectations are off by the difference (at 96 DPI, `13 / 2 = 6`, hence "Expected: 217 / But was: 215"), so the test could pass on one machine and fail on another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1048)
<!-- Reviewable:end -->
