### PR TITLE
LT-22702: Escape custom list range ids at the point they are written

### DIFF
--- a/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
@@ -1135,6 +1135,84 @@ namespace LexTextControlsTests
 			VerifyExportRanges(xdocRangeFile);
 		}
 
+		///--------------------------------------------------------------------------------------
+		/// <summary>
+		/// A custom list name reaches the ranges file as a range id, where it needs the escaping
+		/// rules for an attribute. It used to be escaped once as element content on the way into
+		/// the exporter's map and never again, so a name holding a quotation mark left the ranges
+		/// document unparseable.
+		/// </summary>
+		///--------------------------------------------------------------------------------------
+		[Test]
+		public void LiftExportRanges_CustomListRangeIdWithQuoteIsEscapedForAnAttribute()
+		{
+			const string ksListName = "So-called \"words\"";
+			XmlDocument xdocLift;
+			XmlDocument xdocRangeFile;
+			var customList = ExportWithCustomList(ksListName, out xdocLift, out xdocRangeFile);
+
+			var range = xdocRangeFile.SelectSingleNode(string.Format("//range[@guid='{0}']", customList.Guid));
+			Assert.That(range, Is.Not.Null, "the custom list must be written as a range");
+			Assert.That(range.Attributes["id"].Value, Is.EqualTo(ksListName),
+				"the range id must read back as the name stored");
+		}
+
+		///--------------------------------------------------------------------------------------
+		/// <summary>
+		/// The same name is written into the .lift header and into the ranges file, so the two must
+		/// agree. Escaping once on the way in and again at the header write site turned an ampersand
+		/// into &amp;amp; there while the ranges file kept a single escape.
+		/// </summary>
+		///--------------------------------------------------------------------------------------
+		[Test]
+		public void LiftExportRanges_CustomListRangeIdWithAmpersandIsEscapedExactlyOnce()
+		{
+			const string ksListName = "Birds & Beasts";
+			XmlDocument xdocLift;
+			XmlDocument xdocRangeFile;
+			var customList = ExportWithCustomList(ksListName, out xdocLift, out xdocRangeFile);
+
+			var rangesRange = xdocRangeFile.SelectSingleNode(string.Format("//range[@guid='{0}']", customList.Guid));
+			Assert.That(rangesRange, Is.Not.Null);
+			Assert.That(rangesRange.Attributes["id"].Value, Is.EqualTo(ksListName),
+				"one level of escaping, undone by the parser, must give back the name stored");
+			var headerIds = xdocLift.SelectNodes("//header/ranges/range/@id");
+			Assert.That(headerIds, Is.Not.Null);
+			Assert.That(headerIds.Cast<XmlNode>().Any(id => id.Value == ksListName),
+				"the .lift header must name the range the same way the ranges file does");
+		}
+
+		/// <summary>
+		/// Exports both files from one exporter, so that the custom list is discovered by the .lift
+		/// pass and is therefore written by the ranges pass.
+		/// </summary>
+		private ICmPossibilityList ExportWithCustomList(string listName, out XmlDocument xdocLift, out XmlDocument xdocRangeFile)
+		{
+			ICmPossibilityList customList = null;
+			NonUndoableUnitOfWorkHelper.Do(m_cache.ActionHandlerAccessor, () =>
+			{
+				customList = AddCustomList(listName);
+				MakeCustomField("CustomFieldForCustomList", LexEntryTags.kClassId,
+					WritingSystemServices.kwsAnal, CustomFieldType.ListRefAtomic, customList.Guid);
+			});
+			var exporter = new LiftExporter(m_cache);
+			xdocLift = new XmlDocument();
+			using (var w = new StringWriter())
+			{
+				// SUT: the .lift pass populates the map the ranges pass writes from.
+				exporter.ExportLift(w, LiftFolder);
+				xdocLift.LoadXml(w.ToString());
+			}
+			xdocRangeFile = new XmlDocument();
+			using (var w = new StringWriter())
+			{
+				// SUT
+				exporter.ExportLiftRanges(w);
+				xdocRangeFile.LoadXml(w.ToString());
+			}
+			return customList;
+		}
+
 		/// <summary>
 		/// LT-15467 documents a Flex to WeSay S/R which had pronunciation audio files multiplying like bunny rabbits.
 		/// Make sure the export doesn't make new files when two different references point to the same file.

