### PR TITLE
Use Common Assembly Info in new assemblies

### DIFF
--- a/Build/Installer.legacy.targets
+++ b/Build/Installer.legacy.targets
@@ -202,6 +202,8 @@
 			<!-- versification files from some unit tests -->
 			<DevTestArtifacts Include="$(OutputDirForConfig)\Castle.Core.dll" />
 			<DevTestArtifacts Include="$(OutputDirForConfig)\Moq.dll" />
+			<!-- Dev-iteration sample code for the Avalonia preview host, not product behavior -->
+			<DevTestArtifacts Include="$(OutputDirForConfig)\FwAvalonia.Preview.*" />
 
 			<FontFiles Include="$(fwrt)\DistFiles\Fonts\Raw\Quivira.otf" />
 			<FontFiles Include="$(DownloadsDir)\Fonts\**\*.ttf" />

--- a/Build/Installer.targets
+++ b/Build/Installer.targets
@@ -137,6 +137,8 @@
 	  <DevTestArtifacts Include="$(OutputDirForConfig)\*Tests.*" />
 	  <DevTestArtifacts Include="$(OutputDirForConfig)\test*" />
 	  <DevTestArtifacts Include="$(OutputDirForConfig)\*.vrs" />
+	  <!-- Dev-iteration sample code for the Avalonia preview host, not product behavior -->
+	  <DevTestArtifacts Include="$(OutputDirForConfig)\FwAvalonia.Preview.*" />
 	  <BinFiles Remove="@(DevTestArtifacts)" />
 	</ItemGroup>
 

--- a/Src/AGENTS.md
+++ b/Src/AGENTS.md
@@ -11,6 +11,7 @@ Minimal guidance for source-tree work.
 
 - Preserve native-first build order.
 - Keep managed code compatible with .NET Framework 4.8, the repo default C# 8.0 language policy, and nullable reference types disabled unless a project explicitly opts in.
+- Compile Include `CommonAssemblyInfo.cs` in production projects and `AssemblyInfoForTests.cs` in test projects.
 - Keep interop boundaries explicit; do not introduce COM registration side-effects.
 - Keep user-visible strings in resources.
 

--- a/Src/Common/FwAvalonia/FwAvalonia.csproj
+++ b/Src/Common/FwAvalonia/FwAvalonia.csproj
@@ -30,6 +30,7 @@
 		<LangVersion>latest</LangVersion>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
 	</PropertyGroup>
 

--- a/Src/Common/FwAvalonia/FwAvalonia.csproj
+++ b/Src/Common/FwAvalonia/FwAvalonia.csproj
@@ -47,6 +47,10 @@
 		<Reference Include="System.Windows.Forms" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+	</ItemGroup>
+
 	<!-- The test project lives in the nested FwAvaloniaTests/ folder. Exclude it from this
 	     library's default SDK globbing so production and test trees do not mix. -->
 	<ItemGroup>

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/FwAvaloniaTests.csproj
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/FwAvaloniaTests.csproj
@@ -19,6 +19,7 @@
 		<LangVersion>latest</LangVersion>
 		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
 	</PropertyGroup>
 
@@ -66,6 +67,10 @@
 	<ItemGroup>
 		<Compile Remove="$(FwRoot)Src\AssemblyInfoForTests.cs" />
 		<Compile Remove="$(FwRoot)Src\AssemblyInfoForUiIndependentTests.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
 	</ItemGroup>
 
 </Project>

--- a/Src/Common/FwAvalonia/Preview/FwAvalonia.Preview.csproj
+++ b/Src/Common/FwAvalonia/Preview/FwAvalonia.Preview.csproj
@@ -17,11 +17,16 @@
 		<LangVersion>latest</LangVersion>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Avalonia" ExcludeAssets="analyzers" PrivateAssets="all" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogs.csproj
+++ b/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogs.csproj
@@ -22,6 +22,7 @@
 		<LangVersion>latest</LangVersion>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<!-- Auto-include *.axaml as AvaloniaXaml items and compile XAML at build time. -->
 		<EnableDefaultAvaloniaItems>true</EnableDefaultAvaloniaItems>
 		<!-- Bindings are statically checked at build time (the key payoff of the MVVM decision). -->
@@ -33,6 +34,9 @@
 		<PackageReference Include="Avalonia" ExcludeAssets="analyzers" />
 		<PackageReference Include="Avalonia.Themes.Fluent" ExcludeAssets="analyzers" />
 		<PackageReference Include="CommunityToolkit.Mvvm" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
 	</ItemGroup>
 

--- a/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogs.csproj
+++ b/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogs.csproj
@@ -33,6 +33,7 @@
 		<PackageReference Include="Avalonia" ExcludeAssets="analyzers" />
 		<PackageReference Include="Avalonia.Themes.Fluent" ExcludeAssets="analyzers" />
 		<PackageReference Include="CommunityToolkit.Mvvm" />
+		<Compile Include="..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
 	</ItemGroup>
 
 	<!-- WinForms framework assembly: the generic dialog launcher scaffold takes an IWin32Window owner and

--- a/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogsTests/FwAvaloniaDialogsTests.csproj
+++ b/Src/Common/FwAvaloniaDialogs/FwAvaloniaDialogsTests/FwAvaloniaDialogsTests.csproj
@@ -14,6 +14,7 @@
 		<LangVersion>latest</LangVersion>
 		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
 	</PropertyGroup>
 
@@ -45,6 +46,10 @@
 	<ItemGroup>
 		<Compile Remove="$(FwRoot)Src\AssemblyInfoForTests.cs" />
 		<Compile Remove="$(FwRoot)Src\AssemblyInfoForUiIndependentTests.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\..\..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
TODO: check whether any further assemblies, especially tests, should use this or AssemblyInfoForTests.cs

## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1050)
<!-- Reviewable:end -->
