### PR TITLE
LT-21483: Part 1 - Move JumpToRecord to Pub/Sub (SendMessage)

### DIFF
--- a/Src/FdoUi/PartOfSpeechUi.cs
+++ b/Src/FdoUi/PartOfSpeechUi.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using System.Windows.Forms;
 using SIL.LCModel;
 using XCore;
+using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.FieldWorks.LexText.Controls;
 
 namespace SIL.FieldWorks.FdoUi
@@ -52,9 +54,7 @@ namespace SIL.FieldWorks.FdoUi
 					case DialogResult.OK: // Fall through.
 					case DialogResult.Yes:
 						posUi = new PartOfSpeechUi(dlg.SelectedPOS);
-#pragma warning disable 618 // suppress obsolete warning
-						mediator.SendMessage("JumpToRecord", dlg.SelectedPOS.Hvo);
-#pragma warning restore 618
+						Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, dlg.SelectedPOS.Hvo, propertyTable.GetWindow()));
 						break;
 				}
 			}

--- a/Src/LexText/Interlinear/ConcordanceControl.cs
+++ b/Src/LexText/Interlinear/ConcordanceControl.cs
@@ -1789,6 +1789,21 @@ namespace SIL.FieldWorks.IText
 		{
 			return "";
 		}
+
+		/// <summary>
+		/// The concordance tool's ConcordanceControl gets the first chance to handle a
+		/// published jump. The base implementation only runs the jump if the control declines.
+		/// (The complexConcordance tool shares this clerk class, but its control has no
+		/// jump handling, so it always falls through to the base implementation.)
+		/// </summary>
+		protected override void JumpToRecordViaPublisher(object argument)
+		{
+			if (!IsActiveClerk)
+				return;
+			if (ConcordanceControl is ConcordanceControl concordanceControl && concordanceControl.OnJumpToRecord(argument))
+				return;
+			base.JumpToRecordViaPublisher(argument);
+		}
 	}
 
 	/// <summary>

--- a/Src/LexText/Interlinear/InterlinearImportDlg.cs
+++ b/Src/LexText/Interlinear/InterlinearImportDlg.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using DesktopAnalytics;
 using SIL.FieldWorks.Common.Controls;
 using SIL.FieldWorks.Common.FwUtils;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 using SIL.LCModel;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.FieldWorks.Resources;
@@ -23,6 +24,7 @@ namespace SIL.FieldWorks.IText
 	{
 		private LcmCache m_cache;
 		private Mediator m_mediator;
+		private PropertyTable m_propertyTable;
 
 		private readonly StringBuilder m_messages = new StringBuilder();
 
@@ -77,11 +79,9 @@ namespace SIL.FieldWorks.IText
 						{
 							DialogResult = DialogResult.OK; // only 'OK' if not exception
 							var firstNewText = import.FirstNewText;
-							if (firstNewText != null && m_mediator != null)
+							if (firstNewText != null && m_propertyTable != null)
 							{
-#pragma warning disable 618 // suppress obsolete warning
-								m_mediator.SendMessage("JumpToRecord", firstNewText.Hvo);
-#pragma warning restore 618
+								Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, firstNewText.Hvo, m_propertyTable.GetWindow()));
 							}
 						}
 						else
@@ -129,6 +129,7 @@ namespace SIL.FieldWorks.IText
 		{
 			m_cache = cache;
 			m_mediator = mediator;
+			m_propertyTable = propertyTable;
 			if (m_mediator != null)
 			{
 				m_helpTopicProvider = propertyTable.GetValue<IHelpTopicProvider>("HelpTopicProvider");

--- a/Src/LexText/LexTextControls/EntryDlgListener.cs
+++ b/Src/LexText/LexTextControls/EntryDlgListener.cs
@@ -117,9 +117,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					{
 						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
 					}
-#pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("JumpToRecord", entry.Hvo);
-#pragma warning restore 618
+					Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, entry.Hvo, m_propertyTable.GetWindow()));
 				}
 			}
 			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.
@@ -134,14 +132,21 @@ namespace SIL.FieldWorks.LexText.Controls
 				Form.ActiveForm, tssForm: null, helpProvider: helpProvider);
 			// Jump to the resulting entry whether it was newly created OR an existing entry the user chose from
 			// the matching-entries pane (the legacy "Go to similar entry" outcome, newby == false). The legacy
