### PR TITLE
Add Visual Studio 2026 build support

### DIFF
--- a/.github/BUILD_REQUIREMENTS.md
+++ b/.github/BUILD_REQUIREMENTS.md
@@ -48,7 +48,7 @@ From `.github/workflows/CI.yml`:
 
 **Solution:**
 1. Close your current terminal
-2. Open "Developer Command Prompt for VS 2022" or "Developer PowerShell for VS 2022" from the Start Menu
+2. Open the "Developer Command Prompt" or "Developer PowerShell" for your installed Visual Studio (2026 or 2022) from the Start Menu
 3. Navigate to the repository
 4. Run the build script again
 
@@ -72,8 +72,9 @@ msbuild Build/Src/FwBuildTasks/FwBuildTasks.csproj /t:Restore;Build /p:Configura
 
 ## Visual Studio Requirements
 
-- **Visual Studio 2022** (Community, Professional, or Enterprise)
+- **Visual Studio 2026 or 2022** (Community, Professional, or Enterprise); when both are installed the build uses the newest (see `Build/FieldWorks.Toolchain.props`)
 - **Required Workloads:**
   - .NET desktop development
   - Desktop development with C++
+  - (the repo-root `.vsconfig` lists the exact workloads and components)
 - **Optional:** WiX Toolset 3.14.1 (only for installer builds)

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,6 +43,8 @@
 # EXPECTED FROM windows-2022 (DO NOT RE-INSTALL):
 # ============================================================================
 # - Visual Studio 2022 Enterprise (with Desktop & C++ workloads)
+#   (FieldWorks also supports VS 2026 and builds with the newest installed;
+#   see Build/FieldWorks.Toolchain.props if this runner image changes)
 # - MSBuild (via VS 2022)
 # - .NET Framework 4.8.1 SDK & Targeting Pack
 # - Windows SDK (10.0.17763+, 19041, 22621, 26100)

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -4,4 +4,4 @@
 - Tech stack: predominantly C#/.NET Framework 4.8 managed code, plus native C++/C++-CLI components, WiX installer assets, PowerShell/bash build scripts, and auxiliary Python tooling. Builds rely on MSBuild traversal (`FieldWorks.proj`).
 - Structure highlights: Src/ contains applications and libraries (with per-folder AGENTS.md docs). Build/ houses shared targets/scripts, FLExInstaller/ contains WiX artifacts, Include/ + Lib/ host native headers/libs, and Build/Agent scripts support worktree automation. Specs/ and Docs/ provide planning/reference material.
 - Key guidelines: Follow `.github/instructions/*.instructions.md` (build, managed, native, installer, testing). Respect `.editorconfig`, update COPILOT metadata when touching folders, and keep documentation in sync with code.
-- Tooling environment: development happens on Windows with Visual Studio 2022 workloads (Desktop .NET + C++), WiX 3.14.x.
+- Tooling environment: development happens on Windows with Visual Studio 2026 or 2022 workloads (Desktop .NET + C++; newest installed wins, per Build/FieldWorks.Toolchain.props), WiX 3.14.x.

