### PR TITLE
Record Avalonia UI mode in crash reports

### DIFF
--- a/Src/LexText/LexTextControls/Avalonia/AvaloniaOptionsDialogLauncher.cs
+++ b/Src/LexText/LexTextControls/Avalonia/AvaloniaOptionsDialogLauncher.cs
@@ -493,8 +493,7 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		// Applies a UI-mode change live: persist into settings + mirror+broadcast through the PropertyTable
-		// so the open views (RecordBrowseView/RecordEditView) re-resolve without a restart, and updates the
-		// crash-report value to match so a report reflects the mode active at crash time, not just at startup.
+		// so the open views (RecordBrowseView/RecordEditView) re-resolve without a restart.
 		internal static void ApplyUiModeLive(PropertyTable propertyTable, FwApplicationSettingsBase settings, string mode)
 		{
 			var norm = NormalizeUiMode(mode);
@@ -507,8 +506,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			ErrorReporter.AddProperty("AvaloniaUIMode", norm);
 		}
 
-		// Applies a disabled-tools change live: persist into settings + mirror+broadcast through the
-		// PropertyTable, and keep the crash-report value in step, mirroring ApplyUiModeLive.
+		// Applies a per-tool disabled-tools change live, mirroring ApplyUiModeLive.
 		internal static void ApplyDisabledToolsLive(PropertyTable propertyTable, FwApplicationSettingsBase settings, string disabledTools)
 		{
 			settings.UIModeDisabledTools = disabledTools;

--- a/Src/LexText/LexTextControls/Avalonia/AvaloniaOptionsDialogLauncher.cs
+++ b/Src/LexText/LexTextControls/Avalonia/AvaloniaOptionsDialogLauncher.cs
@@ -343,14 +343,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			// restart.
 			var newDisabledTools = state.UIModeDisabledTools ?? string.Empty;
 			if ((settings.UIModeDisabledTools ?? string.Empty) != newDisabledTools)
-			{
-				settings.UIModeDisabledTools = newDisabledTools;
-				if (propertyTable != null)
-				{
-					propertyTable.SetProperty(UIFrameworkResolver.UIModeDisabledToolsPropertyName, newDisabledTools, true);
-					propertyTable.SetPropertyPersistence(UIFrameworkResolver.UIModeDisabledToolsPropertyName, false);
-				}
-			}
+				ApplyDisabledToolsLive(propertyTable, settings, newDisabledTools);
 
 			// User-interface language: switch the current thread's UI culture live (matches
 			// LexOptionsDlg.m_btnOK_Click), then persist registry value + project WS + reload the string
@@ -500,8 +493,9 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		// Applies a UI-mode change live: persist into settings + mirror+broadcast through the PropertyTable
-		// so the open views (RecordBrowseView/RecordEditView) re-resolve without a restart.
-		private static void ApplyUiModeLive(PropertyTable propertyTable, FwApplicationSettingsBase settings, string mode)
+		// so the open views (RecordBrowseView/RecordEditView) re-resolve without a restart, and updates the
+		// crash-report value to match so a report reflects the mode active at crash time, not just at startup.
+		internal static void ApplyUiModeLive(PropertyTable propertyTable, FwApplicationSettingsBase settings, string mode)
 		{
 			var norm = NormalizeUiMode(mode);
 			settings.UIMode = norm;
@@ -510,6 +504,20 @@ namespace SIL.FieldWorks.LexText.Controls
 				propertyTable.SetProperty(UIModePropertyName, norm, true);
 				propertyTable.SetPropertyPersistence(UIModePropertyName, false);
 			}
+			ErrorReporter.AddProperty("AvaloniaUIMode", norm);
+		}
+
+		// Applies a disabled-tools change live: persist into settings + mirror+broadcast through the
+		// PropertyTable, and keep the crash-report value in step, mirroring ApplyUiModeLive.
+		internal static void ApplyDisabledToolsLive(PropertyTable propertyTable, FwApplicationSettingsBase settings, string disabledTools)
+		{
+			settings.UIModeDisabledTools = disabledTools;
+			if (propertyTable != null)
+			{
+				propertyTable.SetProperty(UIFrameworkResolver.UIModeDisabledToolsPropertyName, disabledTools, true);
+				propertyTable.SetPropertyPersistence(UIFrameworkResolver.UIModeDisabledToolsPropertyName, false);
+			}
+			ErrorReporter.AddProperty("AvaloniaDisabledTools", disabledTools);
 		}
 
 		internal static string NormalizeUiMode(string mode) =>

