### PR TITLE
Fix duplicate PATH casing in VS environment setup

### DIFF
--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -261,7 +261,9 @@ function Set-ProcessEnvironmentVariables {
         $namesToRemove = Get-EnvironmentVariableNamesToRemove `
             -ExistingNames $existingVariables.Keys -IncomingName $variable.Name
         foreach ($existingName in $namesToRemove) {
-            Remove-Item -Path "Env:$existingName"
+            # A case-duplicate group can list the same underlying Windows
+            # variable more than once; removing the first already clears it.
+            [System.Environment]::SetEnvironmentVariable($existingName, $null)
         }
 
         Set-Item -Path "Env:$($variable.Name)" -Value $variable.Value

--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -227,18 +227,28 @@ function Get-VsDevEnvironmentVariables {
         throw 'Failed to initialize Visual Studio environment'
     }
 
-    $variables = [ordered]@{}
-    foreach ($line in $envOutput) {
-        $parts = $line -split '=', 2
-        if ($parts.Length -eq 2 -and $parts[0]) {
-            $variables[$parts[0]] = $parts[1]
-        }
-    }
+    $variables = ConvertFrom-EnvironmentVariableLines -Lines $envOutput
 
     return [pscustomobject]@{
         Toolchain = $toolchain
         Variables = [pscustomobject]$variables
     }
+}
+
+function ConvertFrom-EnvironmentVariableLines {
+    param(
+        [string[]]$Lines
+    )
+
+    $variables = [ordered]@{}
+    foreach ($line in $Lines) {
+        $parts = $line -split '=', 2
+        if ($parts.Length -eq 2 -and $parts[0] -and -not $variables.Contains($parts[0])) {
+            $variables.Add($parts[0], $parts[1])
+        }
+    }
+
+    return [pscustomobject]$variables
 }
 
 function Get-ActiveVcToolBinPath {

--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -251,6 +251,36 @@ function ConvertFrom-EnvironmentVariableLines {
     return [pscustomobject]$variables
 }
 
+function Set-ProcessEnvironmentVariables {
+    param(
+        [pscustomobject]$Variables
+    )
+
+    $existingVariables = [System.Environment]::GetEnvironmentVariables('Process')
+    foreach ($variable in $Variables.PSObject.Properties) {
+        $namesToRemove = Get-EnvironmentVariableNamesToRemove `
+            -ExistingNames $existingVariables.Keys -IncomingName $variable.Name
+        foreach ($existingName in $namesToRemove) {
+            Remove-Item -Path "Env:$existingName"
+        }
+
+        Set-Item -Path "Env:$($variable.Name)" -Value $variable.Value
+    }
+}
+
+function Get-EnvironmentVariableNamesToRemove {
+    param(
+        [string[]]$ExistingNames,
+        [string]$IncomingName
+    )
+
+    foreach ($existingName in $ExistingNames) {
+        if ([string]::Equals($existingName, $IncomingName, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $existingName
+        }
+    }
+}
+
 function Get-ActiveVcToolBinPath {
     <#
     .SYNOPSIS
@@ -380,9 +410,7 @@ function Initialize-VsDevEnvironment {
     Write-Host "   Setting up environment for $arch..." -ForegroundColor Gray
 
     $vsEnvironment = Get-VsDevEnvironmentVariables -Architecture $arch -HostArchitecture $arch
-    foreach ($variable in $vsEnvironment.Variables.PSObject.Properties) {
-        Set-Item -Path "Env:$($variable.Name)" -Value $variable.Value
-    }
+    Set-ProcessEnvironmentVariables -Variables $vsEnvironment.Variables
 
     if (-not (Test-VsDevEnvironmentActive)) {
         throw 'Visual Studio C++ environment not configured'

--- a/Build/Agent/Test-FwBuildEnvironment.ps1
+++ b/Build/Agent/Test-FwBuildEnvironment.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$module = Import-Module (Join-Path $PSScriptRoot 'FwBuildEnvironment.psm1') `
+	-Force -PassThru
+$environmentLines = @(
+	'PATH=C:\toolchain\bin;C:\Windows\System32',
+	'VCToolsInstallDir=C:\toolchain\',
+	'Path=C:\Windows\System32'
+)
+
+$variables = & $module {
+	param($Lines)
+	ConvertFrom-EnvironmentVariableLines -Lines $Lines
+} $environmentLines
+
+$expectedPath = 'C:\toolchain\bin;C:\Windows\System32'
+if ($variables.Path -ne $expectedPath) {
+	throw "Expected the first case-insensitive PATH value to win. Actual: $($variables.Path)"
+}
+
+Write-Output '[OK] FwBuildEnvironment smoke test passed.'

--- a/Build/Agent/Test-FwBuildEnvironment.ps1
+++ b/Build/Agent/Test-FwBuildEnvironment.ps1
@@ -1,5 +1,7 @@
 [CmdletBinding()]
-param()
+param(
+	[switch]$ChildProcess
+)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -20,6 +22,37 @@ $variables = & $module {
 $expectedPath = 'C:\toolchain\bin;C:\Windows\System32'
 if ($variables.Path -ne $expectedPath) {
 	throw "Expected the first case-insensitive PATH value to win. Actual: $($variables.Path)"
+}
+
+$namesToRemove = & $module {
+	Get-EnvironmentVariableNamesToRemove `
+		-ExistingNames @('PATH', 'Path', 'PATHEXT') -IncomingName 'PATH'
+}
+if ((@($namesToRemove) -join ',') -ne 'PATH,Path') {
+	throw "Expected both PATH casings to be removed. Actual: $(@($namesToRemove) -join ',')"
+}
+
+if ($ChildProcess) {
+	& $module {
+		param($Variables)
+		Set-ProcessEnvironmentVariables -Variables $Variables
+	} $variables
+
+	$pathLines = & C:\Windows\System32\cmd.exe /d /c 'set path'
+	$pathVariableLines = @($pathLines | Where-Object { $_ -match '^PATH=' })
+	if ($pathVariableLines.Count -ne 1) {
+		throw "Expected one case-insensitive PATH entry. Actual count: $($pathVariableLines.Count)"
+	}
+
+	$null = ([System.Diagnostics.ProcessStartInfo]::new()).EnvironmentVariables
+	Write-Output '[OK] FwBuildEnvironment child-process smoke test passed.'
+	exit 0
+}
+
+$pwshPath = [System.Environment]::ProcessPath
+& $pwshPath -NoProfile -File $PSCommandPath -ChildProcess
+if ($LASTEXITCODE -ne 0) {
+	throw "Expected isolated child-process smoke test to pass. Exit code: $LASTEXITCODE"
 }
 
 Write-Output '[OK] FwBuildEnvironment smoke test passed.'


### PR DESCRIPTION
## Quick Summary

- Fixes the CI crash this branch's earlier two commits introduced: removing
  a case-duplicate environment variable name threw `ItemNotFoundException`
  once the first duplicate had already cleared the variable.
- Swaps `Remove-Item -Path "Env:$name"` for
  `[System.Environment]::SetEnvironmentVariable($name, $null)`, .NET's
  documented safe no-op for removing a variable that's already gone.
- No behavior change to which value wins or which duplicates get removed —
  only the removal call itself is now idempotent.

## Why this was needed

The earlier commits taught `Set-ProcessEnvironmentVariables` to strip every
case-cased duplicate of an incoming VS variable (a stray `Path` beside
`PATH`) before applying VsDevCmd's value. On GitHub's Windows runners this
threw immediately: Windows env vars are one case-insensitive namespace, so
removing the first duplicate in a group already clears it, and the next
`Remove-Item` for a same-named duplicate found nothing left. `Build Debug
and run tests` died in ~45 seconds, before a single test ran ([failing
run](https://github.com/sillsdev/FieldWorks/actions/runs/31699801693/job/94445940346)).

This is a known, still-open .NET behavior — `GetEnvironmentVariables()` can
expose one Windows variable as two case-distinct dictionary keys, see
[dotnet/runtime#42029](https://github.com/dotnet/runtime/issues/42029) —
not something specific to this repo's parsing.

## Where to look

- `Set-ProcessEnvironmentVariables` (`Build/Agent/FwBuildEnvironment.psm1`)
  — the removal loop, now idempotent.
- `Get-EnvironmentVariableNamesToRemove` — unchanged; still returns every
  case-insensitive match, which is exactly why removal needed to tolerate
  a duplicate already being gone.
- `Test-FwBuildEnvironment.ps1` — existing coverage for name *selection*;
  see "Surprising findings" below for why it didn't catch this.

## What is deliberately not here

- No new automated test reproduces the exact CI failure (a case-duplicate
  already sitting in the process environment before removal runs) —
  verified by hand instead (see Evidence accordion).
- No migration to Microsoft's `Enter-VsDevShell` / `Launch-VsDevShell.ps1`,
  which sidesteps this whole bug class — a follow-up question, not folded
  into this fix. See "Paths not taken."

## Verification

- `Check commit messages` (gitlint) passes on the new commit.
- `Build Debug and run tests` was re-running as of this write-up — confirm
  green on the [Checks tab](https://github.com/sillsdev/FieldWorks/pull/1062/checks)
  before merging.
- Manually reproduced the fix surviving the failure: two case-duplicate
  names through `SetEnvironmentVariable($name, $null)` raise no exception
  (the old `Remove-Item` form throws on the second call).
- Full native build/test suite not run locally, unchanged from this
  branch's existing checklist note.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1062)
<!-- Reviewable:end -->

---

<details>
<summary><b>Reading this a year from now</b> -- start here</summary>

This PR's first two commits added case-duplicate reconciliation to VS
environment setup; this third commit fixes the bug that reconciliation
introduced. There's no deleted research doc behind this one — the
reasoning below is just the parts too long for the pitch above.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

**`[System.Environment]::SetEnvironmentVariable($name, $null)` over a
`Test-Path` guard or `-ErrorAction SilentlyContinue`.** All three make the
removal idempotent. `SetEnvironmentVariable(name, $null)` was picked
because it's the one with an explicit written contract for this exact
case — Microsoft's docs state plainly: *"If `variable` doesn't exist, no
error occurs even though the operation cannot be performed."* A
`Test-Path` guard would work too but adds a branch; `-ErrorAction
SilentlyContinue` on `Remove-Item` would also work but silently swallows
any *other* reason removal could fail. The chosen form has no failure mode
to swallow — it's a documented no-op, not suppressed error handling.

</details>

<details>
<summary><b>Paths not taken</b></summary>

**Migrating to `Enter-VsDevShell` / `Launch-VsDevShell.ps1`.** Microsoft
ships this as a supported PowerShell module
(`Microsoft.VisualStudio.DevShell.dll`) specifically for initializing a VS
developer environment, and its docs call it "the recommended way to
initialize Developer PowerShell interactively or for scripting build
automation." That would replace the hand-rolled `cmd.exe /c VsDevCmd.bat
&& set`-then-parse approach in `Get-VsDevEnvironmentVariables` entirely,
removing this whole class of bug at the root.

It wasn't adopted here for two reasons: it's a materially bigger change
than a CI-fix PR should carry, and this repo's VS-instance selection
(`Get-FwToolchainPolicy`, pinned via `vswhere` against
`FieldWorks.Toolchain.props`) would need to be re-verified against
`Enter-VsDevShell -VsInstallPath`/`-InstanceId` rather than assumed
compatible. Worth a dedicated follow-up, not this branch.

Also checked whether mainstream CI tooling already solved this: the
popular `ilammy/msvc-dev-cmd` GitHub Action does not — it diffs old vs.
new environment by exact-case string key with no case-insensitive
handling at all. This repo's reconciliation logic is already ahead of
that prior art; it just needed the removal step made idempotent.

</details>

<details>
<summary><b>Surprising findings</b></summary>

`Test-FwBuildEnvironment.ps1` (added earlier on this branch) already
exercises `Get-EnvironmentVariableNamesToRemove` with `@('PATH', 'Path',
'PATHEXT')` and correctly asserts both `PATH` and `Path` are selected for
removal. Its `-ChildProcess` smoke test even calls
`Set-ProcessEnvironmentVariables` for real. It still didn't catch this bug
locally, because that smoke test's child process doesn't start with a
genuine case-duplicate already present in its own environment the way
GitHub's Windows runner apparently does — the test proves selection logic
is correct without proving the removal loop survives acting on its own
output.

</details>

<details>
<summary><b>Evidence</b></summary>

Failing run, before this commit:

```
Remove-Item : Cannot find path 'Env:\GITHUB_ACTION_REF' because it does not exist.
At D:\a\FieldWorks\FieldWorks\Build\Agent\FwBuildEnvironment.psm1:264 char:13
+             Remove-Item -Path "Env:$existingName"
    + CategoryInfo          : ObjectNotFound: (Env:\GITHUB_ACTION_REF:String) [Remove-Item], ItemNotFoundException
##[error]Process completed with exit code 1.
```

[Full failing run](https://github.com/sillsdev/FieldWorks/actions/runs/31699801693/job/94445940346).

Local reproduction of the fix surviving the same shape of failure:

```powershell
$env:TESTDUP = "old"
foreach ($n in @("TESTDUP", "TESTDUP")) {
    [System.Environment]::SetEnvironmentVariable($n, $null)
}
# No exception; second call is a documented no-op.
```

`Environment.SetEnvironmentVariable` docs (`learn.microsoft.com`):
*"If `variable` doesn't exist, no error occurs even though the operation
cannot be performed."*

</details>