--- a/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
@@ -493,7 +493,11 @@ namespace LexTextControlsTests
 			m_mapPartsOfSpeech.Clear();
 			m_mapAcademicDomains.Clear();
 			m_mapPublications.Clear();
-			// NUnit shares one fixture instance across the tests, so this outlives the cache it indexes.
+			// NUnit shares one fixture instance across the tests, so these outlive the cache they index.
+			m_customFieldEntryIds.Clear();
+			m_customFieldSenseIds.Clear();
+			m_customFieldAllomorphsIds.Clear();
+			m_customFieldExampleSentencesIds.Clear();
 			m_customListsGuids.Clear();
 			var mockProjectName = "xxyyzProjectFolderForLIFTTest";
 			MockProjectFolder = Path.Combine(Path.GetTempPath(), mockProjectName);

--- a/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
@@ -493,6 +493,8 @@ namespace LexTextControlsTests
 			m_mapPartsOfSpeech.Clear();
 			m_mapAcademicDomains.Clear();
 			m_mapPublications.Clear();
+			// NUnit shares one fixture instance across the tests, so this outlives the cache it indexes.
+			m_customListsGuids.Clear();
 			var mockProjectName = "xxyyzProjectFolderForLIFTTest";
 			MockProjectFolder = Path.Combine(Path.GetTempPath(), mockProjectName);
 			var mockProjectPath = Path.Combine(MockProjectFolder, mockProjectName + ".fwdata");
@@ -1137,10 +1139,8 @@ namespace LexTextControlsTests
 
 		///--------------------------------------------------------------------------------------
 		/// <summary>
-		/// A custom list name reaches the ranges file as a range id, where it needs the escaping
-		/// rules for an attribute. It used to be escaped once as element content on the way into
-		/// the exporter's map and never again, so a name holding a quotation mark left the ranges
-		/// document unparseable.
+		/// A custom list name reaches the ranges file as a range id, which is an attribute, so a name
+		/// holding a quotation mark has to be escaped by the attribute rules for the document to parse.
 		/// </summary>
 		///--------------------------------------------------------------------------------------
 		[Test]
@@ -1159,9 +1159,8 @@ namespace LexTextControlsTests
 
 		///--------------------------------------------------------------------------------------
 		/// <summary>
-		/// The same name is written into the .lift header and into the ranges file, so the two must
-		/// agree. Escaping once on the way in and again at the header write site turned an ampersand
-		/// into &amp;amp; there while the ranges file kept a single escape.
+		/// A custom list name is written as a range id in both the .lift header and the ranges file,
+		/// escaped once in each, so that the two files name the range the same way.
 		/// </summary>
 		///--------------------------------------------------------------------------------------
 		[Test]

