### PR TITLE
LT-21720: Give unpositioned dialogs centered start positions and owners

### DIFF
--- a/Src/Common/Controls/DetailControls/SemanticDomainReferenceLauncher.cs
+++ b/Src/Common/Controls/DetailControls/SemanticDomainReferenceLauncher.cs
@@ -63,7 +63,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			var labels = ObjectLabel.CreateObjectLabels(m_cache, m_obj.ReferenceTargetCandidates(m_flid),
 				m_displayNameProperty, displayWs);
 			chooser.Initialize(labels, sense.SemanticDomainsRC, m_propertyTable);
-			var result = chooser.ShowDialog();
+			var result = chooser.ShowDialog(FindForm());
 			if(result == DialogResult.OK)
 			{
 				UndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW(Resources.DetailControlsStrings.ksUndoSet,

--- a/Src/Common/Controls/DetailControls/SemanticDomainsChooser.cs
+++ b/Src/Common/Controls/DetailControls/SemanticDomainsChooser.cs
@@ -47,6 +47,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 		public SemanticDomainsChooser()
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			btnCancelSearch.Init();
 			editDomainsLinkPic.Image = DetailControlsStrings.gotoLinkPic;
 		}

--- a/Src/Common/FwUtils/FwUpdateChooserDlg.cs
+++ b/Src/Common/FwUtils/FwUpdateChooserDlg.cs
@@ -14,6 +14,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 		public FwUpdateChooserDlg()
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterScreen;
 		}
 
 		public FwUpdateChooserDlg(FwUpdate current, IEnumerable<FwUpdate> available) : this()

--- a/Src/FdoUi/Dialogs/CantRestoreLinkedFilesToOriginalLocation.cs
+++ b/Src/FdoUi/Dialogs/CantRestoreLinkedFilesToOriginalLocation.cs
@@ -23,6 +23,8 @@ namespace SIL.FieldWorks.FdoUi.Dialogs
 		{
 			m_helpTopicProvider = helpTopicProvider;
 			InitializeComponent();
+			// Shown without an owner, possibly before any main window exists.
+			StartPosition = FormStartPosition.CenterScreen;
 		}
 
 		/// <summary>

--- a/Src/FdoUi/Dialogs/ConflictingSaveDlg.cs
+++ b/Src/FdoUi/Dialogs/ConflictingSaveDlg.cs
@@ -19,6 +19,8 @@ namespace SIL.FieldWorks.FdoUi.Dialogs
 		public ConflictingSaveDlg()
 		{
 			InitializeComponent();
+			// Shown without an owner, possibly before any main window exists.
+			StartPosition = FormStartPosition.CenterScreen;
 			pictureBox1.BackgroundImage = SystemIcons.Warning.ToBitmap();
 			pictureBox1.Size = SystemIcons.Warning.Size;
 		}

--- a/Src/FdoUi/Dialogs/FilesToRestoreAreOlder.cs
+++ b/Src/FdoUi/Dialogs/FilesToRestoreAreOlder.cs
@@ -23,6 +23,8 @@ namespace SIL.FieldWorks.FdoUi.Dialogs
 		{
 			m_helpTopicProvider = helpTopicProvider;
 			InitializeComponent();
+			// Shown without an owner, possibly before any main window exists.
+			StartPosition = FormStartPosition.CenterScreen;
 		}
 
 		/// <summary>

--- a/Src/FdoUi/Dialogs/RestoreLinkedFilesToProjectsFolder.cs
+++ b/Src/FdoUi/Dialogs/RestoreLinkedFilesToProjectsFolder.cs
@@ -23,6 +23,8 @@ namespace SIL.FieldWorks.FdoUi.Dialogs
 		{
 			m_helpTopicProvider = helpTopicProvider;
 			InitializeComponent();
+			// Shown without an owner, possibly before any main window exists.
+			StartPosition = FormStartPosition.CenterScreen;
 		}
 
 		/// <summary>

