### PR TITLE
Fix buffer overread setting line-break text in LgLineBreaker

### DIFF
--- a/Src/views/Test/TestLgLineBreaker.h
+++ b/Src/views/Test/TestLgLineBreaker.h
@@ -65,6 +65,30 @@ namespace TestViews
 			}
 		}
 
+		void testPutLineBreakTextUsesLength()
+		{
+			unitpp::assert_true("m_qlb", m_qlb.Ptr());
+			// The text sits inside a larger buffer with no NUL terminator; the characters
+			// after cch must not become part of the break text, and the copy must not
+			// scan past cch looking for a terminator.
+			OLECHAR rgch[] = { 'o','n','e',' ','t','w','o',' ','s','i','x','X','X','X','X','X' };
+			const int cch = 11; // "one two six"
+			CheckHr(m_qlb->put_LineBreakText(rgch, cch));
+
+			OLECHAR rgchOut[32];
+			int cchOut = 0;
+			CheckHr(m_qlb->GetLineBreakText(32, rgchOut, &cchOut));
+			unitpp::assert_eq("break text length", cch, cchOut);
+			unitpp::assert_true("break text content",
+				memcmp(rgch, rgchOut, cch * isizeof(OLECHAR)) == 0);
+
+			// Word boundaries inside the text must be found.
+			int ichBreak = -1;
+			LgLineBreak lbWeight;
+			CheckHr(m_qlb->LineBreakBefore(10, &ichBreak, &lbWeight));
+			unitpp::assert_eq("line break before 'six'", 8, ichBreak);
+		}
+
 	public:
 		TestLgLineBreaker();
 		virtual void SuiteSetup()

--- a/Src/views/lib/LgLineBreaker.cpp
+++ b/Src/views/lib/LgLineBreaker.cpp
@@ -519,10 +519,12 @@ STDMETHODIMP LgLineBreaker::put_LineBreakText(OLECHAR * prgchIn, int cch)
 	SetupBreakIterator(); //make sure we have one.
 
 	m_cchBrkMax = cch;
-	// Make a copy of the line break text so that the scope of the iterator and the UnicodeString contents
-	// have the same lifetime. This will consume more memory than using m_usBrkIt->setText but is safer
-	// (and perhaps necessary after the icu70 upgrade which stopped building our projects with a static CRT)
-	m_usBrkIt = prgchIn;
+	// The break iterator retains a reference to m_usBrkIt, and prgchIn is a transient
+	// buffer with no NUL terminator, so store a length-bounded copy, never an alias.
+	// The copy must take its length from cch rather than a terminator scan; the
+	// (text, textLength) constructor is ICU's only copying wchar_t overload that
+	// takes an explicit length.
+	m_usBrkIt = UnicodeString(prgchIn, cch);
 	m_pBrkit->setText(m_usBrkIt);
 
 	END_COM_METHOD(g_fact, IID_ILgLineBreaker);


### PR DESCRIPTION
## Quick Summary

- Fixes the intermittent `VerifyScenario("long-prose")` / `RunBenchmark("long-prose")` CI failure — a `COMException: Access violation` from `VwRootBox.Layout` that hit unrelated PRs roughly weekly (five identical failures Jul 16–Aug 10; [example run](https://github.com/sillsdev/FieldWorks/runs/93608132221)).
- `LgLineBreaker::put_LineBreakText` now copies its text with the length-taking `UnicodeString` constructor instead of assigning the bare pointer, which scans an unterminated buffer for a null terminator.
- Adds a native regression test covering the copy length and word-break lookup.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)

**Why it failed.** `UniscribeEngine::FindBreakPoint` hands `put_LineBreakText` a text buffer that carries no null terminator. Storing that text by assigning the bare pointer made ICU scan past the end of the buffer looking for a terminator; the read only faults when the memory after the buffer happens to be unmapped, which is what made the crash rare and heap-layout dependent. It surfaced only in the `long-prose` scenario because paragraphs under 1000 characters go through a stack buffer (where the overread never faults), and that scenario has by far the largest heap-allocated paragraph text. The overread shipped with the ICU 70 upgrade (6592f1ea6, Feb 2022), so real projects with paragraphs over ~1000 characters have been exposed to it since.

**Verification.** Made the crash deterministic with full PageHeap: the scan faulted at exactly `text[cch]` inside `icuuc70!UnicodeString::doAppend` on every long-prose layout before the fix, and not at all after. All 30 render baseline tests pass unchanged (the fix does not alter break positions), and the new native `TestLgLineBreaker` test passes.

**Related history.** The STA attribute added by #919 for these same AVs remains correct and should stay: Views COM objects are apartment-threaded, so the fixtures need `[Apartment(ApartmentState.STA)]` regardless — but the AVs it chased were most likely this overread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1057)
<!-- Reviewable:end -->