-			// WinForms path likewise JumpToRecord's for both. A MasterRefresh is only needed for a new entry.
+			// WinForms path likewise jumps for both. A refresh is only needed for a new entry.
 			if (entry != null)
 			{
-#pragma warning disable 618 // suppress obsolete warning
 				if (newby)
-					m_mediator.SendMessage("MasterRefresh", null);
-				m_mediator.SendMessage("JumpToRecord", entry.Hvo);
-#pragma warning restore 618
+				{
+					// Two-stage refresh: if the active content control can satisfy the request by
+					// regenerating its own content (the XHTML document views), skip the full refresh.
+					var refreshRequest = new ReturnObject(null);
+					Publisher.Publish(new PublisherParameterObject(EventConstants.RefreshCurrentView, refreshRequest, m_propertyTable.GetWindow()));
+					if (!refreshRequest.ReturnValue)
+					{
+						Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, m_propertyTable.GetWindow()));
+					}
+				}
+				Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, entry.Hvo, m_propertyTable.GetWindow()));
 			}
 		}
 
@@ -228,9 +233,7 @@ namespace SIL.FieldWorks.LexText.Controls
 						LexTextControls.ksEntriesHaveBeenMerged,
 						LexTextControls.ksMergeReport,
 						MessageBoxButtons.OK, MessageBoxIcon.Information);
-#pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("JumpToRecord", survivor.Hvo);
-#pragma warning restore 618
+					Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, survivor.Hvo, m_propertyTable.GetWindow()));
 				}
 			}
 			return true;
@@ -280,9 +283,7 @@ namespace SIL.FieldWorks.LexText.Controls
 					LexTextControls.ksEntriesHaveBeenMerged,
 					LexTextControls.ksMergeReport,
 					MessageBoxButtons.OK, MessageBoxIcon.Information);
-#pragma warning disable 618 // suppress obsolete warning
-				m_mediator.SendMessage("JumpToRecord", survivor.Hvo);
-#pragma warning restore 618
+				Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, survivor.Hvo, m_propertyTable.GetWindow()));
 			}
 		}
 		#endregion XCORE Message Handlers

--- a/Src/LexText/LexTextControls/RecordDlgListener.cs
+++ b/Src/LexText/LexTextControls/RecordDlgListener.cs
@@ -108,9 +108,7 @@ namespace SIL.FieldWorks.LexText.Controls
 				if (dlg.ShowDialog(Form.ActiveForm) == DialogResult.OK)
 				{
 					IRnGenericRec newRec = dlg.NewRecord;
-#pragma warning disable 618 // suppress obsolete warning
-					m_mediator.SendMessage("JumpToRecord", newRec.Hvo);
-#pragma warning restore 618
+					Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, newRec.Hvo, m_propertyTable.GetWindow()));
 				}
 			}
 			retObj.ReturnValue = true; // We "handled" the message, regardless of what happened.

--- a/Src/xWorks/RecordClerk.cs
+++ b/Src/xWorks/RecordClerk.cs
@@ -1039,6 +1039,23 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// Pub/Sub subscriber for JumpToRecord.
+		/// More than one clerk can be subscribed at a time, so every implementation,
+		/// including overrides, MUST return without doing anything unless IsActiveClerk.
+		/// Subclasses can override this to route the jump elsewhere first (the concordance
+		/// clerk lets its ConcordanceControl try the jump before falling back to this base
+		/// implementation).
+		/// Note: Mediator broadcasts of "JumpToRecord" still arrive via OnJumpToRecord
+		/// until those senders are also converted to Pub/Sub.
+		/// </summary>
+		protected virtual void JumpToRecordViaPublisher(object argument)
+		{
+			if (!IsActiveClerk)
+				return;
+			JumpToRecord(argument);
+		}
+
+		/// <summary>
 		/// display the given record
 		/// </summary>
 		/// <param name="argument">the hvo of the record</param>
@@ -1941,6 +1958,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			Subscriber.Unsubscribe(EventConstants.FilterListChanged, FilterListChanged);
 			Subscriber.Unsubscribe(EventConstants.DeleteRecord, DeleteRecord);
+			Subscriber.Unsubscribe(EventConstants.JumpToRecord, JumpToRecordViaPublisher);
 
 			// We need the list to get the cache.
 			if (m_list == null || m_list.IsDisposed || Cache == null || Cache.IsDisposed || Cache.DomainDataByFlid == null)
@@ -2042,6 +2060,7 @@ namespace SIL.FieldWorks.XWorks
 			// RecordClerk only needs to handle changes if RecordClerk is being used in GUI
 			Subscriber.Subscribe(EventConstants.FilterListChanged, FilterListChanged, m_propertyTable.GetWindow());
 			Subscriber.Subscribe(EventConstants.DeleteRecord, DeleteRecord, m_propertyTable.GetWindow());