--- a/Src/LexText/LexTextControls/InsertEntryDlg.cs
+++ b/Src/LexText/LexTextControls/InsertEntryDlg.cs
@@ -1837,7 +1837,7 @@ namespace SIL.FieldWorks.LexText.Controls
 
 				using (dlg)
 				{
-					if (dlg.ShowDialog() == DialogResult.OK)
+					if (dlg.ShowDialog(this) == DialogResult.OK)
 					{
 						Gloss = dlg.Result;
 						m_MGAGlossListBoxItems = dlg.Items;

--- a/Src/LexText/LexTextControls/LexImportWizardMarker.cs
+++ b/Src/LexText/LexTextControls/LexImportWizardMarker.cs
@@ -396,6 +396,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			// Required for Windows Form Designer support
 			//
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			AccessibleName = GetType().Name;
 
 			InitBottomPanel();

--- a/Src/LexText/Morphology/ConcordanceDlg.cs
+++ b/Src/LexText/Morphology/ConcordanceDlg.cs
@@ -96,6 +96,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 			// Required for Windows Form Designer support
 			//
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			AccessibleName = GetType().Name;
 
 			helpProvider = new FlexHelpProvider();

--- a/Src/LexText/Morphology/MGA/MGADialog.cs
+++ b/Src/LexText/Morphology/MGA/MGADialog.cs
@@ -123,6 +123,7 @@ namespace  SIL.FieldWorks.LexText.Controls.MGA
 			// Required for Windows Form Designer support
 			//
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 
 			SuspendLayout();
 

--- a/Src/LexText/Morphology/RespellerDlg.cs
+++ b/Src/LexText/Morphology/RespellerDlg.cs
@@ -69,6 +69,7 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		public RespellerDlg()
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			// Handle localization here since the dialog isn't localized, it can't be edited in the
 			// designer to make it localized.
 			m_cbUpdateLexicon.Text = MEStrings.ksUpdateMonoMorphemicLexicalEntries;

--- a/Src/xWorks/DictionaryConfigMgrDlg.cs
+++ b/Src/xWorks/DictionaryConfigMgrDlg.cs
@@ -43,6 +43,7 @@ namespace SIL.FieldWorks.XWorks
 		public DictionaryConfigMgrDlg(Mediator mediator, PropertyTable propertyTable, string objType, List<XmlNode> configViews, XmlNode current)
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 
 			m_mediator = mediator;
 			m_propertyTable = propertyTable;

--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -464,7 +464,7 @@ namespace SIL.FieldWorks.XWorks
 					renameDialog.NewSuffix = dictionaryNode.LabelSuffix;
 
 					// Unchanged?
-					if (renameDialog.ShowDialog() != DialogResult.OK || renameDialog.NewSuffix == dictionaryNode.LabelSuffix)
+					if (renameDialog.ShowDialog(View as Form) != DialogResult.OK || renameDialog.NewSuffix == dictionaryNode.LabelSuffix)
 						return;
 
 					if (!dictionaryNode.ChangeSuffix(renameDialog.NewSuffix, siblings))

--- a/Src/xWorks/DictionaryConfigurationImportController.cs
+++ b/Src/xWorks/DictionaryConfigurationImportController.cs
@@ -353,7 +353,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// Connect to and show a view for the user to perform an import.
 		/// </summary>
-		public void DisplayView(DictionaryConfigurationImportDlg dialog)
+		public void DisplayView(DictionaryConfigurationImportDlg dialog, Form owner)
 		{
 			_view = dialog;
 			_view.browseButton.Click += (a, b) => OnBrowse();
@@ -369,7 +369,7 @@ namespace SIL.FieldWorks.XWorks
 			};
 			_view.overwriteGroupBox.Visible = false;
 			_view.importButton.Enabled = false;
-			_view.ShowDialog();
+			_view.ShowDialog(owner);
 		}
 
 		/// <summary>

--- a/Src/xWorks/DictionaryConfigurationImportDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationImportDlg.cs
@@ -21,6 +21,7 @@ namespace SIL.FieldWorks.XWorks
 		public DictionaryConfigurationImportDlg(IHelpTopicProvider helpProvider)
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			m_helpTopicProvider = helpProvider;
 			// Clear away example text
 			explanationLabel.Text = string.Empty;

--- a/Src/xWorks/DictionaryConfigurationManagerController.cs
+++ b/Src/xWorks/DictionaryConfigurationManagerController.cs
@@ -634,7 +634,7 @@ namespace SIL.FieldWorks.XWorks
 			var importController = new DictionaryConfigurationImportController(_cache, _propertyTable, _projectConfigDir, _configurations);
 			using (var importDialog = new DictionaryConfigurationImportDlg(_propertyTable.GetValue<IHelpTopicProvider>("HelpTopicProvider")) { HelpTopic = _view.HelpTopic })
 			{
-				importController.DisplayView(importDialog);
+				importController.DisplayView(importDialog, _view);
 			}
 
 			if (importController.StyleImportHappened)

--- a/Src/xWorks/DictionaryConfigurationManagerDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationManagerDlg.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows.Forms;
 using SIL.Linq;
 using SIL.FieldWorks.Common.FwUtils;
+using SIL.Windows.Forms;
 using XCore;
 
 namespace SIL.FieldWorks.XWorks
@@ -23,6 +24,8 @@ namespace SIL.FieldWorks.XWorks
 		public DictionaryConfigurationManagerDlg(IHelpTopicProvider helpTopicProvider)
 		{
 			InitializeComponent();
+			// Open centered on the owner so the dialog appears on the same monitor as the main window.
+			StartPosition = FormStartPosition.CenterParent;
 
 			m_toolTip = new ToolTip();
 			m_toolTip.SetToolTip(copyButton, xWorksStrings.DuplicateViewToolTip);
@@ -43,6 +46,18 @@ namespace SIL.FieldWorks.XWorks
 			m_helpProvider.SetHelpKeyword(this, m_helpTopicProvider.GetHelpString(HelpTopic));
 			m_helpProvider.SetHelpNavigator(this, HelpNavigator.Topic);
 			m_helpProvider.SetShowHelp(this, true);
+		}
+
+		/// <summary>
+		/// Make sure the dialog is not displayed off-screen on multi-monitor setups.
+		/// </summary>
+		protected override void OnShown(EventArgs e)
+		{
+			base.OnShown(e);
+			var rect = DesktopBounds;
+			ScreenHelper.EnsureVisibleRect(ref rect);
+			if (rect != DesktopBounds)
+				DesktopBounds = rect;
 		}
 
 		private void OnGotFocus(object sender, EventArgs eventArgs)

--- a/Src/xWorks/DictionaryConfigurationNodeRenameDlg.cs
+++ b/Src/xWorks/DictionaryConfigurationNodeRenameDlg.cs
@@ -31,6 +31,7 @@ namespace SIL.FieldWorks.XWorks
 		public DictionaryConfigurationNodeRenameDlg()
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 		}
 	}
 }

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -1230,7 +1230,8 @@ namespace SIL.FieldWorks.XWorks
 			using (var controller = new UploadToWebonaryController(cache, propertyTable, mediator))
 			using (var dialog = new UploadToWebonaryDlg(controller, model, propertyTable))
 			{
-				dialog.ShowDialog();
+				// Pass the main window as owner so the dialog opens on the same monitor.
+				dialog.ShowDialog(propertyTable.GetValue<IWin32Window>("window"));
 			}
 		}
 