--- a/Src/LexText/LexTextControls/LexOptionsDlg.cs
+++ b/Src/LexText/LexTextControls/LexOptionsDlg.cs
@@ -19,6 +19,7 @@ using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel.Utils;
 using SIL.LCModel;
 using SIL.PlatformUtilities;
+using SIL.Reporting;
 using SIL.Settings;
 using SIL.Utils;
 using XCore;
@@ -158,6 +159,8 @@ namespace SIL.FieldWorks.LexText.Controls
 						m_propertyTable.SetPropertyPersistence(UIModePropertyName, false);
 					}
 				}
+				// Keep the crash-report value in step with a live toggle, not just the startup seed.
+				ErrorReporter.AddProperty("AvaloniaUIMode", newUiMode);
 			}
 
 			m_sNewUserWs = m_userInterfaceChooser.NewUserWs;

--- a/Src/LexText/LexTextControls/LexOptionsDlg.cs
+++ b/Src/LexText/LexTextControls/LexOptionsDlg.cs
@@ -158,9 +158,8 @@ namespace SIL.FieldWorks.LexText.Controls
 						m_propertyTable.SetProperty(UIModePropertyName, newUiMode, true);
 						m_propertyTable.SetPropertyPersistence(UIModePropertyName, false);
 					}
+					ErrorReporter.AddProperty("AvaloniaUIMode", newUiMode);
 				}
-				// Keep the crash-report value in step with a live toggle, not just the startup seed.
-				ErrorReporter.AddProperty("AvaloniaUIMode", newUiMode);
 			}
 
 			m_sNewUserWs = m_userInterfaceChooser.NewUserWs;

--- a/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/AvaloniaOptionsDialogLauncherTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/AvaloniaOptionsDialogLauncherTests.cs
@@ -32,7 +32,7 @@ namespace LexTextControlsTests
 			ErrorReport.Properties.Remove("AvaloniaDisabledTools");
 		}
 
-		// ----- ApplyUiModeLive / ApplyDisabledToolsLive (the crash-report mirror behind Apply) -----
+		// ----- ApplyUiModeLive / ApplyDisabledToolsLive: crash-report mirror -----
 
 		[Test]
 		public void ApplyUiModeLive_PersistsBroadcastsAndRecordsForCrashReports()