+			Subscriber.Subscribe(EventConstants.JumpToRecord, JumpToRecordViaPublisher, m_propertyTable.GetWindow());
 
 			m_fIsActiveInGui = true;
 			CheckDisposed();

--- a/Src/xWorks/XhtmlDocView.cs
+++ b/Src/xWorks/XhtmlDocView.cs
@@ -690,7 +690,6 @@ namespace SIL.FieldWorks.XWorks
 			var item = (ToolStripMenuItem)sender;
 			var tagObjects = (object[])item.Tag;
 			var propertyTable = tagObjects[0] as PropertyTable;
-			var mediator = tagObjects[1] as Mediator;
 			var cache = propertyTable.GetValue<LcmCache>("cache");
 			GeckoElement entryElement = tagObjects[2] as GeckoElement;
 			GeckoElement fieldElement = tagObjects[3] as GeckoElement;
@@ -728,9 +727,7 @@ namespace SIL.FieldWorks.XWorks
 				ILexEntry fieldLexEntry = GetGeckoLexEntry(fieldElement, cache);
 				if (entryLexEntry != null && fieldLexEntry != null && fieldLexEntry != entryLexEntry)
 				{
-#pragma warning disable 618 // suppress obsolete warning
-					mediator.SendMessage("JumpToRecord", fieldLexEntry.Hvo);
-#pragma warning restore 618
+					Publisher.Publish(new PublisherParameterObject(EventConstants.JumpToRecord, fieldLexEntry.Hvo, propertyTable.GetWindow()));
 				}
 				// Jump to field on idle to allow JumpToRecord to finish.
 				object[] arguments = new object[] { fieldObj.Hvo, fieldName, fieldElement.TextContent };


### PR DESCRIPTION
## Summary

Converts every synchronous `SendMessage("JumpToRecord")` sender to a window-scoped `Publisher.Publish` (sync-to-sync, timing-neutral) — the original six sites plus the two just added by the Avalonia Insert/Merge Entry dialogs. The Avalonia insert path's `SendMessage("MasterRefresh")` is likewise converted to the two-stage `RefreshCurrentView`/`MasterRefresh` publish (the LT-21402 pattern), still only for newly created entries.

Part 1 of the JumpToRecord conversion; the 14 deferred `Broadcast*` senders and all `OnJumpToRecord` Mediator entry points are unchanged (dual dispatch until Part 2).

## Design

- **`RecordClerk` is the single Pub/Sub subscriber:** a new `protected virtual JumpToRecordViaPublisher`, subscribed in `ActivateUI` and removed in `RemoveNotification`. Every implementation first bails out unless `IsActiveClerk`, because dependent clerks (e.g. `OccurrencesOfSelectedWordform`) subscribe without ever becoming the "ActiveClerk" — without the guard, one publish could run two clerks' jumps in unspecified order.
- **`OccurrencesOfSelectedUnit` overrides the virtual** to give `ConcordanceControl` the first chance at a published jump, so the clerk's jump-miss path (which would add texts to the interesting-texts list and can prompt about filters) cannot run in the Concordance tool. No converted sender can currently fire in that tool (LT-11998 hides the FLExText import there), so this arbitration is groundwork the Part 2 Broadcast-sender conversions will rely on.
- **`XhtmlDocView` deliberately does not subscribe:** under the Mediator its handler runs only when the clerk misses, and no converted sender can reach a clerk-miss in its views (Dictionary, Reversal Indexes, and Classified Dictionary are all Lexicon-area, while the one import that could miss is gated to Texts & Words). Part 2 designs its clerk-miss arbitration when converting Follow-Link.

## What stopped happening, and why each disappearance is safe

Nothing user-reachable — every converted sender fires in a context where the active clerk was already the only effective Mediator responder. The two corners where dispatch behavior differs on paper (FLExText import while a Dictionary/Reversal doc view is active) are unreachable: that import is only offered in the Texts & Words area.

## Validation

- `build.ps1 -SkipNative` clean; re-grep confirms zero `SendMessage("JumpToRecord"`/`SendMessage("MasterRefresh"` sites remain and the 14 `Broadcast*` sites are untouched.
- xWorksTests: 1221 passed / 2 skipped. ITextDllTests: 207 passed / 1 skipped.
- Manual GUI testing: insert/merge entry (Legacy and New UI), FLExText import across Texts & Words tools (jump to new text in Interlinear Texts; interesting-texts behavior in Analyses/Complex Concordance), Grammar category insert, Notebook record insert, and the two-window check (a jump in one window does not move the other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1054)
<!-- Reviewable:end -->