--- a/Src/xWorks/UploadToWebonaryDlg.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.cs
@@ -318,7 +318,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			using(var dlg = new WebonaryLogViewer(Model.LastUploadReport))
 			{
-				dlg.ShowDialog();
+				dlg.ShowDialog(this);
 			}
 		}
 

--- a/Src/xWorks/UploadToWebonaryDlg.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.cs
@@ -35,7 +35,7 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// Needed to get the HelpTopicProvider and to save project specific settings
 		/// </summary>
-		protected PropertyTable PropertyTable { get; set; }
+		private PropertyTable m_propertyTable;
 
 		public UploadToWebonaryDlg()
 		{
@@ -51,6 +51,7 @@ namespace SIL.FieldWorks.XWorks
 				MinimumSize = new Size(MinimumSize.Width, MinimumSize.Height + m_additionalMinimumHeightForMono);
 
 			m_controller = controller;
+			m_propertyTable = propertyTable;
 			Model = model;
 			LoadFromModel();
 
@@ -64,10 +65,10 @@ namespace SIL.FieldWorks.XWorks
 			};
 
 			// Restore the location and size from last time we called this dialog.
-			if (PropertyTable != null)
+			if (m_propertyTable != null)
 			{
-				object locWnd = PropertyTable.GetValue<object>("UploadToWebonaryDlg_Location");
-				object szWnd = PropertyTable.GetValue<object>("UploadToWebonaryDlg_Size");
+				object locWnd = m_propertyTable.GetValue<object>("UploadToWebonaryDlg_Location");
+				object szWnd = m_propertyTable.GetValue<object>("UploadToWebonaryDlg_Size");
 				if (locWnd != null && szWnd != null)
 				{
 					Rectangle rect = new Rectangle((Point) locWnd, (Size) szWnd);
@@ -340,12 +341,12 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		protected override void OnClosing(CancelEventArgs e)
 		{
-			if (PropertyTable != null)
+			if (m_propertyTable != null)
 			{
-				PropertyTable.SetProperty("UploadToWebonaryDlg_Location", Location, false);
-				PropertyTable.SetPropertyPersistence("UploadToWebonaryDlg_Location", true);
-				PropertyTable.SetProperty("UploadToWebonaryDlg_Size", Size, false);
-				PropertyTable.SetPropertyPersistence("UploadToWebonaryDlg_Size", true);
+				m_propertyTable.SetProperty("UploadToWebonaryDlg_Location", Location, false);
+				m_propertyTable.SetPropertyPersistence("UploadToWebonaryDlg_Location", true);
+				m_propertyTable.SetProperty("UploadToWebonaryDlg_Size", Size, false);
+				m_propertyTable.SetPropertyPersistence("UploadToWebonaryDlg_Size", true);
 			}
 			base.OnClosing(e);
 		}

--- a/Src/xWorks/UploadToWebonaryDlg.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.cs
@@ -337,6 +337,23 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// A remembered position may be on a monitor the main window has since left; recenter
+		/// on the owner's screen so a modal dialog is never stranded where the user isn't looking.
+		/// </summary>
+		protected override void OnShown(EventArgs e)
+		{
+			base.OnShown(e);
+			if (Owner == null || StartPosition != FormStartPosition.Manual)
+				return;
+			var ownerScreen = System.Windows.Forms.Screen.FromControl(Owner);
+			if (ownerScreen.Equals(System.Windows.Forms.Screen.FromRectangle(DesktopBounds)))
+				return;
+			var workingArea = ownerScreen.WorkingArea;
+			Location = new Point(workingArea.Left + Math.Max(0, (workingArea.Width - Width) / 2),
+				workingArea.Top + Math.Max(0, (workingArea.Height - Height) / 2));
+		}
+
+		/// <summary>
 		/// Save the location and size for next time.
 		/// </summary>
 		protected override void OnClosing(CancelEventArgs e)

--- a/Src/xWorks/WebonaryLogViewer.cs
+++ b/Src/xWorks/WebonaryLogViewer.cs
@@ -39,6 +39,7 @@ namespace SIL.FieldWorks.XWorks
 		public WebonaryLogViewer(string filePath)
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 			_resourceManager = new ResourceManager("SIL.FieldWorks.XWorks.WebonaryLogViewer", typeof(WebonaryLogViewer).Assembly);
 
 			// Set localized text for UI elements

--- a/Src/xWorks/XmlDiagnosticsDlg.cs
+++ b/Src/xWorks/XmlDiagnosticsDlg.cs
@@ -13,6 +13,7 @@ namespace SIL.FieldWorks.XWorks
 		public XmlDiagnosticsDlg(GeckoElement element, Guid guid)
 		{
 			InitializeComponent();
+			StartPosition = FormStartPosition.CenterParent;
 
 			m_tb_guid.Text = guid.ToString();
 			var htmlElement = element as GeckoHtmlElement;

--- a/Src/xWorks/XmlDocConfigureDlg.cs
+++ b/Src/xWorks/XmlDocConfigureDlg.cs
@@ -4363,7 +4363,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				dlg.Text = String.Format(dlg.Text, m_configObjectName);
 				var presenter = dlg.Presenter;
-				if (dlg.ShowDialog() == DialogResult.OK)
+				if (dlg.ShowDialog(this) == DialogResult.OK)
 					ProcessXMLConfigChanges(presenter as IDictConfigManager);
 			}
 		}


### PR DESCRIPTION
## Quick Summary

Partially addresses [LT-21720](https://jira.sil.org/browse/LT-21720) (remembered window locations misbehaving on multi-monitor setups).

- Revive `UploadToWebonaryDlg` position persistence: its restore/clamp/save code null-checked a `PropertyTable` auto-property that the constructor never assigned, so it has been dead since it was written. The property is now a constructor-assigned field, and the dialog is shown with the main window as owner. Per review feedback, `OnShown` now recenters the dialog on the owner's screen when the remembered position is on a different monitor, so a modal dialog is never stranded where the user isn't looking.
- Give `DictionaryConfigurationManagerDlg` a `CenterParent` start position and clamp its bounds back onto a screen in `OnShown` — it previously had no positioning code and could open off-screen, leaving the app looking hung (one of the LT-21720 reports).
- Sweep the highest-risk dialogs that had no positioning code at all: `CenterParent` on ten (dictionary-configuration child dialogs, Webonary log viewer, the Gecko-hosting MGA/diagnostics/import-marker dialogs, semantic-domains chooser, respeller, concordance dialog) and `CenterScreen` on five that can be shown before any main window exists (the four FdoUi restore dialogs and the update chooser).
- Pass an explicit owner at the six `ShowDialog()` call sites that had none, threading an owner parameter through `DictionaryConfigurationImportController.DisplayView`.

This PR does not cover the dialogs that persist and restore positions of their own (`BaseGoDlg` and its subclasses, `ReallySimpleListChooser`, `InsertEntryDlg`'s registry restore, `FwFindReplaceDlg`, the shared `Persistence` helper, and similar) — several of the dialogs named in LT-21720 are in that family, which is follow-up work.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)

WinForms' default `WindowsDefaultLocation` leaves placement to the OS cascade, which on multi-monitor setups can land a dialog on the wrong screen or entirely off the visible area. Centering on an owner — or on a screen, for dialogs that can appear before any window exists — takes the OS out of the placement decision. The swept dialogs are behavior-neutral one-liners except `DisplayView`, whose new owner parameter has exactly one caller (updated in the same commit).

Validation: `build.ps1 -SkipNative` clean; `test.ps1` on `xWorksTests` filtered to UploadToWebonary + DictionaryConfiguration, all passing after rebasing onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1053)
<!-- Reviewable:end -->