--- a/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/AvaloniaOptionsDialogLauncherTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/AvaloniaOptionsDialogLauncherTests.cs
@@ -25,6 +25,48 @@ namespace LexTextControlsTests
 	[TestFixture]
 	public class AvaloniaOptionsDialogLauncherTests
 	{
+		[TearDown]
+		public void TearDown()
+		{
+			ErrorReport.Properties.Remove("AvaloniaUIMode");
+			ErrorReport.Properties.Remove("AvaloniaDisabledTools");
+		}
+
+		// ----- ApplyUiModeLive / ApplyDisabledToolsLive (the crash-report mirror behind Apply) -----
+
+		[Test]
+		public void ApplyUiModeLive_PersistsBroadcastsAndRecordsForCrashReports()
+		{
+			var settings = new TestFwApplicationSettings { UIMode = "Legacy" };
+			using (var mediator = new Mediator())
+			using (var propertyTable = new PropertyTable(mediator))
+			{
+				SIL.FieldWorks.LexText.Controls.AvaloniaOptionsDialogLauncher.ApplyUiModeLive(
+					propertyTable, settings, "new");
+
+				Assert.That(settings.UIMode, Is.EqualTo("New"));
+				Assert.That(propertyTable.GetStringProperty("UIMode", "Legacy"), Is.EqualTo("New"));
+				Assert.That(ErrorReport.Properties["AvaloniaUIMode"], Is.EqualTo("New"));
+			}
+		}
+
+		[Test]
+		public void ApplyDisabledToolsLive_PersistsBroadcastsAndRecordsForCrashReports()
+		{
+			var settings = new TestFwApplicationSettings { UIMode = "New" };
+			using (var mediator = new Mediator())
+			using (var propertyTable = new PropertyTable(mediator))
+			{
+				SIL.FieldWorks.LexText.Controls.AvaloniaOptionsDialogLauncher.ApplyDisabledToolsLive(
+					propertyTable, settings, "lexiconEdit,posEdit");
+
+				Assert.That(settings.UIModeDisabledTools, Is.EqualTo("lexiconEdit,posEdit"));
+				Assert.That(propertyTable.GetStringProperty("UIModeDisabledTools", null),
+					Is.EqualTo("lexiconEdit,posEdit"));
+				Assert.That(ErrorReport.Properties["AvaloniaDisabledTools"], Is.EqualTo("lexiconEdit,posEdit"));
+			}
+		}
+
 		// ----- UIModeGates.ShouldUseAvaloniaUI (the shared New-mode gate, hoisted to FwUtils so checking
 		// it never loads the Avalonia assemblies) -----
 

--- a/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
@@ -25,6 +25,9 @@ namespace LexTextControlsTests
 			m_savedSwitchingVariable =
 				Environment.GetEnvironmentVariable(UIModeGates.SwitchingEnabledVariable);
 			Environment.SetEnvironmentVariable(UIModeGates.SwitchingEnabledVariable, "1");
+			// ErrorReport.Properties is process-wide: establish the absence this
+			// fixture asserts instead of inheriting a sibling test's teardown.
+			ErrorReport.Properties.Remove("AvaloniaUIMode");
 		}
 
 		[TearDown]

--- a/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/Avalonia/LexOptionsDlgTests.cs
@@ -32,6 +32,7 @@ namespace LexTextControlsTests
 		{
 			Environment.SetEnvironmentVariable(
 				UIModeGates.SwitchingEnabledVariable, m_savedSwitchingVariable);
+			ErrorReport.Properties.Remove("AvaloniaUIMode");
 		}
 
 		[Test]
@@ -59,6 +60,8 @@ namespace LexTextControlsTests
 				Assert.That(propertyTable.GetStringProperty("UIMode", "Legacy"), Is.EqualTo("New"));
 				// UIMode flips live (RecordEditView settles and re-resolves on the spot) -- no restart needed.
 				Assert.That(dlg.RestartPromptCount, Is.EqualTo(0));
+				Assert.That(ErrorReport.Properties["AvaloniaUIMode"], Is.EqualTo("New"),
+					"a live toggle must update the crash-report value, not just the startup seed");
 			}
 		}
 
@@ -81,6 +84,8 @@ namespace LexTextControlsTests
 				Assert.That(settings.SaveCalls, Is.EqualTo(1));
 				Assert.That(propertyTable.GetStringProperty("UIMode", "Legacy"), Is.EqualTo("Legacy"));
 				Assert.That(dlg.RestartPromptCount, Is.EqualTo(0));
+				Assert.That(ErrorReport.Properties.ContainsKey("AvaloniaUIMode"), Is.False,
+					"an unchanged selection must not touch the crash-report value");
 			}
 		}
 

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -562,7 +562,6 @@ namespace SIL.FieldWorks.XWorks
 				settingsDisabledTools ?? string.Empty, false);
 			propertyTable.SetPropertyPersistence(UIFrameworkResolver.UIModeDisabledToolsPropertyName, false);
 
-			// Record for crash reports; everything else about the crash comes from the trace.
 			ErrorReporter.AddProperty("AvaloniaUIMode", UIFrameworkResolver.NormalizeUIMode(settingsUiMode));
 			ErrorReporter.AddProperty("AvaloniaDisabledTools", settingsDisabledTools ?? string.Empty);
 		}

--- a/Src/xWorks/FwXWindow.cs
+++ b/Src/xWorks/FwXWindow.cs
@@ -561,6 +561,10 @@ namespace SIL.FieldWorks.XWorks
 			propertyTable.SetProperty(UIFrameworkResolver.UIModeDisabledToolsPropertyName,
 				settingsDisabledTools ?? string.Empty, false);
 			propertyTable.SetPropertyPersistence(UIFrameworkResolver.UIModeDisabledToolsPropertyName, false);