--- a/.vscode/context7-configuration.json
+++ b/.vscode/context7-configuration.json
@@ -26,7 +26,7 @@
     {
       "name": "microsoft/visualstudio",
       "description": "Visual Studio IDE and development tools documentation",
-      "reason": "FieldWorks uses Visual Studio 2022 for development. Useful for IDE configuration and debugging.",
+      "reason": "FieldWorks uses Visual Studio 2026 or 2022 for development. Useful for IDE configuration and debugging.",
       "autoApprove": true
     },
     {

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,14 @@
+{
+	"version": "1.0",
+	"components": [
+		"Microsoft.VisualStudio.Workload.ManagedDesktop",
+		"Microsoft.VisualStudio.Workload.NativeDesktop",
+		"Microsoft.Component.MSBuild",
+		"Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+		"Microsoft.VisualStudio.Component.VC.ATL",
+		"Microsoft.VisualStudio.Component.VC.ATLMFC",
+		"Microsoft.VisualStudio.Component.Windows11SDK.22621",
+		"Microsoft.Net.Component.4.8.SDK",
+		"Microsoft.Net.Component.4.8.TargetingPack"
+	]
+}

--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -38,6 +38,50 @@ function Get-VsWherePath {
     return $null
 }
 
+function Get-VsDisplayLabel {
+    <#
+    .SYNOPSIS
+        Formats a Visual Studio instance for build output.
+    .DESCRIPTION
+        Leads with the installer's product name because it carries the release year
+        ('Visual Studio Community 2026'), which the version numbers do not. The
+        version is reduced to its product version; a trailing servicing date is
+        dropped because VS 2022 reports display versions such as
+        '17.14.37 (July 2026)', where the parenthesized year invites the reader to
+        mistake a 2022 build for a 2026 one. Falls back to the version alone when
+        an instance reports no product name.
+    #>
+    param(
+        [string]$DisplayName,
+        [string]$DisplayVersion,
+        [string]$InstallationVersion
+    )
+
+    $name = "$DisplayName".Trim()
+
+    $version = "$DisplayVersion".Trim()
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        $version = "$InstallationVersion".Trim()
+    }
+    if ($version -match '^(?<product>.+?)\s*\([^)]*\)$') {
+        $version = $Matches['product'].Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($name)) {
+        if ([string]::IsNullOrWhiteSpace($version)) {
+            return $name
+        }
+
+        return "$name ($version)"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        return 'Visual Studio (unknown version)'
+    }
+
+    return "Visual Studio $version"
+}
+
 function Get-FwToolchainPolicy {
     <#
     .SYNOPSIS
@@ -176,6 +220,7 @@ function Get-VsInstallationInfo {
     }
 
     $displayVersion = & $vsWhere @baseArgs -property catalog_productDisplayVersion
+    $displayName = & $vsWhere @baseArgs -property displayName
 
     $visualStudioMajor = $null
     if ("$installationVersion" -match '^(\d+)\.') {
@@ -187,7 +232,9 @@ function Get-VsInstallationInfo {
         InstallationPath = $installationPath
         InstallationVersion = $installationVersion
         VisualStudioMajor = $visualStudioMajor
+        DisplayName = $displayName
         DisplayVersion = $displayVersion
+        DisplayLabel = Get-VsDisplayLabel -DisplayName "$displayName" -DisplayVersion "$displayVersion" -InstallationVersion "$installationVersion"
     }
 }
 
@@ -256,7 +303,9 @@ function Get-VsToolchainInfo {
         InstallationPath = $installationPath
         InstallationVersion = $vsInfo.InstallationVersion
         VisualStudioMajor = $visualStudioMajor
+        DisplayName = $vsInfo.DisplayName
         DisplayVersion = $vsInfo.DisplayVersion
+        DisplayLabel = $vsInfo.DisplayLabel
         VisualStudioVersionRange = $toolchainPolicy.VisualStudioVersionRange
         VsDevCmdPath = $vsDevCmdPath
         MSBuildPath = $msbuildPath
@@ -428,13 +477,7 @@ function Initialize-VsDevEnvironment {
     # x64-only build
     $arch = 'amd64'
     $vsInstallPath = $vsToolchain.InstallationPath
-    $vsVersion = if ([string]::IsNullOrWhiteSpace($vsToolchain.DisplayVersion)) {
-        Split-Path (Split-Path (Split-Path (Split-Path $vsInstallPath))) -Leaf
-    }
-    else {
-        $vsToolchain.DisplayVersion
-    }
-    Write-Host "   Found Visual Studio $vsVersion at: $vsInstallPath" -ForegroundColor Gray
+    Write-Host "   Found $($vsToolchain.DisplayLabel) at: $vsInstallPath" -ForegroundColor Gray
     Write-Host "   Setting up environment for $arch..." -ForegroundColor Gray
 
     $vsEnvironment = Get-VsDevEnvironmentVariables -Architecture $arch -HostArchitecture $arch
@@ -450,6 +493,7 @@ function Initialize-VsDevEnvironment {
 
     Write-Host '[OK] Visual Studio environment initialized successfully' -ForegroundColor Green
     Write-Host "   VCINSTALLDIR: $env:VCINSTALLDIR" -ForegroundColor Gray
+    Write-Host "   PlatformToolset: $($vsToolchain.PlatformToolset)" -ForegroundColor Gray
 }
 
 function Get-CvtresDiagnostics {

--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -42,22 +42,28 @@ function Get-FwToolchainPolicy {
     <#
     .SYNOPSIS
         Returns the repo-controlled FieldWorks toolchain policy.
+    .DESCRIPTION
+        Reads Build/FieldWorks.Toolchain.props: the supported Visual Studio version
+        range plus the per-Visual-Studio-major toolset mapping carried by the
+        numbered properties (FwPlatformToolset17, FwVCTargetsVersion18, ...).
+        ToolsetsByMajor is keyed by the Visual Studio major version as a string.
     #>
     if ($script:FwToolchainPolicy) {
         return $script:FwToolchainPolicy
     }
 
     $policyPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'FieldWorks.Toolchain.props'
-    $defaults = [ordered]@{
-        VisualStudioMajor = '17'
-        VisualStudioVersionRange = '[17.0,18.0)'
-        VCTargetsVersion = 'v170'
-        PlatformToolset = 'v143'
-        DotNetFrameworkSdkVisualStudioVersion = '17.0'
+    $defaultRange = '[17.0,19.0)'
+    $defaultToolsets = @{
+        '17' = [pscustomobject]@{ VCTargetsVersion = 'v170'; PlatformToolset = 'v143'; DotNetFrameworkSdkVisualStudioVersion = '17.0' }
+        '18' = [pscustomobject]@{ VCTargetsVersion = 'v180'; PlatformToolset = 'v145'; DotNetFrameworkSdkVisualStudioVersion = '18.0' }
     }
 
     if (-not (Test-Path $policyPath)) {
-        $script:FwToolchainPolicy = [pscustomobject]$defaults
+        $script:FwToolchainPolicy = [pscustomobject]@{
+            VisualStudioVersionRange = $defaultRange
+            ToolsetsByMajor = $defaultToolsets
+        }
         return $script:FwToolchainPolicy
     }
 
@@ -76,21 +82,44 @@ function Get-FwToolchainPolicy {
                 continue
             }
 
-            $value = $node.'#text'
-            if (-not [string]::IsNullOrWhiteSpace($value)) {
-                return $value.Trim()
+            # The XML adapter returns a plain string for attribute-less elements
+            # and an XmlElement when attributes (e.g. Condition) are present.
+            foreach ($candidate in @($node)) {
+                $value = if ($candidate -is [System.Xml.XmlElement]) { $candidate.'#text' } else { [string]$candidate }
+                if (-not [string]::IsNullOrWhiteSpace($value)) {
+                    return $value.Trim()
+                }
             }
         }
 
         return $DefaultValue
     }
 
+    # Majors are discovered from the numbered FwPlatformToolset<major> properties so
+    # adding a new Visual Studio major to the policy file needs no script change.
+    $toolsets = @{}
+    foreach ($propertyGroup in $propertyGroups) {
+        foreach ($child in @($propertyGroup.ChildNodes)) {
+            if ($child.Name -match '^FwPlatformToolset(\d+)$') {
+                $major = $Matches[1]
+                if (-not $toolsets.ContainsKey($major)) {
+                    $toolsets[$major] = [pscustomobject]@{
+                        VCTargetsVersion = Get-PolicyValue -Name "FwVCTargetsVersion$major" -DefaultValue $null
+                        PlatformToolset = Get-PolicyValue -Name "FwPlatformToolset$major" -DefaultValue $null
+                        DotNetFrameworkSdkVisualStudioVersion = Get-PolicyValue -Name "FwDotNetFrameworkSdkVisualStudioVersion$major" -DefaultValue $null
+                    }
+                }
+            }
+        }
+    }
+
+    if ($toolsets.Count -eq 0) {
+        $toolsets = $defaultToolsets
+    }
+
     $script:FwToolchainPolicy = [pscustomobject]@{
-        VisualStudioMajor = Get-PolicyValue -Name 'FwVisualStudioMajor' -DefaultValue $defaults.VisualStudioMajor
-        VisualStudioVersionRange = Get-PolicyValue -Name 'FwVisualStudioVersionRange' -DefaultValue $defaults.VisualStudioVersionRange
-        VCTargetsVersion = Get-PolicyValue -Name 'FwVCTargetsVersion' -DefaultValue $defaults.VCTargetsVersion
-        PlatformToolset = Get-PolicyValue -Name 'FwPlatformToolset' -DefaultValue $defaults.PlatformToolset
-        DotNetFrameworkSdkVisualStudioVersion = Get-PolicyValue -Name 'FwDotNetFrameworkSdkVisualStudioVersion' -DefaultValue $defaults.DotNetFrameworkSdkVisualStudioVersion
+        VisualStudioVersionRange = Get-PolicyValue -Name 'FwVisualStudioVersionRange' -DefaultValue $defaultRange
+        ToolsetsByMajor = $toolsets
     }
 
     return $script:FwToolchainPolicy
@@ -99,7 +128,13 @@ function Get-FwToolchainPolicy {
 function Get-VsInstallationInfo {
     <#
     .SYNOPSIS
-        Returns installation metadata for the latest matching Visual Studio instance.
+        Returns installation metadata for the newest Visual Studio instance in the
+        supported version range.
+    .DESCRIPTION
+        Selection is prefer-newest: when the newest in-range instance is missing a
+        required component this function throws with install instructions instead of
+        falling back to an older instance, so the toolchain a machine builds with is
+        deterministic. Returns $null when vswhere or any in-range instance is absent.
     #>
     param(
         [string[]]$Requires = @(),
@@ -115,27 +150,43 @@ function Get-VsInstallationInfo {
         $VersionRange = (Get-FwToolchainPolicy).VisualStudioVersionRange
     }
 
-    $vsWhereArgs = @('-latest', '-products', '*')
+    $baseArgs = @('-latest', '-products', '*')
     if (-not [string]::IsNullOrWhiteSpace($VersionRange)) {
-        $vsWhereArgs += '-version'
-        $vsWhereArgs += $VersionRange
+        $baseArgs += '-version'
+        $baseArgs += $VersionRange
     }
 
-    if ($Requires -and $Requires.Count -gt 0) {
-        $vsWhereArgs += '-requires'
-        $vsWhereArgs += $Requires
-    }
-
-    $installationPath = & $vsWhere @vsWhereArgs -property installationPath
+    $installationPath = & $vsWhere @baseArgs -property installationPath
     if (-not $installationPath) {
         return $null
     }
 
-    $displayVersion = & $vsWhere @vsWhereArgs -property catalog_productDisplayVersion
+    $installationVersion = & $vsWhere @baseArgs -property installationVersion
+
+    if ($Requires -and $Requires.Count -gt 0) {
+        $qualifiedArgs = $baseArgs + @('-requires') + $Requires
+        $qualifiedPath = & $vsWhere @qualifiedArgs -property installationPath
+        if (-not $qualifiedPath -or -not [string]::Equals("$qualifiedPath", "$installationPath", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $requiresList = $Requires -join ', '
+            throw ("Visual Studio $installationVersion at '$installationPath' is the newest installation in the supported range $VersionRange, " +
+                "but it is missing required components: $requiresList. FieldWorks builds with the newest supported Visual Studio and does not " +
+                "fall back to an older one. Open the Visual Studio Installer and add the missing workloads/components (the repo-root .vsconfig " +
+                "lists everything FieldWorks needs), then retry.")
+        }
+    }
+
+    $displayVersion = & $vsWhere @baseArgs -property catalog_productDisplayVersion
+
+    $visualStudioMajor = $null
+    if ("$installationVersion" -match '^(\d+)\.') {
+        $visualStudioMajor = $Matches[1]
+    }
 
     return [pscustomobject]@{
         VsWherePath = $vsWhere
         InstallationPath = $installationPath
+        InstallationVersion = $installationVersion
+        VisualStudioMajor = $visualStudioMajor
         DisplayVersion = $displayVersion
     }
 }
@@ -143,7 +194,12 @@ function Get-VsInstallationInfo {
 function Get-VsToolchainInfo {
     <#
     .SYNOPSIS
-        Returns derived toolchain paths for the latest matching Visual Studio instance.
+        Returns derived toolchain paths for the selected Visual Studio instance.
+    .DESCRIPTION
+        Combines the selected installation with the policy's per-major toolset
+        mapping (PlatformToolset, VC targets folder, .NET Framework SDK version).
+        Throws when the selected Visual Studio major has no mapping in
+        Build/FieldWorks.Toolchain.props.
     #>
     param(
         [string[]]$Requires = @('Microsoft.Component.MSBuild')
@@ -155,6 +211,15 @@ function Get-VsToolchainInfo {
     }
 
     $toolchainPolicy = Get-FwToolchainPolicy
+    $visualStudioMajor = $vsInfo.VisualStudioMajor
+    $toolset = $null
+    if ($visualStudioMajor -and $toolchainPolicy.ToolsetsByMajor.ContainsKey($visualStudioMajor)) {
+        $toolset = $toolchainPolicy.ToolsetsByMajor[$visualStudioMajor]
+    }
+    if (-not $toolset) {
+        throw ("Visual Studio $($vsInfo.InstallationVersion) at '$($vsInfo.InstallationPath)' has no toolchain mapping in Build/FieldWorks.Toolchain.props. " +
+            "Add FwPlatformToolset$visualStudioMajor, FwVCTargetsVersion$visualStudioMajor, and FwDotNetFrameworkSdkVisualStudioVersion$visualStudioMajor entries for it.")
+    }
 
     $installationPath = $vsInfo.InstallationPath
     $vsDevCmdPath = Join-Path $installationPath 'Common7\Tools\VsDevCmd.bat'
@@ -179,8 +244,8 @@ function Get-VsToolchainInfo {
     }
 
     $vcTargetsPath = $null
-    if (-not [string]::IsNullOrWhiteSpace($toolchainPolicy.VCTargetsVersion)) {
-        $vcTargetsPath = Join-Path $installationPath (Join-Path 'MSBuild\Microsoft\VC' $toolchainPolicy.VCTargetsVersion)
+    if (-not [string]::IsNullOrWhiteSpace($toolset.VCTargetsVersion)) {
+        $vcTargetsPath = Join-Path $installationPath (Join-Path 'MSBuild\Microsoft\VC' $toolset.VCTargetsVersion)
         if (-not (Test-Path $vcTargetsPath)) {
             $vcTargetsPath = $null
         }
@@ -189,6 +254,8 @@ function Get-VsToolchainInfo {
     return [pscustomobject]@{
         VsWherePath = $vsInfo.VsWherePath
         InstallationPath = $installationPath
+        InstallationVersion = $vsInfo.InstallationVersion
+        VisualStudioMajor = $visualStudioMajor
         DisplayVersion = $vsInfo.DisplayVersion
         VisualStudioVersionRange = $toolchainPolicy.VisualStudioVersionRange
         VsDevCmdPath = $vsDevCmdPath
@@ -196,8 +263,8 @@ function Get-VsToolchainInfo {
         VSTestPath = $vsTestPath
         VcInstallDir = $vcInstallDir
         VCTargetsPath = $vcTargetsPath
-        PlatformToolset = $toolchainPolicy.PlatformToolset
-        DotNetFrameworkSdkVisualStudioVersion = $toolchainPolicy.DotNetFrameworkSdkVisualStudioVersion
+        PlatformToolset = $toolset.PlatformToolset
+        DotNetFrameworkSdkVisualStudioVersion = $toolset.DotNetFrameworkSdkVisualStudioVersion
     }
 }
 
@@ -345,16 +412,17 @@ function Initialize-VsDevEnvironment {
 
     if (-not $vsToolchain) {
         $vsWhere = Get-VsWherePath
+        $policyRange = (Get-FwToolchainPolicy).VisualStudioVersionRange
         Write-Host ''
         if (-not $vsWhere) {
-            Write-Host '[ERROR] Visual Studio 2017+ not found' -ForegroundColor Red
-            Write-Host '   Install from: https://visualstudio.microsoft.com/downloads/' -ForegroundColor Yellow
+            Write-Host '[ERROR] vswhere.exe not found; no Visual Studio installation is detectable' -ForegroundColor Red
+            Write-Host '   Install Visual Studio from: https://visualstudio.microsoft.com/downloads/' -ForegroundColor Yellow
             throw 'Visual Studio not found'
         }
 
-        Write-Host '[ERROR] Visual Studio found but missing required C++ tools' -ForegroundColor Red
-        Write-Host '   Please install the "Desktop development with C++" workload' -ForegroundColor Yellow
-        throw 'Visual Studio C++ tools not found'
+        Write-Host "[ERROR] No Visual Studio installation found in the supported version range $policyRange (Visual Studio 2022 or 2026)" -ForegroundColor Red
+        Write-Host '   Install Visual Studio 2026 (preferred) or 2022 with the workloads listed in the repo-root .vsconfig' -ForegroundColor Yellow
+        throw 'Visual Studio not found'
     }
 
     # x64-only build

--- a/Build/Agent/Run-VsTests.ps1
+++ b/Build/Agent/Run-VsTests.ps1
@@ -75,7 +75,7 @@ $runSettings = Join-Path $repoRoot "Test.runsettings"
 $vsTestPath = Get-VSTestPath
 
 if (-not (Test-Path $vsTestPath)) {
-	Write-Error "vstest.console.exe not found. Install Visual Studio 2022 or Build Tools."
+	Write-Error "vstest.console.exe not found. Install Visual Studio 2026 or 2022 (or Build Tools) with its testing tools."
 	exit 1
 }
 

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -136,7 +136,7 @@ $vsDevEnvActive = Test-VsDevEnvironmentActive
 
 if ($toolchain) {
 	$vsVersion = if ([string]::IsNullOrWhiteSpace($toolchain.DisplayVersion)) { 'unknown version' } else { $toolchain.DisplayVersion }
-		Write-Host "[OK] Visual Studio 2022: $vsVersion" -ForegroundColor Green
+		Write-Host "[OK] Visual Studio: $vsVersion" -ForegroundColor Green
 
 	if ($toolchain.MSBuildPath) {
 		Write-Host "[OK] MSBuild found: $($toolchain.MSBuildPath)" -ForegroundColor Green
@@ -162,7 +162,7 @@ if ($toolchain) {
 	}
 } else {
 	if (Get-VsWherePath) {
-		$issues += "Visual Studio 2022 with MSBuild and C++ tools not installed"
+		$issues += "Visual Studio (2022/2026) with MSBuild and C++ tools not installed"
 	} else {
 	$issues += "Visual Studio Installer not found"
 	}

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -135,8 +135,7 @@ $toolchain = Get-VsToolchainInfo -Requires @('Microsoft.Component.MSBuild', 'Mic
 $vsDevEnvActive = Test-VsDevEnvironmentActive
 
 if ($toolchain) {
-	$vsVersion = if ([string]::IsNullOrWhiteSpace($toolchain.DisplayVersion)) { 'unknown version' } else { $toolchain.DisplayVersion }
-		Write-Host "[OK] Visual Studio: $vsVersion" -ForegroundColor Green
+		Write-Host "[OK] $($toolchain.DisplayLabel)" -ForegroundColor Green
 
 	if ($toolchain.MSBuildPath) {
 		Write-Host "[OK] MSBuild found: $($toolchain.MSBuildPath)" -ForegroundColor Green

--- a/Build/Agent/Verify-FwDependencies.ps1
+++ b/Build/Agent/Verify-FwDependencies.ps1
@@ -9,9 +9,9 @@
 	Use -PassThru when a caller needs structured results returned on the pipeline.
 
 	Expected dependencies (typically pre-installed on windows-latest):
-	- Visual Studio 2022 with Desktop & C++ workloads
+	- Visual Studio 2022 or 2026 (newest installed wins) with Desktop & C++ workloads
 	- MSBuild
-	- .NET Framework 4.8.1 SDK & Targeting Pack
+	- .NET Framework 4.8+ SDK & Targeting Pack
 	- Windows SDK
 	- WiX Toolset v6 (installer builds restore via NuGet)
 	- .NET SDK 8.x+
@@ -166,7 +166,7 @@ $results += Test-Dependency -Name "Windows SDK" -Check {
 }
 
 # Visual Studio / MSBuild
-$results += Test-Dependency -Name "Visual Studio 2022" -Check {
+$results += Test-Dependency -Name "Visual Studio (2022/2026)" -Check {
 	$vsInfo = Get-VsInstallationInfo -Requires @('Microsoft.Component.MSBuild', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
 	if (-not $vsInfo) {
 		$vsWhere = Get-VsWherePath

--- a/Build/Agent/Verify-FwDependencies.ps1
+++ b/Build/Agent/Verify-FwDependencies.ps1
@@ -174,7 +174,7 @@ $results += Test-Dependency -Name "Visual Studio (2022/2026)" -Check {
 		throw "No VS installation with MSBuild and C++ tools found"
 	}
 
-	return "Version $($vsInfo.DisplayVersion) at $($vsInfo.InstallationPath)"
+	return "$($vsInfo.DisplayLabel) at $($vsInfo.InstallationPath)"
 }
 
 # MSBuild

--- a/Build/FieldWorks.Toolchain.props
+++ b/Build/FieldWorks.Toolchain.props
@@ -1,13 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
+	<!--
+		Repo-controlled toolchain policy. Scripts discover installations dynamically,
+		but only within this supported Visual Studio / MSVC configuration.
+
+		The numbered properties (FwPlatformToolset17, ...) map each supported Visual
+		Studio major version to its MSVC toolset, VC targets folder, and .NET Framework
+		SDK version. They are plain data so consumers that cannot evaluate MSBuild
+		conditions (Build/Agent/FwBuildEnvironment.psm1 and FwBuildTasks BuildUtils)
+		can read them from this file directly. Add a new numbered trio to support a
+		new Visual Studio major; widen FwVisualStudioVersionRange to match.
+	-->
 	<PropertyGroup Label="FieldWorks Toolchain Policy">
-		<!--
-			Repo-controlled toolchain policy. Scripts discover installations dynamically,
-			but only within this supported Visual Studio / MSVC configuration.
-		-->
-		<FwVisualStudioMajor Condition="'$(FwVisualStudioMajor)' == ''">17</FwVisualStudioMajor>
-		<FwVisualStudioVersionRange Condition="'$(FwVisualStudioVersionRange)' == ''">[17.0,18.0)</FwVisualStudioVersionRange>
-		<FwVCTargetsVersion Condition="'$(FwVCTargetsVersion)' == ''">v170</FwVCTargetsVersion>
-		<FwPlatformToolset Condition="'$(FwPlatformToolset)' == ''">v143</FwPlatformToolset>
-		<FwDotNetFrameworkSdkVisualStudioVersion Condition="'$(FwDotNetFrameworkSdkVisualStudioVersion)' == ''">17.0</FwDotNetFrameworkSdkVisualStudioVersion>
+		<FwVisualStudioVersionRange Condition="'$(FwVisualStudioVersionRange)' == ''">[17.0,19.0)</FwVisualStudioVersionRange>
+
+		<!-- Visual Studio 2022 -->
+		<FwVCTargetsVersion17>v170</FwVCTargetsVersion17>
+		<FwPlatformToolset17>v143</FwPlatformToolset17>
+		<FwDotNetFrameworkSdkVisualStudioVersion17>17.0</FwDotNetFrameworkSdkVisualStudioVersion17>
+
+		<!-- Visual Studio 2026 -->
+		<FwVCTargetsVersion18>v180</FwVCTargetsVersion18>
+		<FwPlatformToolset18>v145</FwPlatformToolset18>
+		<FwDotNetFrameworkSdkVisualStudioVersion18>18.0</FwDotNetFrameworkSdkVisualStudioVersion18>
+	</PropertyGroup>
+
+	<!--
+		Effective toolchain for MSBuild consumers, selected by the Visual Studio that
+		is running the build ($(VisualStudioVersion) is 17.0 under VS 2022 MSBuild and
+		18.0 under VS 2026 MSBuild). The empty-value guards keep environment variables
+		and /p: overrides authoritative.
+
+		Scope: these properties govern vcxproj-based builds (the IDE and the native
+		test projects). The nmake-driven product natives (Make task over *.mak in
+		Build/mkall.targets) compile with the selected Visual Studio's activated
+		developer-environment toolset, whose default family matches this mapping
+		for the supported majors.
+	-->
+	<PropertyGroup Label="Effective Toolchain">
+		<FwVCTargetsVersion Condition="'$(FwVCTargetsVersion)' == '' And '$(VisualStudioVersion)' == '18.0'">$(FwVCTargetsVersion18)</FwVCTargetsVersion>
+		<FwPlatformToolset Condition="'$(FwPlatformToolset)' == '' And '$(VisualStudioVersion)' == '18.0'">$(FwPlatformToolset18)</FwPlatformToolset>
+		<FwDotNetFrameworkSdkVisualStudioVersion Condition="'$(FwDotNetFrameworkSdkVisualStudioVersion)' == '' And '$(VisualStudioVersion)' == '18.0'">$(FwDotNetFrameworkSdkVisualStudioVersion18)</FwDotNetFrameworkSdkVisualStudioVersion>
+
+		<FwVCTargetsVersion Condition="'$(FwVCTargetsVersion)' == ''">$(FwVCTargetsVersion17)</FwVCTargetsVersion>
+		<FwPlatformToolset Condition="'$(FwPlatformToolset)' == ''">$(FwPlatformToolset17)</FwPlatformToolset>
+		<FwDotNetFrameworkSdkVisualStudioVersion Condition="'$(FwDotNetFrameworkSdkVisualStudioVersion)' == ''">$(FwDotNetFrameworkSdkVisualStudioVersion17)</FwDotNetFrameworkSdkVisualStudioVersion>
 	</PropertyGroup>
 </Project>

--- a/Build/Src/FwBuildTasks/BuildUtils.cs
+++ b/Build/Src/FwBuildTasks/BuildUtils.cs
@@ -313,9 +313,41 @@ namespace FwBuildTasks
 			}
 		}
 
+		/// <summary>
+		/// Returns the major version of the MSBuild release executing this task, or null when it
+		/// cannot be determined. MSBuild assemblies pin their assembly version for compatibility,
+		/// so the product file version is what identifies the actual release.
+		/// </summary>
+		private static string GetRunningMSBuildMajorVersion()
+		{
+			try
+			{
+				var location = typeof(ToolLocationHelper).Assembly.Location;
+				if (String.IsNullOrEmpty(location))
+					return null;
+				var versionInfo = FileVersionInfo.GetVersionInfo(location);
+				return versionInfo.ProductMajorPart > 0 ? versionInfo.ProductMajorPart.ToString() : null;
+			}
+			catch
+			{
+				return null;
+			}
+		}
+
 		private static VisualStudioVersion? GetConfiguredDotNetFrameworkSdkVisualStudioVersion()
 		{
-			switch (GetToolchainPolicyProperty("FwDotNetFrameworkSdkVisualStudioVersion"))
+			// The toolchain policy maps each Visual Studio major to its .NET Framework SDK
+			// version through numbered properties (FwDotNetFrameworkSdkVisualStudioVersion17,
+			// ...18); the running MSBuild's major version selects the entry. A policy file
+			// that carries a literal value in the unnumbered property is honored as fallback.
+			string configuredValue = null;
+			var msbuildMajor = GetRunningMSBuildMajorVersion();
+			if (!String.IsNullOrEmpty(msbuildMajor))
+				configuredValue = GetToolchainPolicyProperty("FwDotNetFrameworkSdkVisualStudioVersion" + msbuildMajor);
+			if (String.IsNullOrEmpty(configuredValue))
+				configuredValue = GetToolchainPolicyProperty("FwDotNetFrameworkSdkVisualStudioVersion");
+
+			switch (configuredValue)
 			{
 				case "10.0":
 					return VisualStudioVersion.Version100;

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,6 +46,9 @@ It is intentionally not a full architecture manual. It should stay biased toward
 - **FwKernel** and **Views**: Native rendering and view infrastructure.
 - **ViewsInterfaces**: The managed interface layer generated from native IDL and used across the managed/native boundary.
 - **Traversal build**: The ordered build driven by `FieldWorks.proj` and invoked via `build.ps1`.
+- **Toolchain policy**: `Build/FieldWorks.Toolchain.props` — the single repo-controlled source for which Visual Studio majors are supported and which MSVC toolset/VCTargets each major uses. Consumed by MSBuild (imported from `Directory.Build.props`), by PowerShell (`Build/Agent/FwBuildEnvironment.psm1`), and by FwBuildTasks (`BuildUtils`). Toolset identifiers (`v143`, `v145`, `v170`, `v180`) belong only in this file.
+- **Per-major toolset mapping**: The toolchain policy maps VS 17 (2022) → PlatformToolset `v143` / VCTargets `v170` and VS 18 (2026) → `v145` / `v180`. Which mapping applies is decided by the Visual Studio actually running the build, so native binaries depend on the building VS; official/release builds define the shipped toolset. Two mechanisms produce the same outcome: vcxproj-based builds (IDE, native test projects) consume `FwPlatformToolset`, while the nmake-driven product natives (`Make` task over `*.mak` in `Build/mkall.targets`) compile with the selected Visual Studio's activated developer-environment toolset, whose default family matches this mapping for supported majors.
+- **VS selection**: `build.ps1`/`test.ps1` select the newest stable Visual Studio inside the policy's version range. If that newest instance is missing required workloads/components, the build fails with install instructions — it never silently falls back to an older VS.
 - **LcmCache**: Root entry point to LCModel (`SIL.LCModel`); called "the cache" in code and comments. Not a simple data cache — the name is historical. Exposes the language project, writing system factory, action handler, and `ServiceLocator`.
 - **Service locator**: `LcmCache.ServiceLocator` (`ILcmServiceLocator`). IoC container for LCModel — the primary way to retrieve repositories, factories, and services.
 - **Unit of work**: Groups data-model changes under `IActionHandler`. All LCModel writes must occur inside one. `UndoableUnitOfWorkHelper` (undoable) and `NonUndoableUnitOfWorkHelper` (non-undoable) are in `SIL.LCModel.Infrastructure`; use as a `using` block or via their static `.Do(...)` helpers.
@@ -81,6 +84,7 @@ It is intentionally not a full architecture manual. It should stay biased toward
 - Installer work lives under `FLExInstaller/`.
 - Integration tests often depend on deterministic sample data such as `TestLangProj/`.
 - Worktree-aware scripts are preferred because concurrent work across git worktrees is supported.
+- Visual Studio and MSVC toolset versions are policy-driven from `Build/FieldWorks.Toolchain.props`; never hardcode them in projects, scripts, or docs.
 - FLEx/Language Explorer is built with architectural boundaries, new dependencies between existing projects must be justified.
 ## Key Relationships
 - FieldWorks the repository contains the FLEx application, supporting tools, shared libraries, installer authoring, and docs.
@@ -111,3 +115,5 @@ It is intentionally not a full architecture manual. It should stay biased toward
 ## ADR Candidates
 - No repository-wide ADR location is established yet.
 - If a terminology decision becomes hard to reverse or affects naming across many files, record it here first and promote it to a formal ADR only if the repo adopts a dedicated ADR convention.
+- **2026-08: Per-major toolset mapping for VS 2026 support.** When VS 2026 (18.x) builds the repo, native projects compile with MSVC `v145`/VCTargets `v180`; VS 2022 keeps `v143`/`v170`. Chosen over pinning `v143` under both so that 2026 support is real (its own compiler) and a later repo-wide toolset flip is a data edit in the toolchain policy. Consequence: dev binaries built on 2026-only machines use a newer toolset than v143 release/CI binaries until official builds move; the FLExInstaller VC-redist set must be revisited before release builds adopt `v145`.
+- **2026-08: Prefer-newest VS selection hard-fails on an underequipped newest instance.** If the newest in-range VS lacks required components, the build errors with install instructions instead of silently using an older VS. Chosen so a machine's effective toolchain is deterministic and half-installed upgrades are surfaced, at the cost of blocking builds until the install is fixed.

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -27,9 +27,9 @@ During installation:
 - On "Adjusting your PATH environment": Select any option you want - "Use Git Bash only" is sufficient unless you want to run git commands from the Windows command prompt.
 - On "Configuring the line ending conversions": Select **"Checkout Windows-style, commit Unix-style line endings"**.
 
-#### Visual Studio 2022
+#### Visual Studio 2026 or 2022
 
-Download and install Visual Studio 2022 Community Edition or higher. See [Visual Studio Setup](visual-studio-setup.md) for detailed configuration.
+Download and install Visual Studio Community Edition or higher (2026 preferred; when both are installed the build uses the newest). See [Visual Studio Setup](visual-studio-setup.md) for detailed configuration, or import the repo-root `.vsconfig` in the Visual Studio Installer.
 
 Required workloads:
 - .NET desktop development
@@ -147,7 +147,7 @@ Default recommendation:
 
 If you are a core developer using GitHub Copilot or Claude Code, follow [AI-Assisted PR Workflow](workflows/ai-pr-workflow.md) for the Jira-to-PR path: create a dedicated worktree, validate with repo tasks/scripts, run `pr-preflight`, and then work review comments through the repo review-response workflow.
 
-Switch to **Visual Studio 2022** when you need:
+Switch to **Visual Studio** (2026 or 2022) when you need:
 - WinForms designer workflows
 - Mixed managed/native debugging across interop boundaries
 - Complex legacy .NET Framework project-system scenarios where VS Code is unreliable

--- a/Docs/core-developer-setup.md
+++ b/Docs/core-developer-setup.md
@@ -7,7 +7,7 @@ This document describes additional setup steps for core FieldWorks developers. U
 ## Prerequisites
 
 Complete all steps in [CONTRIBUTING.md](CONTRIBUTING.md) first:
-1. Install required software (Git, Visual Studio 2022)
+1. Install required software (Git, Visual Studio 2026 or 2022)
 2. Clone the repository
 3. Verify you can build successfully
 
@@ -15,13 +15,14 @@ Complete all steps in [CONTRIBUTING.md](CONTRIBUTING.md) first:
 
 The following tools are required for FieldWorks development:
 
-### Visual Studio 2022
+### Visual Studio 2026 or 2022
 
+FieldWorks builds with either; when both are installed the build uses the newest.
 Install with these workloads:
 - **.NET desktop development**
 - **Desktop development with C++** (including ATL/MFC components)
 
-See [Visual Studio Setup](visual-studio-setup.md) for detailed component list.
+See [Visual Studio Setup](visual-studio-setup.md) for the detailed component list, or import the repo-root `.vsconfig` in the Visual Studio Installer.
 
 ### WiX Toolset (v6 via NuGet restore)
 
@@ -135,7 +136,7 @@ Recommended VS Code extensions for daily development:
 - **C/C++** (`ms-vscode.cpptools`) for native editing/debugging
 - **PowerShell** (`ms-vscode.powershell`) for build/test scripts
 
-Use **Visual Studio 2022** when working on:
+Use **Visual Studio** (2026 or 2022) when working on:
 - WinForms designer changes
 - Mixed managed/native debugging across interop boundaries
 - Complex legacy .NET Framework project-system issues

--- a/Docs/installer-build-guide.md
+++ b/Docs/installer-build-guide.md
@@ -20,11 +20,11 @@ Use the installer setup script to validate your environment:
 
 ### Required Software
 
-1. **Visual Studio 2022** with Desktop workloads (C++ and .NET)
+1. **Visual Studio 2026 or 2022** with Desktop workloads (C++ and .NET). Official installers are produced from Visual Studio 2022 (v143) builds; a v145 build gets a warning because the bundled VC++ redistributables predate that toolset.
 2. **WiX Toolset v3.x** for the legacy WiX 3 build (default), plus the **Visual Studio WiX Toolset v3 extension** so `Wix.CA.targets` is available under MSBuild
 3. **WiX Toolset v6** via `WixToolset.Sdk` for the opt-in WiX 6 build (restored via NuGet as part of the build)
-4. **MSBuild** (included with VS 2022)
-5. **.NET Framework 4.8.1 SDK** (included with VS 2022)
+4. **MSBuild** (included with Visual Studio)
+5. **.NET Framework 4.8 SDK** (included with Visual Studio)
 
 ### One-Time Setup
 

--- a/Docs/visual-studio-setup.md
+++ b/Docs/visual-studio-setup.md
@@ -1,25 +1,34 @@
 # Set Up Visual Studio for FieldWorks Development on Windows
 
-This guide covers the Visual Studio 2022 setup required for FieldWorks development.
+This guide covers the Visual Studio setup required for FieldWorks development.
+FieldWorks builds with Visual Studio 2026 or 2022. When both are installed, the build
+uses the newest; `Build/FieldWorks.Toolchain.props` defines the supported version range
+and the MSVC toolset each Visual Studio uses (v145 under 2026, v143 under 2022).
 
 > `$FWROOT` in this document refers to the root directory of the FieldWorks source tree (where you cloned the repository).
 
-## Install Visual Studio 2022
+## Install Visual Studio
 
-1. **Download Visual Studio 2022 Community Edition** (or Professional/Enterprise):
-   - Go to [https://aka.ms/vs/17/release/vs_community.exe](https://aka.ms/vs/17/release/vs_community.exe)
-   - Download and run the installer
+1. **Download Visual Studio Community Edition** (or Professional/Enterprise):
+   - Visual Studio 2026 (preferred): [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
+   - Visual Studio 2022: [https://aka.ms/vs/17/release/vs_community.exe](https://aka.ms/vs/17/release/vs_community.exe)
 
-2. **Select the following Workloads:**
-   - ✅ **.NET desktop development**
-   - ✅ **Desktop development with C++**
+2. **Select workloads and components.** The simplest way is to import the repo's
+   `.vsconfig`: in the Visual Studio Installer choose **More -> Import configuration**
+   and select `$FWROOT\.vsconfig`. (Opening the solution in Visual Studio also prompts
+   to install anything missing.) The equivalent manual selections:
 
-3. **Select the following Individual Components:**
-   - ✅ C++ ATL for latest v143 build tools (x86 & x64)
-   - ✅ C++ MFC for latest v143 build tools (x86 & x64)
-   - ✅ Windows 11 SDK (10.0.22621.0)
-   - ✅ .NET Framework 4.8.1 SDK
-   - ✅ .NET Framework 4.8.1 targeting pack
+   Workloads:
+   - **.NET desktop development**
+   - **Desktop development with C++**
+
+   Individual components:
+   - MSVC C++ x64/x86 build tools (latest for your Visual Studio: v145 in 2026, v143 in 2022)
+   - C++ ATL for the latest build tools (x86 & x64)
+   - C++ MFC for the latest build tools (x86 & x64)
+   - Windows 11 SDK (10.0.22621.0 or newer)
+   - .NET Framework 4.8 SDK
+   - .NET Framework 4.8 targeting pack
 
 ## Configure Visual Studio Settings
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,7 +4,7 @@ New to FieldWorks development? Start here:
 
 - **[Contributing Guide](Docs/CONTRIBUTING.md)** - How to set up your development environment and contribute code
 - **[VS Code Stability Profile](Docs/vscode-stability-profile.md)** - ReSharper-first VS Code setup and when to switch to Visual Studio
-- **[Visual Studio Setup](Docs/visual-studio-setup.md)** - Detailed VS 2022 configuration
+- **[Visual Studio Setup](Docs/visual-studio-setup.md)** - Detailed Visual Studio configuration (2026 or 2022)
 - **[Core Developer Setup](Docs/core-developer-setup.md)** - Additional setup for team members
 - **[AI-Assisted PR Workflow](Docs/workflows/ai-pr-workflow.md)** - Canonical core-developer path from Jira to worktree setup, branch preflight, and review response
 
@@ -23,7 +23,7 @@ If you need runnable output, use a Windows machine and run `./build.ps1` or `./t
 For first-time setup on a Windows development machine:
 
 - Install required software:
-	- [Visual Studio 2022](https://aka.ms/vs/17/release/vs_community.exe) with .NET desktop and C++ desktop workloads
+	- [Visual Studio 2026](https://visualstudio.microsoft.com/downloads/) (preferred) or [Visual Studio 2022](https://aka.ms/vs/17/release/vs_community.exe) with .NET desktop and C++ desktop workloads (the repo-root `.vsconfig` lists the exact components)
 	- Git for Windows
 - Run the setup script:
 ```powershell

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -62,8 +62,7 @@ if ($git) {
 if (-not $SkipVSCheck) {
 	$vsToolchain = Get-VsToolchainInfo -Requires @('Microsoft.Component.MSBuild', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
 	if ($vsToolchain) {
-		$vsVersion = if ([string]::IsNullOrWhiteSpace($vsToolchain.DisplayVersion)) { 'unknown version' } else { $vsToolchain.DisplayVersion }
-		Write-Host "[OK] Visual Studio: $vsVersion" -ForegroundColor Green
+		Write-Host "[OK] $($vsToolchain.DisplayLabel)" -ForegroundColor Green
 		Write-Host "     Location: $($vsToolchain.InstallationPath)" -ForegroundColor Gray
 		Write-Host "     PlatformToolset: $($vsToolchain.PlatformToolset)" -ForegroundColor Gray
 	} elseif (Get-VsWherePath) {

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -9,9 +9,10 @@
 #   .\Setup-Developer-Machine.ps1 -WhatIf            # Show what would be installed
 #
 # Prerequisites (must be installed manually):
-#   - Visual Studio 2022 with:
+#   - Visual Studio 2026 (preferred) or 2022 with:
 #	 - .NET desktop development workload
 #	 - Desktop development with C++ workload (including ATL/MFC)
+#	 (the repo-root .vsconfig lists the exact workloads/components)
 #   - Git for Windows
 #
 # Note: Serena MCP language servers (Microsoft's Roslyn C# server and clangd for C++)
@@ -57,20 +58,22 @@ if ($git) {
 	exit 1
 }
 
-# Check Visual Studio 2022
+# Check Visual Studio (newest installed within the supported range wins)
 if (-not $SkipVSCheck) {
 	$vsToolchain = Get-VsToolchainInfo -Requires @('Microsoft.Component.MSBuild', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
 	if ($vsToolchain) {
 		$vsVersion = if ([string]::IsNullOrWhiteSpace($vsToolchain.DisplayVersion)) { 'unknown version' } else { $vsToolchain.DisplayVersion }
-		Write-Host "[OK] Visual Studio 2022: $vsVersion" -ForegroundColor Green
+		Write-Host "[OK] Visual Studio: $vsVersion" -ForegroundColor Green
 		Write-Host "     Location: $($vsToolchain.InstallationPath)" -ForegroundColor Gray
+		Write-Host "     PlatformToolset: $($vsToolchain.PlatformToolset)" -ForegroundColor Gray
 	} elseif (Get-VsWherePath) {
-		Write-Host "[MISSING] Visual Studio 2022 - Please install with:" -ForegroundColor Red
+		Write-Host "[MISSING] Visual Studio 2026 (preferred) or 2022 - Please install with:" -ForegroundColor Red
 		Write-Host "         - .NET desktop development workload" -ForegroundColor Red
 		Write-Host "         - Desktop development with C++ workload" -ForegroundColor Red
+		Write-Host "         (open the repo-root .vsconfig in the Visual Studio Installer to select everything)" -ForegroundColor Red
 		exit 1
 	} else {
-		Write-Host "[MISSING] Visual Studio 2022 - Please install from https://visualstudio.microsoft.com/" -ForegroundColor Red
+		Write-Host "[MISSING] Visual Studio 2026 (preferred) or 2022 - Please install from https://visualstudio.microsoft.com/" -ForegroundColor Red
 		exit 1
 	}
 }
@@ -240,7 +243,7 @@ Write-Host "`n--- Configuring PATH ---" -ForegroundColor Yellow
 
 $pathsToAdd = @()
 
-# VSTest (Visual Studio 2022)
+# VSTest (from the selected Visual Studio)
 if (-not $vsToolchain -and -not $SkipVSCheck) {
 	$vsToolchain = Get-VsToolchainInfo -Requires @('Microsoft.Component.MSBuild', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
 }

--- a/build.ps1
+++ b/build.ps1
@@ -430,6 +430,7 @@ function Test-FwBuildTasksBootstrapRequired {
 		(Join-Path $RepoRoot "Directory.Packages.props"),
 		(Join-Path $RepoRoot "Directory.Build.props"),
 		(Join-Path $RepoRoot "Directory.Build.targets"),
+		(Join-Path $RepoRoot "Build/FieldWorks.Toolchain.props"),
 		(Join-Path $RepoRoot "Build/SilVersions.props"),
 		(Join-Path $RepoRoot "Build/Src/Directory.Packages.props"),
 		(Join-Path $RepoRoot "Build/Src/FwBuildTasks/Directory.Build.props")
@@ -496,6 +497,13 @@ try {
 		# Initialize Visual Studio Developer environment
 		Initialize-VsDevEnvironment
 		Test-CvtresCompatibility
+
+		if ($BuildInstaller -or $BuildPatch) {
+			$installerToolchain = Get-VsToolchainInfo
+			if ($installerToolchain -and $installerToolchain.PlatformToolset -ne 'v143') {
+				Write-Host "[WARN] Installer build with PlatformToolset $($installerToolchain.PlatformToolset): the bundled VC++ redistributables predate this toolset. Official installers are produced from v143 (Visual Studio 2022) builds until the FLExInstaller redistributables are updated." -ForegroundColor Yellow
+			}
+		}
 
 		if (-not $SkipDependencyCheck) {
 			$verifyScript = Join-Path $PSScriptRoot "Build/Agent/Verify-FwDependencies.ps1"

--- a/regen_midl.cmd
+++ b/regen_midl.cmd
@@ -9,15 +9,26 @@ setlocal
 set CONFIG=%~1
 if "%CONFIG%"=="" set CONFIG=Debug
 
-REM Find vcvarsall.bat - try VS 2022 Community, then BuildTools
-if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" (
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-) else if exist "C:\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
-    call "C:\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
-) else (
-    echo ERROR: Cannot find vcvarsall.bat
+REM Locate the newest supported Visual Studio via vswhere.
+REM The version range mirrors FwVisualStudioVersionRange in Build\FieldWorks.Toolchain.props.
+REM The result goes through a temp file because cmd's for /f parsing cannot safely
+REM carry both the "(x86)" path parenthesis and the version-range parenthesis.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+    echo ERROR: Cannot find vswhere.exe - install Visual Studio 2026 or 2022
     exit /b 1
 )
+set "VSROOT="
+set "VSROOT_FILE=%TEMP%\fw_vsroot_%RANDOM%.txt"
+"%VSWHERE%" -latest -products * -version "[17.0,19.0)" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%VSROOT_FILE%"
+set /p VSROOT=<"%VSROOT_FILE%"
+del "%VSROOT_FILE%" >nul 2>&1
+if not defined VSROOT (
+    echo ERROR: No Visual Studio 2026/2022 installation with C++ build tools was found
+    exit /b 1
+)
+call "%VSROOT%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 REM Navigate to configuration-specific output directory
 cd /d "%~dp0Output\%CONFIG%\Common"


### PR DESCRIPTION
FieldWorks now builds with Visual Studio 2026 or 2022, preferring the newest installed. VS 2026 builds use its MSVC toolset; VS 2022 builds are unchanged.

## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->

## Merge ready checklist
- [x] Someone else has installed 2026 and built and run FieldWorks successfully

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1067)
<!-- Reviewable:end -->