--- a/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/LiftExportTests.cs
@@ -489,11 +489,11 @@ namespace LexTextControlsTests
 		[SetUp]
 		public void CreateMockCache()
 		{
+			// NUnit shares one fixture instance across the tests, so these all outlive the cache that filled them.
 			m_mapSemanticDomains.Clear();
 			m_mapPartsOfSpeech.Clear();
 			m_mapAcademicDomains.Clear();
 			m_mapPublications.Clear();
-			// NUnit shares one fixture instance across the tests, so these outlive the cache they index.
 			m_customFieldEntryIds.Clear();
 			m_customFieldSenseIds.Clear();
 			m_customFieldAllomorphsIds.Clear();

--- a/Src/LexText/LexTextControls/LiftExporter.cs
+++ b/Src/LexText/LexTextControls/LiftExporter.cs
@@ -57,7 +57,13 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// <summary>
 		/// This contains the possibility lists that are custom or that are referenced by a custom field.
 		/// </summary>
+		/// <remarks>
+		/// Range names are held unescaped. Each write site escapes for the context it writes into, as
+		/// everything else in this exporter does; escaping on the way in instead escaped a second time
+		/// at the write site, and picked the element rules for a value only ever written as an attribute.
+		/// </remarks>
 		private Dictionary<Guid, string> m_CmPossListsReferencedOrCustom = new Dictionary<Guid, string>();
+		/// <remarks>Range names are held unescaped, as for <see cref="m_CmPossListsReferencedOrCustom"/>.</remarks>
 		private Dictionary<Guid, string> m_ListsGuidToRangeName = new Dictionary<Guid, string>();
 		private readonly ICmPossibilityListRepository m_repoCmPossibilityLists;
 		private readonly ISilDataAccessManaged m_sda;
@@ -1979,10 +1985,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		{
 			if (list.PossibilitiesOS.Count == 0)
 				return;
+			var sRangeId = MakeSafeAndNormalizedAttribute(rangeId);
 			if (String.IsNullOrEmpty(guid))					//only output the guid for custom lists
-				w.WriteLine("<range id=\"{0}\">", rangeId);
+				w.WriteLine("<range id=\"{0}\">", sRangeId);
 			else
-				w.WriteLine("<range id=\"{0}\" guid=\"{1}\">", rangeId, MakeSafeAndNormalizedAttribute(guid));
+				w.WriteLine("<range id=\"{0}\" guid=\"{1}\">", sRangeId, MakeSafeAndNormalizedAttribute(guid));
 			foreach (var poss in list.ReallyReallyAllPossibilities)
 			{
 				var liftId = poss.Name.BestAnalysisVernacularAlternative.Text;
@@ -2348,7 +2355,7 @@ namespace SIL.FieldWorks.LexText.Controls
 						{
 							var rangeName = RangeNames.GetRangeNameForLiftExport(m_mdc, possList);
 							if (!listsToBeExported.ContainsKey(possList.Guid))
-								listsToBeExported.Add(possList.Guid, MakeSafeAndNormalizedXml(rangeName));
+								listsToBeExported.Add(possList.Guid, rangeName);
 						}
 						break;
 					default:
@@ -2367,7 +2374,7 @@ namespace SIL.FieldWorks.LexText.Controls
 				if (list.Owner == null && !listsToBeExported.ContainsKey(list.Guid))
 				{
 					var rangeName = RangeNames.GetRangeNameForLiftExport(m_mdc, list);
-					listsToBeExported[list.Guid] = MakeSafeAndNormalizedXml(rangeName);
+					listsToBeExported[list.Guid] = rangeName;
 				}
 			}
 		}
@@ -2440,7 +2447,7 @@ namespace SIL.FieldWorks.LexText.Controls
 				var rangeName = RangeNames.GetRangeNameForLiftExport(m_mdc, possList);
 				if (!cmPossibilityListsReferencedByFields.ContainsKey(possListGuid))
 				{
-					cmPossibilityListsReferencedByFields.Add(possListGuid, MakeSafeAndNormalizedXml(rangeName));
+					cmPossibilityListsReferencedByFields.Add(possListGuid, rangeName);
 				}
 			}
 		}
@@ -2463,7 +2470,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			//by a custom field and which are not already included yet.
 			foreach (var list in cmPossibilityListsReferencedByFields)
 			{
-				m_ListsGuidToRangeName.Add(list.Key, MakeSafeAndNormalizedXml(list.Value));
+				m_ListsGuidToRangeName.Add(list.Key, list.Value);
 			}
 		}
 

--- a/Src/LexText/LexTextControls/LiftExporter.cs
+++ b/Src/LexText/LexTextControls/LiftExporter.cs
@@ -61,8 +61,8 @@ namespace SIL.FieldWorks.LexText.Controls
 		/// </summary>
 		private Dictionary<Guid, string> m_CmPossListsReferencedOrCustom = new Dictionary<Guid, string>();
 		/// <summary>
-		/// Maps a possibility list to the name of its LIFT range. Range names are held unescaped, so
-		/// that each is escaped by the rules of the context it is written into.
+		/// Range names are held unescaped, so that each is escaped by the rules of the context it is
+		/// written into.
 		/// </summary>
 		private Dictionary<Guid, string> m_ListsGuidToRangeName = new Dictionary<Guid, string>();
 		private readonly ICmPossibilityListRepository m_repoCmPossibilityLists;

--- a/Src/LexText/LexTextControls/LiftExporter.cs
+++ b/Src/LexText/LexTextControls/LiftExporter.cs
@@ -56,14 +56,14 @@ namespace SIL.FieldWorks.LexText.Controls
 		private readonly int m_wsBestVernAnal;
 		/// <summary>
 		/// This contains the possibility lists that are custom or that are referenced by a custom field.
+		/// Range names are held unescaped, so that each is escaped by the rules of the context it is
+		/// written into.
 		/// </summary>