+
+			// Record for crash reports; everything else about the crash comes from the trace.
+			ErrorReporter.AddProperty("AvaloniaUIMode", UIFrameworkResolver.NormalizeUIMode(settingsUiMode));
+			ErrorReporter.AddProperty("AvaloniaDisabledTools", settingsDisabledTools ?? string.Empty);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/FwXWindowUIModeSeedingTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/FwXWindowUIModeSeedingTests.cs
@@ -6,6 +6,7 @@ using System;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.FwAvalonia;
 using SIL.FieldWorks.Common.FwUtils;
+using SIL.Reporting;
 using XCore;
 
 namespace SIL.FieldWorks.XWorks
@@ -43,6 +44,8 @@ namespace SIL.FieldWorks.XWorks
 				UIModeGates.SwitchingEnabledVariable, m_savedSwitchingVariable);
 			m_propertyTable.Dispose();
 			m_mediator.Dispose();
+			ErrorReport.Properties.Remove("AvaloniaUIMode");
+			ErrorReport.Properties.Remove("AvaloniaDisabledTools");
 		}
 
 		[TestCase("New", "New")]
@@ -70,6 +73,15 @@ namespace SIL.FieldWorks.XWorks
 			FwXWindow.SeedUIModeProperties(m_propertyTable, "New", null);
 			Assert.That(m_propertyTable.GetStringProperty(
 				UIFrameworkResolver.UIModeDisabledToolsPropertyName, null), Is.EqualTo(""));
+		}
+
+		[Test]
+		public void SeedUIModeProperties_RecordsModeAndDisabledToolsForCrashReports()
+		{
+			FwXWindow.SeedUIModeProperties(m_propertyTable, "New", "lexiconEdit,posEdit");
+
+			Assert.That(ErrorReport.Properties["AvaloniaUIMode"], Is.EqualTo("New"));
+			Assert.That(ErrorReport.Properties["AvaloniaDisabledTools"], Is.EqualTo("lexiconEdit,posEdit"));
 		}
 	}
 }


### PR DESCRIPTION
## Quick Summary

Crash reports now record whether Avalonia ("New") UI mode is active and which
tools are opted out via `UIModeDisabledTools`, alongside the OS/.NET environment
info `ErrorReporter` already collects.

The value tracks the whole session, not just window construction:
`FwXWindow.SeedUIModeProperties` seeds it at startup, and both live-toggle paths
--- `LexOptionsDlg.m_btnOK_Click` (WinForms) and
`AvaloniaOptionsDialogLauncher.ApplyUiModeLive`/`ApplyDisabledToolsLive`
(Avalonia) --- push the same update into `ErrorReporter` that they already push
into the `PropertyTable`. An OK-click that does not change the mode records
nothing, so it cannot fabricate a value.

`LexOptionsDlg` has no per-tool disabled-tools editor, so only `AvaloniaUIMode`
is updated there; `ApplyDisabledToolsLive` exists only on the Avalonia side,
where that setting is actually edited.

Property names `AvaloniaUIMode`/`AvaloniaDisabledTools` were chosen to read
clearly in a raw crash-report dump rather than to mirror the internal
`UIMode`/`UIModeDisabledTools` `PropertyTable` keys.

Standalone branch off `main`, not stacked.

## Test plan

- `./build.ps1 -CommentHygiene` --- clean.
- `./test.ps1 -TestProject "Src/xWorks/xWorksTests" -TestFilter "FwXWindowUIModeSeedingTests"`
  --- 8 tests, all pass.
- `./test.ps1 -TestProject "Src/LexText/LexTextControls/LexTextControlsTests" -TestFilter "LexOptionsDlgTests|AvaloniaOptionsDialogLauncherTests"`
  --- 46 tests, all pass, including the assertions on
  `ErrorReport.Properties["AvaloniaUIMode"]`/`["AvaloniaDisabledTools"]` after a
  live toggle and the unchanged-selection case.
- Full repo `test.ps1` was not run; CI covers it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1066)
<!-- Reviewable:end -->