-		/// <remarks>
-		/// Range names are held unescaped. Each write site escapes for the context it writes into, as
-		/// everything else in this exporter does; escaping on the way in instead escaped a second time
-		/// at the write site, and picked the element rules for a value only ever written as an attribute.
-		/// </remarks>
 		private Dictionary<Guid, string> m_CmPossListsReferencedOrCustom = new Dictionary<Guid, string>();
-		/// <remarks>Range names are held unescaped, as for <see cref="m_CmPossListsReferencedOrCustom"/>.</remarks>
+		/// <summary>
+		/// Maps a possibility list to the name of its LIFT range. Range names are held unescaped, so
+		/// that each is escaped by the rules of the context it is written into.
+		/// </summary>
 		private Dictionary<Guid, string> m_ListsGuidToRangeName = new Dictionary<Guid, string>();
 		private readonly ICmPossibilityListRepository m_repoCmPossibilityLists;
 		private readonly ISilDataAccessManaged m_sda;


### PR DESCRIPTION
Fixes [LT-22702](https://jira.sil.org/browse/LT-22702).

Companion to #1063. The two diffs do not overlap.

## Quick Summary

- A custom possibility list's name is written into two XML **attributes**: the `range/@id` in
  the `.lift` header, and the `range/@id` of the same range in the `.lift-ranges` file.
- The exporter escaped that name **once, on collection**, with the element-content rules
  (`MakeSafeAndNormalizedXml`), rather than at each write site with the attribute rules --
  which is both the wrong rule and the wrong place.
- This branch holds the collected names unescaped and escapes at each write site, matching what
  the rest of the exporter already does for every other range and range-element id.

**Two defects fall out of escaping on collection:**

1. **The header disagrees with its own ranges file.** The header write site escapes again, so a
   list named `Birds & Beasts` is emitted as `Birds &amp;amp; Beasts`, while the ranges file
   kept a single escape.
2. **The ranges file can be unparseable.** The ranges write site does not escape at all, and
   element rules never escape `"`, so a list named `So-called "words"` closes the id attribute
   early and leaves the `.lift-ranges` unreadable by any conforming parser.

## The change

**Collect raw.** Four sites stop pre-escaping, so the two name maps hold what the user typed:

- `GetCustomListsAndReferencedLists`
- `GetCustomListsNotYetAdded`
- `AddPossListRefdByField`
- `MapCmPossibilityListGuidsToLiftRangeNames`

The `m_ListsGuidToRangeName` map already held standard range names raw via `MapGuidToRange`, so
this also stops it holding a mix of escaped and unescaped values.

**Escape at the write site.** `WritePossibilityListAsRange` now puts its `rangeId` through
`MakeSafeAndNormalizedAttribute`, hoisted into a local so the normalizer runs once and both
branches are visibly the same.

**Leave the two already-correct write sites alone.** The header `<range id href>` and the
custom-field spec string need no change once their input is raw; they stop double-escaping on
their own.

**Record the invariant.** It is stated on the two map declarations, since "held unescaped" is
the kind of thing a later change would otherwise re-break.

## Scope

Only custom and referenced possibility lists are affected. `WritePossibilityListAsRange` has
six callers; the other five pass `RangeNames` constants, where the helper is a no-op.

**Not addressed here.** `WriteRangeRefsForListsReferencedByFields` writes a header
`<range id href>` for every collected list, while `WritePossibilityListAsRange` returns before
writing anything for a list with no possibilities. So an empty custom list still yields a header
reference to a range that has no body in the ranges file. That is pre-existing and left alone;
the only effect here is that the dangling id now carries the corrected spelling.

<details>
<summary><b>Sweep: every other range id write already escapes and normalizes</b></summary>

I swept every `<range id=` and `<range-element id=` write in `LiftExporter.cs` to be sure this
is the whole of it.

- `WritePossibilityRangeElement` -- covers semantic domains, status, locations, people,
  anthropology, translation tags, production restrictions and custom lists. Escapes and
  normalizes both its range ids and its range-element ids.
- The four part-of-speech sub-range writers -- `-feature-value`, `-slot`, `-infl-class`,
  `-stem-name`. Same.
- Everything else is a literal or a `RangeNames` constant.

</details>

## Effects worth knowing

**This is not a normalization change.** The collected names were already NFC-normalized on the
way in, and remain so -- `MakeSafeAndNormalizedAttribute` normalizes as well as escapes. No id
changes spelling as a result of this branch; only escaping changes, and only for names holding
`&`, `<`, `>` or `"`. (#1063 is the branch that changes spelling.)

**FLEx's own importer is unaffected.** A custom list's range falls through
`ProcessRangeElement`'s switch to `default:`, which handles only the `-slot`, `-infl-class`,
`-feature-value` and `-stem-name` suffixes and otherwise does nothing but a `Debug.WriteLine`.
FLEx does not import custom-list ranges at all, so there is no re-import behavior to check.
This matters only to third-party consumers of the files, and to what lands in a shared repo.

**The `qaa-x-spec` custom-field definition also changes.** `GetCustomFieldDefinition` appends
the map value raw into `; range={0}`, and `GenerateCustomFieldSpecs` escapes the whole spec
string once at its write site. With the map now holding raw names, a custom list name containing
one of the four characters reaches that form single-escaped where it used to be double-escaped.
This is the same defect and the same correction as the header range ref, and it brings custom
lists into line with the standard list names, which `MapGuidToRange` has always stored raw. It
is called out separately because it touches the header field definitions, not just ranges.

**LIFT Send/Receive sees a whole-record delete plus add.** `range` is keyed on `@id` by both the
Chorus element strategy and by `XmlMergeService`'s record splitting, and unlike `range-element`
it has no guid to fall back on.

- For any project whose custom list name contains one of the four characters, the first export
  after upgrading rewrites that id once. Chorus models that as a delete plus an add of the whole
  `<range>` record, taking every `<range-element>` inside it along -- a large single diff.
- It is a one-time event per affected list. The new spelling is stable, unlike a normalization
  change, which an un-upgraded client would keep undoing.
- A project whose list name contains a `"` has been committing an unparseable ranges file until
  now.

## Testing

Two regression tests in `LiftExportTests`, each covering one of the two defects. Both were
confirmed to fail on `main` before the fix.

1. `LiftExportRanges_CustomListRangeIdWithQuoteIsEscapedForAnAttribute` -- a custom list named
   `So-called "words"`, asserting the ranges document parses and the id reads back as the name
   stored. Without the fix this fails with
   `XmlException: 'words' is an unexpected token. Expecting white space.`
2. `LiftExportRanges_CustomListRangeIdWithAmpersandIsEscapedExactlyOnce` -- a custom list named
   `Birds & Beasts`, asserting the ranges id reads back as the name stored and that the `.lift`
   header names the range the same way. Without the fix the header and the ranges file disagree.

Both drive the real exporter over a real custom list and custom field, through a shared
`ExportWithCustomList` helper that runs the `.lift` pass and the ranges pass on one exporter --
the ranges pass writes only the lists the `.lift` pass collected.

`.\test.ps1 -SkipNative -TestProject LexTextControlsTests -TestFilter "FullyQualifiedName~LiftExportTests"`:
**7 passed, 0 failed**, including the pre-existing `LiftExport` (which asserts the header range
ids for both a referenced and an unreferenced custom list) and
`LiftExport_MultiParagraphWithAmpersandExports`. The full suite and the native tests have not
been run locally; leaving this as a draft for CI.

### Test fixture resets

The fixture also now resets its five shared custom-field collections in `[SetUp]`, alongside the
maps it already reset there. NUnit shares one fixture instance across a class, so each of them
outlived the cache it indexes and grew by several entries per test, while `VerifyExport` and
`VerifyExportRanges` index them positionally.

<details>
<summary>Why each of the five needed resetting</summary>

`m_customListsGuids` had to be reset for the new tests to pass: guids are minted per object, so
`[0]` and `[1]` named lists in a cache that had already been disposed.

The four flid lists (`m_customFieldEntryIds`, `m_customFieldSenseIds`,
`m_customFieldAllomorphsIds`, `m_customFieldExampleSentencesIds`) were still passing, but only
because `AddCustomField` allocates from `clid * 1000 + 500` upward per metadata cache, so a fresh
cache plus an unchanged `[SetUp]` order reassigns the same flids and the stale entries happened
to hold the values the current cache would assign. Resetting them too retires that unwritten
invariant, which a reordered or added custom field would otherwise break into a confusing
failure.

</details>

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md`.
- [x] No whitespace warnings locally (`git log --check` and `git diff --check` are clean).
- [x] Builds locally, and the touched test fixture passes.
- [x] Jira ticket filed: LT-22702.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1064)
<!-- Reviewable:end -->
