### PR TITLE
LT-22524: Add substring search to Find Lexical Entry

### DIFF
--- a/Build/SilVersions.props
+++ b/Build/SilVersions.props
@@ -12,7 +12,7 @@
 		=============================================================
 	-->
 	<PropertyGroup Label="SIL Ecosystem Versions">
-		<SilLcmVersion>11.0.0-beta0178</SilLcmVersion>
+		<SilLcmVersion>11.0.0-beta0180</SilLcmVersion>
 		<SilLibPalasoVersion>18.0.0-beta0030</SilLibPalasoVersion>
 		<SilLibPalasoL10nsVersion>18.0.0-beta0012</SilLibPalasoL10nsVersion>
 		<SilChorusVersion>6.0.0-beta0065</SilChorusVersion>

--- a/Src/Common/Controls/XMLViews/MatchingObjectsBrowser.cs
+++ b/Src/Common/Controls/XMLViews/MatchingObjectsBrowser.cs
@@ -205,6 +205,21 @@ namespace SIL.FieldWorks.Common.Controls
 			ResumeLayout(false);
 		}
 
+		/// <summary>
+		/// Swap the active search engine (e.g. when toggling substring-match mode). The caller
+		/// owns the lifetime of both engines; this only re-hooks the SearchCompleted event.
+		/// </summary>
+		public void SetSearchEngine(SearchEngine searchEngine)
+		{
+			CheckDisposed();
+			if (ReferenceEquals(m_searchEngine, searchEngine))
+				return;
+			if (m_searchEngine != null)
+				m_searchEngine.SearchCompleted -= m_searchEngine_SearchCompleted;
+			m_searchEngine = searchEngine;
+			m_searchEngine.SearchCompleted += m_searchEngine_SearchCompleted;
+		}
+
 		private void m_searchEngine_SearchCompleted(object sender, SearchCompletedEventArgs e)
 		{
 			UpdateResults(e.Fields.FirstOrDefault(), e.Results);

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -54,7 +54,8 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
-		/// The substring (match-anywhere) engine. Built lazily the first time the user ticks the box.
+		/// The substring (match-anywhere) engine. Built lazily the first time a query is long enough
+		/// to use substring matching (see <see cref="SubstringSearchPolicy"/>).
 		/// </summary>
 		private SearchEngine SubstringSearchEngine
 		{

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -54,8 +54,8 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
-		/// The substring (match-anywhere) engine. Built lazily the first time a query is long enough
-		/// to use substring matching (see <see cref="SubstringSearchPolicy"/>).
+		/// The substring (match-anywhere) engine. Built lazily the first time a query is long
+		/// enough to use substring matching (see <see cref="SubstringSearchPolicy"/>).
 		/// </summary>
 		private SearchEngine SubstringSearchEngine
 		{
@@ -67,9 +67,10 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
-		/// True when this query should use substring matching. The decision (minimum query length)
-		/// lives in <see cref="SubstringSearchPolicy"/>. (Kept separate from <see cref="SearchEngineFor"/>
-		/// so callers can test the mode without instantiating the substring engine.)
+		/// True when this query should use substring matching. The decision (minimum query
+		/// length) lives in <see cref="SubstringSearchPolicy"/>. Kept separate from
+		/// <see cref="SearchEngineFor"/> so callers can test the mode without instantiating the
+		/// substring engine.
 		/// </summary>
 		private bool UseSubstringFor(string searchKey)
 		{
@@ -202,8 +203,8 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_oldSearchKey = searchKey;
 			m_oldSearchWs = wsSelHvo;
 
-			// Select the engine for this query: substring once the key is long enough (>= MinQueryLength);
-			// otherwise the default full-text engine, so short keys behave like the original search.
+			// Select the engine for this query: substring once the key is long enough
+			// (>= MinQueryLength), otherwise full-text so short keys behave like the original.
 			m_matchingObjectsBrowser.SetSearchEngine(SearchEngineFor(searchKey));
 			m_matchingObjectsBrowser.SearchAsync(GetFields(searchKey, wsSelHvo));
 		}

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -42,6 +42,51 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
+		/// The default engine: full-text (word-prefix) matching. Cached in the property table.
+		/// </summary>
+		private SearchEngine FullTextSearchEngine
+		{
+			get
+			{
+				return SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSearchEngine",
+					() => new EntryGoSearchEngine(m_cache, SearchType.FullText));
+			}
+		}
+
+		/// <summary>
+		/// The substring (match-anywhere) engine. Built lazily the first time a query is long enough
+		/// to use substring matching (see <see cref="SubstringSearchPolicy"/>).
+		/// </summary>
+		private SearchEngine SubstringSearchEngine
+		{
+			get
+			{
+				return SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSubstringSearchEngine",
+					() => new EntryGoSearchEngine(m_cache, SearchType.Substring));
+			}
+		}
+
+		/// <summary>
+		/// True when this query should use substring matching. The decision (minimum query length)
+		/// lives in <see cref="SubstringSearchPolicy"/>. (Kept separate from <see cref="SearchEngineFor"/>
+		/// so callers can test the mode without instantiating the substring engine.)
+		/// </summary>
+		private bool UseSubstringFor(string searchKey)
+		{
+			return SubstringSearchPolicy.UseSubstring(searchKey);
+		}
+
+		/// <summary>
+		/// Choose the engine for a given search key: the substring engine only when
+		/// <see cref="UseSubstringFor"/> is true; otherwise the default full-text engine
+		/// (which still returns its normal results for short keys).
+		/// </summary>
+		private SearchEngine SearchEngineFor(string searchKey)
+		{
+			return UseSubstringFor(searchKey) ? SubstringSearchEngine : FullTextSearchEngine;
+		}
+
+		/// <summary>
 		/// Get/Set the starting entry object.  This will not be displayed in the list of
 		/// matching entries.
 		/// </summary>
@@ -85,10 +130,8 @@ namespace SIL.FieldWorks.LexText.Controls
 			var xnWindow = m_propertyTable.GetValue<XmlNode>("WindowConfiguration");
 			XmlNode configNode = xnWindow.SelectSingleNode("controls/parameters/guicontrol[@id=\"matchingEntries\"]/parameters");
 
-			SearchEngine searchEngine = SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSearchEngine", () => new EntryGoSearchEngine(cache));
-
 			m_matchingObjectsBrowser.Initialize(cache, FontHeightAdjuster.StyleSheetFromPropertyTable(m_propertyTable), m_mediator, m_propertyTable, configNode,
-				searchEngine);
+				SearchEngineFor(string.Empty));
 
 			m_matchingObjectsBrowser.ColumnsChanged += m_matchingObjectsBrowser_ColumnsChanged;
 
@@ -97,6 +140,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			if (selectedWs != null)
 				m_matchingObjectsBrowser.SearchAsync(GetFields(string.Empty, selectedWs.Handle));
 		}
+
 		#endregion Construction and Destruction
 
 		#region	Other methods
@@ -158,6 +202,9 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_oldSearchKey = searchKey;
 			m_oldSearchWs = wsSelHvo;
 
+			// Select the engine for this query: substring once the key is long enough (>= MinQueryLength);
+			// otherwise the default full-text engine, so short keys behave like the original search.
+			m_matchingObjectsBrowser.SetSearchEngine(SearchEngineFor(searchKey));
 			m_matchingObjectsBrowser.SearchAsync(GetFields(searchKey, wsSelHvo));
 		}
 

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -42,6 +42,50 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
+		/// The default engine: full-text (word-prefix) matching. Cached in the property table.
+		/// </summary>
+		private SearchEngine FullTextSearchEngine
+		{
+			get
+			{
+				return SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSearchEngine",
+					() => new EntryGoSearchEngine(m_cache, SearchType.FullText));
+			}
+		}
+
+		/// <summary>
+		/// The substring (match-anywhere) engine. Built lazily the first time the user ticks the box.
+		/// </summary>
+		private SearchEngine SubstringSearchEngine
+		{
+			get
+			{
+				return SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSubstringSearchEngine",
+					() => new EntryGoSearchEngine(m_cache, SearchType.Substring));
+			}
+		}
+
+		/// <summary>
+		/// True when this query should use substring matching. The decision (minimum query length)
+		/// lives in <see cref="SubstringSearchPolicy"/>. (Kept separate from <see cref="SearchEngineFor"/>
+		/// so callers can test the mode without instantiating the substring engine.)
+		/// </summary>
+		private bool UseSubstringFor(string searchKey)
+		{
+			return SubstringSearchPolicy.UseSubstring(searchKey);
+		}
+
+		/// <summary>
+		/// Choose the engine for a given search key: the substring engine only when
+		/// <see cref="UseSubstringFor"/> is true; otherwise the default full-text engine
+		/// (which still returns its normal results for short keys).
+		/// </summary>
+		private SearchEngine SearchEngineFor(string searchKey)
+		{
+			return UseSubstringFor(searchKey) ? SubstringSearchEngine : FullTextSearchEngine;
+		}
+
+		/// <summary>
 		/// Get/Set the starting entry object.  This will not be displayed in the list of
 		/// matching entries.
 		/// </summary>
@@ -85,10 +129,8 @@ namespace SIL.FieldWorks.LexText.Controls
 			var xnWindow = m_propertyTable.GetValue<XmlNode>("WindowConfiguration");
 			XmlNode configNode = xnWindow.SelectSingleNode("controls/parameters/guicontrol[@id=\"matchingEntries\"]/parameters");
 
-			SearchEngine searchEngine = SearchEngine.Get(m_mediator, m_propertyTable, "EntryGoSearchEngine", () => new EntryGoSearchEngine(cache));
-
 			m_matchingObjectsBrowser.Initialize(cache, FontHeightAdjuster.StyleSheetFromPropertyTable(m_propertyTable), m_mediator, m_propertyTable, configNode,
-				searchEngine);
+				SearchEngineFor(string.Empty));
 
 			m_matchingObjectsBrowser.ColumnsChanged += m_matchingObjectsBrowser_ColumnsChanged;
 
@@ -97,6 +139,7 @@ namespace SIL.FieldWorks.LexText.Controls
 			if (selectedWs != null)
 				m_matchingObjectsBrowser.SearchAsync(GetFields(string.Empty, selectedWs.Handle));
 		}
+
 		#endregion Construction and Destruction
 
 		#region	Other methods
@@ -158,6 +201,9 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_oldSearchKey = searchKey;
 			m_oldSearchWs = wsSelHvo;
 
+			// Select the engine for this query: substring once the key is long enough (>= MinQueryLength);
+			// otherwise the default full-text engine, so short keys behave like the original search.
+			m_matchingObjectsBrowser.SetSearchEngine(SearchEngineFor(searchKey));
 			m_matchingObjectsBrowser.SearchAsync(GetFields(searchKey, wsSelHvo));
 		}
 

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -43,8 +43,10 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		/// <summary>
 		/// The default engine: full-text (word-prefix) matching. Cached in the property table.
+		/// Overridable so a subclass can supply a specialized engine (for example one that
+		/// excludes a starting entry).
 		/// </summary>
-		private SearchEngine FullTextSearchEngine
+		protected virtual SearchEngine FullTextSearchEngine
 		{
 			get
 			{
@@ -54,10 +56,11 @@ namespace SIL.FieldWorks.LexText.Controls
 		}
 
 		/// <summary>
-		/// The substring (match-anywhere) engine. Built lazily the first time a query is long
-		/// enough to use substring matching (see <see cref="SubstringSearchPolicy"/>).
+		/// The substring (match-anywhere) engine, used once a query is long enough
+		/// (see <see cref="SubstringSearchPolicy"/>). A subclass can override it to supply a
+		/// specialized engine that also filters substring results.
 		/// </summary>
-		private SearchEngine SubstringSearchEngine
+		protected virtual SearchEngine SubstringSearchEngine
 		{
 			get
 			{

--- a/Src/LexText/LexTextControls/EntryGoDlg.cs
+++ b/Src/LexText/LexTextControls/EntryGoDlg.cs
@@ -142,7 +142,10 @@ namespace SIL.FieldWorks.LexText.Controls
 			// start building index
 			var selectedWs = (CoreWritingSystemDefinition) m_cbWritingSystems.SelectedItem;
 			if (selectedWs != null)
+			{
 				m_matchingObjectsBrowser.SearchAsync(GetFields(string.Empty, selectedWs.Handle));
+				SubstringSearchEngine.SearchAsync(GetFields(string.Empty, selectedWs.Handle));
+			}
 		}
 
 		#endregion Construction and Destruction

--- a/Src/LexText/LexTextControls/EntryGoSearchEngine.cs
+++ b/Src/LexText/LexTextControls/EntryGoSearchEngine.cs
@@ -20,8 +20,8 @@ namespace SIL.FieldWorks.LexText.Controls
 	{
 		private readonly Virtuals m_virtuals;
 
-		public EntryGoSearchEngine(LcmCache cache)
-			: base(cache, SearchType.FullText)
+		public EntryGoSearchEngine(LcmCache cache, SearchType searchType = SearchType.FullText)
+			: base(cache, searchType)
 		{
 			m_virtuals = Cache.ServiceLocator.GetInstance<Virtuals>();
 		}

--- a/Src/LexText/LexTextControls/LexTextControls.Designer.cs
+++ b/Src/LexText/LexTextControls/LexTextControls.Designer.cs
@@ -1149,7 +1149,7 @@ namespace SIL.FieldWorks.LexText.Controls {
                 return ResourceManager.GetString("ksFindLexEntry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Find Record.
         /// </summary>

--- a/Src/LexText/LexTextControls/LexTextControlsTests/MergeEntrySearchEngineTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/MergeEntrySearchEngineTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.Controls;
+using SIL.FieldWorks.LexText.Controls;
+using SIL.LCModel;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.DomainServices;
+
+namespace LexTextControlsTests
+{
+	/// <summary>
+	/// The Merge Entry search engine must exclude the starting entry from its matches in BOTH
+	/// full-text and substring modes, so an entry can never be offered as a target for merging
+	/// into itself. The substring case matters because a typical multi-character merge-target
+	/// query runs under substring matching (see <see cref="SubstringSearchPolicy"/>).
+	/// </summary>
+	[TestFixture]
+	public class MergeEntrySearchEngineTests : MemoryOnlyBackendProviderRestoredForEachTestTestBase
+	{
+		private ILexEntry _language;
+		private ILexEntry _languor;
+
+		// The base opens a UOW in TestSetup and calls CreateTestData() inside it, so data is
+		// created directly here with no UOW wrapper (a nested task would throw).
+		protected override void CreateTestData()
+		{
+			base.CreateTestData();
+			_language = MakeEntry("language", "speech");
+			_languor = MakeEntry("languor", "weariness");
+		}
+
+		private ILexEntry MakeEntry(string lexemeForm, string gloss)
+		{
+			var components = new LexEntryComponents
+			{
+				MorphType = Cache.ServiceLocator.GetInstance<IMoMorphTypeRepository>()
+					.GetObject(MoMorphTypeTags.kguidMorphStem)
+			};
+			components.LexemeFormAlternatives.Add(TsStringUtils.MakeString(lexemeForm, Cache.DefaultVernWs));
+			components.GlossAlternatives.Add(TsStringUtils.MakeString(gloss, Cache.DefaultAnalWs));
+			return Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create(components);
+		}
+
+		private IEnumerable<SearchField> LexemeFormQuery(string query)
+		{
+			var tss = TsStringUtils.MakeString(query, Cache.DefaultVernWs);
+			return new[] { new SearchField(LexEntryTags.kflidLexemeForm, tss) };
+		}
+
+		[Test]
+		public void FullTextEngine_ExcludesTheStartingEntry()
+		{
+			using (var engine = new MergeEntryDlg.MergeEntrySearchEngine(Cache, SearchType.FullText))
+			{
+				// "langu" is a word-prefix shared by both entries, so full-text matches both.
+				var withoutExclusion = engine.Search(LexemeFormQuery("langu")).ToList();
+				Assert.That(withoutExclusion, Does.Contain(_language.Hvo).And.Contain(_languor.Hvo),
+					"both entries match the shared prefix before any entry is excluded");
+
+				engine.CurrentEntryHvo = _language.Hvo;
+				var withExclusion = engine.Search(LexemeFormQuery("langu")).ToList();
+				Assert.That(withExclusion, Does.Not.Contain(_language.Hvo),
+					"the starting entry is never offered as a target for merging into itself");
+				Assert.That(withExclusion, Does.Contain(_languor.Hvo),
+					"the other matching entry still appears");
+			}
+		}
+
+		[Test]
+		public void SubstringEngine_ExcludesTheStartingEntry()
+		{
+			using (var engine = new MergeEntryDlg.MergeEntrySearchEngine(Cache, SearchType.Substring))
+			{
+				// "angu" is an interior substring of both entries and a prefix of neither, so it
+				// exercises the substring (match-anywhere) path specifically.
+				var withoutExclusion = engine.Search(LexemeFormQuery("angu")).ToList();
+				Assert.That(withoutExclusion, Does.Contain(_language.Hvo).And.Contain(_languor.Hvo),
+					"both entries match the interior substring before any entry is excluded");
+
+				engine.CurrentEntryHvo = _language.Hvo;
+				var withExclusion = engine.Search(LexemeFormQuery("angu")).ToList();
+				Assert.That(withExclusion, Does.Not.Contain(_language.Hvo),
+					"substring results also exclude the starting entry (the self-merge guard)");
+				Assert.That(withExclusion, Does.Contain(_languor.Hvo),
+					"the other interior-substring match still appears");
+			}
+		}
+	}
+}

--- a/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
@@ -8,14 +8,14 @@ using SIL.FieldWorks.LexText.Controls;
 namespace LexTextControlsTests
 {
 	/// <summary>
-	/// Tests for the pure Find-Lexical-Entry substring-search decision logic that was extracted from
-	/// EntryGoDlg so it could be tested without driving the dialog.
+	/// Verifies the query-length gate that decides when Find Lexical Entry uses substring
+	/// (match-anywhere) matching.
 	/// </summary>
 	[TestFixture]
 	public class SubstringSearchPolicyTests
 	{
-		// A base letter followed by a combining acute accent (U+0301): 2 UTF-16 units that compose to
-		// a single character under FormC normalization.
+		// A base letter followed by a combining acute accent (U+0301): 2 UTF-16 units that
+		// compose to a single character under FormC normalization.
 		private static readonly string ComposedAcuteE = "e" + (char)0x0301;
 
 		[TestCase("", ExpectedResult = false)]
@@ -37,9 +37,9 @@ namespace LexTextControlsTests
 		[Test]
 		public void UseSubstring_countsComposedCharacters_notUtf16Units()
 		{
-			// Each ComposedAcuteE is 2 UTF-16 units but 1 character after FormC. If the policy counted
-			// raw Length it would see 4 and 6 (both >= 3) and wrongly enable substring; counting composed
-			// characters it sees 2 and 3.
+			// Each ComposedAcuteE is 2 UTF-16 units but 1 character after FormC. Counting raw
+			// Length would see 4 and 6 (both >= 3) and wrongly enable substring; composed
+			// characters count as 2 and 3.
 			string twoComposed = ComposedAcuteE + ComposedAcuteE;                   // raw Length 4 -> 2
 			string threeComposed = ComposedAcuteE + ComposedAcuteE + ComposedAcuteE; // raw Length 6 -> 3
 

--- a/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using NUnit.Framework;
+using SIL.FieldWorks.LexText.Controls;
+
+namespace LexTextControlsTests
+{
+	/// <summary>
+	/// Tests for the pure Find-Lexical-Entry substring-search decision logic that was extracted from
+	/// EntryGoDlg so it could be tested without driving the dialog.
+	/// </summary>
+	[TestFixture]
+	public class SubstringSearchPolicyTests
+	{
+		// A base letter followed by a combining acute accent (U+0301): 2 UTF-16 units that compose to
+		// a single character under FormC normalization.
+		private static readonly string ComposedAcuteE = "e" + (char)0x0301;
+
+		[TestCase("", ExpectedResult = false)]
+		[TestCase("l", ExpectedResult = false)]
+		[TestCase("la", ExpectedResult = false)]      // below MinQueryLength
+		[TestCase("lan", ExpectedResult = true)]      // exactly MinQueryLength
+		[TestCase("language", ExpectedResult = true)]
+		public bool UseSubstring_gatesOnLength(string key)
+		{
+			return SubstringSearchPolicy.UseSubstring(key);
+		}
+
+		[Test]
+		public void UseSubstring_nullKey_isFalse()
+		{
+			Assert.That(SubstringSearchPolicy.UseSubstring(null), Is.False);
+		}
+
+		[Test]
+		public void UseSubstring_countsComposedCharacters_notUtf16Units()
+		{
+			// Each ComposedAcuteE is 2 UTF-16 units but 1 character after FormC. If the policy counted
+			// raw Length it would see 4 and 6 (both >= 3) and wrongly enable substring; counting composed
+			// characters it sees 2 and 3.
+			string twoComposed = ComposedAcuteE + ComposedAcuteE;                   // raw Length 4 -> 2
+			string threeComposed = ComposedAcuteE + ComposedAcuteE + ComposedAcuteE; // raw Length 6 -> 3
+
+			Assert.That(SubstringSearchPolicy.UseSubstring(twoComposed), Is.False,
+				"two composed characters should count as length 2, below the threshold");
+			Assert.That(SubstringSearchPolicy.UseSubstring(threeComposed), Is.True,
+				"three composed characters should count as length 3, at the threshold");
+		}
+
+		[Test]
+		public void MinQueryLength_hasExpectedDefault()
+		{
+			Assert.That(SubstringSearchPolicy.MinQueryLength, Is.EqualTo(3));
+		}
+	}
+}

--- a/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
+++ b/Src/LexText/LexTextControls/LexTextControlsTests/SubstringSearchPolicyTests.cs
@@ -14,9 +14,18 @@ namespace LexTextControlsTests
 	[TestFixture]
 	public class SubstringSearchPolicyTests
 	{
-		// A base letter followed by a combining acute accent (U+0301): 2 UTF-16 units that
-		// compose to a single character under FormC normalization.
+		// A base letter plus combining acute (U+0301): 2 UTF-16 units that DO compose to one
+		// precomposed character under FormC.
 		private static readonly string ComposedAcuteE = "e" + (char)0x0301;
+
+		// A base letter plus combining tilde (U+0303): one grapheme (2 UTF-16 units) with NO
+		// precomposed form, so FormC leaves it decomposed. This is the case a code-unit count
+		// gets wrong.
+		private static readonly string NonComposableGrapheme = "b" + (char)0x0303;
+
+		// A non-BMP character (U+10480): one grapheme encoded as a surrogate pair, so 2 UTF-16
+		// units.
+		private static readonly string SurrogatePairChar = char.ConvertFromUtf32(0x10480);
 
 		[TestCase("", ExpectedResult = false)]
 		[TestCase("l", ExpectedResult = false)]
@@ -35,18 +44,19 @@ namespace LexTextControlsTests
 		}
 
 		[Test]
-		public void UseSubstring_countsComposedCharacters_notUtf16Units()
+		public void UseSubstring_countsGraphemes_notUtf16Units()
 		{
-			// Each ComposedAcuteE is 2 UTF-16 units but 1 character after FormC. Counting raw
-			// Length would see 4 and 6 (both >= 3) and wrongly enable substring; composed
-			// characters count as 2 and 3.
-			string twoComposed = ComposedAcuteE + ComposedAcuteE;                   // raw Length 4 -> 2
-			string threeComposed = ComposedAcuteE + ComposedAcuteE + ComposedAcuteE; // raw Length 6 -> 3
-
-			Assert.That(SubstringSearchPolicy.UseSubstring(twoComposed), Is.False,
-				"two composed characters should count as length 2, below the threshold");
-			Assert.That(SubstringSearchPolicy.UseSubstring(threeComposed), Is.True,
-				"three composed characters should count as length 3, at the threshold");
+			// Each grapheme below is 2 UTF-16 units, so a code-unit count would over-count.
+			// All three kinds (composable, non-composable, non-BMP) must gate on text
+			// elements, not raw code units.
+			var graphemes = new[] { ComposedAcuteE, NonComposableGrapheme, SurrogatePairChar };
+			foreach (var grapheme in graphemes)
+			{
+				Assert.That(SubstringSearchPolicy.UseSubstring(grapheme + grapheme), Is.False,
+					"two graphemes should count as length 2, below the threshold");
+				Assert.That(SubstringSearchPolicy.UseSubstring(grapheme + grapheme + grapheme), Is.True,
+					"three graphemes should count as length 3, at the threshold");
+			}
 		}
 
 		[Test]

--- a/Src/LexText/LexTextControls/MergeEntryDlg.cs
+++ b/Src/LexText/LexTextControls/MergeEntryDlg.cs
@@ -187,35 +187,44 @@ namespace SIL.FieldWorks.LexText.Controls
 			m_fwTextBoxBottomMsg.Tss = tsb.GetString();
 		}
 
-		protected override void InitializeMatchingObjects(LcmCache cache)
+		/// <summary>
+		/// The full-text engine, specialized to drop the starting entry so an entry can never be
+		/// offered as a merge target for itself.
+		/// </summary>
+		protected override SearchEngine FullTextSearchEngine
 		{
-			var xnWindow = m_propertyTable.GetValue<XmlNode>("WindowConfiguration");
-			XmlNode configNode = xnWindow.SelectSingleNode("controls/parameters/guicontrol[@id=\"matchingEntries\"]/parameters");
-
-			var searchEngine = (MergeEntrySearchEngine)SearchEngine.Get(m_mediator, m_propertyTable, "MergeEntrySearchEngine", () => new MergeEntrySearchEngine(cache));
-			searchEngine.CurrentEntryHvo = m_startingEntry.Hvo;
-
-			m_matchingObjectsBrowser.Initialize(cache, FontHeightAdjuster.StyleSheetFromPropertyTable(m_propertyTable), m_mediator, m_propertyTable, configNode,
-				searchEngine);
-
-			// start building index
-			var selectedWs = (CoreWritingSystemDefinition) m_cbWritingSystems.SelectedItem;
-			if(selectedWs != null)
-				m_matchingObjectsBrowser.SearchAsync(GetFields(string.Empty, selectedWs.Handle));
+			get { return MergeSearchEngine("MergeEntrySearchEngine", SearchType.FullText); }
 		}
 
 		/// <summary>
-		/// A search engine that excludes the current entry (you can't merge an entry with its self
+		/// The substring engine, specialized to drop the starting entry.
 		/// </summary>
-		private class MergeEntrySearchEngine : EntryGoSearchEngine
+		protected override SearchEngine SubstringSearchEngine
+		{
+			get { return MergeSearchEngine("MergeEntrySubstringSearchEngine", SearchType.Substring); }
+		}
+
+		private SearchEngine MergeSearchEngine(string cacheKey, SearchType searchType)
+		{
+			var searchEngine = (MergeEntrySearchEngine)SearchEngine.Get(m_mediator, m_propertyTable,
+				cacheKey, () => new MergeEntrySearchEngine(m_cache, searchType));
+			searchEngine.CurrentEntryHvo = m_startingEntry.Hvo;
+			return searchEngine;
+		}
+
+		/// <summary>
+		/// A search engine that excludes the current entry, since you cannot merge an entry
+		/// with itself.
+		/// </summary>
+		internal class MergeEntrySearchEngine : EntryGoSearchEngine
 		{
 			public int CurrentEntryHvo { private get; set; }
 
-			public MergeEntrySearchEngine(LcmCache cache) : base(cache)
+			public MergeEntrySearchEngine(LcmCache cache, SearchType searchType) : base(cache, searchType)
 			{
 			}
 
-			protected override IEnumerable<int>  FilterResults(IEnumerable<int> results)
+			protected override IEnumerable<int> FilterResults(IEnumerable<int> results)
 			{
 				return results == null ? null : results.Where(hvo => hvo != CurrentEntryHvo);
 			}

--- a/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
+++ b/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Text;
+
+namespace SIL.FieldWorks.LexText.Controls
+{
+	/// <summary>
+	/// UI-independent decision logic for the Find Lexical Entry "match anywhere" (substring) search
+	/// mode: when substring matching applies, plus its tuning knobs. Kept out of <see cref="EntryGoDlg"/>
+	/// so it can be unit-tested without driving the dialog.
+	/// </summary>
+	internal static class SubstringSearchPolicy
+	{
+		/// <summary>
+		/// Substring matching engages only once the query is at least this many characters; shorter
+		/// keys fall back to the default full-text engine, so short queries behave like the original
+		/// search (a 1-2 char substring in a large project would otherwise match most entries).
+		/// </summary>
+		public const int MinQueryLength = 3;
+
+		/// <summary>
+		/// True when a query should use substring matching: the key is at least
+		/// <see cref="MinQueryLength"/> characters. Length is counted after FormC normalization, so a
+		/// base character plus a combining diacritic counts as one character. Shorter keys fall back to
+		/// the default full-text search.
+		/// </summary>
+		/// <param name="searchKey">The (already trimmed) search key.</param>
+		public static bool UseSubstring(string searchKey)
+		{
+			return !string.IsNullOrEmpty(searchKey)
+				&& searchKey.Normalize(NormalizationForm.FormC).Length >= MinQueryLength;
+		}
+	}
+}

--- a/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
+++ b/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
@@ -7,24 +7,25 @@ using System.Text;
 namespace SIL.FieldWorks.LexText.Controls
 {
 	/// <summary>
-	/// UI-independent decision logic for the Find Lexical Entry "match anywhere" (substring) search
-	/// mode: when substring matching applies, plus its tuning knobs. Kept out of <see cref="EntryGoDlg"/>
-	/// so it can be unit-tested without driving the dialog.
+	/// UI-independent decision logic for the Find Lexical Entry "match anywhere" (substring)
+	/// search mode: when substring matching applies, plus its tuning knobs. Kept out of
+	/// <see cref="EntryGoDlg"/> so it can be unit-tested without driving the dialog.
 	/// </summary>
 	internal static class SubstringSearchPolicy
 	{
 		/// <summary>
-		/// Substring matching engages only once the query is at least this many characters; shorter
-		/// keys fall back to the default full-text engine, so short queries behave like the original
-		/// search (a 1-2 char substring in a large project would otherwise match most entries).
+		/// Substring matching engages only once the query is at least this many characters;
+		/// shorter keys fall back to the default full-text engine, so short queries behave like
+		/// the original search (a 1-2 char substring in a large project would otherwise match
+		/// most entries).
 		/// </summary>
 		public const int MinQueryLength = 3;
 
 		/// <summary>
 		/// True when a query should use substring matching: the key is at least
-		/// <see cref="MinQueryLength"/> characters. Length is counted after FormC normalization, so a
-		/// base character plus a combining diacritic counts as one character. Shorter keys fall back to
-		/// the default full-text search.
+		/// <see cref="MinQueryLength"/> characters. Length is counted after FormC normalization,
+		/// so a base character plus a combining diacritic counts as one character. Shorter keys
+		/// fall back to the default full-text search.
 		/// </summary>
 		/// <param name="searchKey">The (already trimmed) search key.</param>
 		public static bool UseSubstring(string searchKey)

--- a/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
+++ b/Src/LexText/LexTextControls/SubstringSearchPolicy.cs
@@ -2,7 +2,7 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using System.Text;
+using System.Globalization;
 
 namespace SIL.FieldWorks.LexText.Controls
 {
@@ -23,15 +23,16 @@ namespace SIL.FieldWorks.LexText.Controls
 
 		/// <summary>
 		/// True when a query should use substring matching: the key is at least
-		/// <see cref="MinQueryLength"/> characters. Length is counted after FormC normalization,
-		/// so a base character plus a combining diacritic counts as one character. Shorter keys
-		/// fall back to the default full-text search.
+		/// <see cref="MinQueryLength"/> characters. Length is counted in text elements
+		/// (graphemes), so a base character plus one or more combining diacritics counts as one
+		/// character whether or not a precomposed form exists, and a non-BMP character counts as
+		/// one. Shorter keys fall back to the default full-text search.
 		/// </summary>
 		/// <param name="searchKey">The (already trimmed) search key.</param>
 		public static bool UseSubstring(string searchKey)
 		{
 			return !string.IsNullOrEmpty(searchKey)
-				&& searchKey.Normalize(NormalizationForm.FormC).Length >= MinQueryLength;
+				&& new StringInfo(searchKey).LengthInTextElements >= MinQueryLength;
 		}
 	}
 }


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
Find Lexical Entry now matches typed characters anywhere in a word for queries of 3+ characters, using liblcm's new SearchType.Substring; shorter queries keep the original full-text search. The mode decision lives in a unit-tested SubstringSearchPolicy, and results retain the existing exact -> starts-with -> anywhere ordering.

Depends on https://github.com/sillsdev/liblcm/pull/395

https://jira.sil.org/browse/LT-22524

**Note: Two search indexes over the lexicon.** Find Lexical Entry now keeps two `StringSearcher` engines alive per dialog session — a full-text engine and a substring engine — selected per query by length (`SubstringSearchPolicy`). Both are built lazily-but-eagerly warmed at dialog open, and `SearchEngine.Get` caches them on the property table, so it's one extra background index build per session, not per open. The cost is two entry arrays, two `ConsumerThreads`, and two `IVwNotifyChange` registrations, so every lexicon data change now notifies both engines. This is a deliberate trade: it avoids rebuilding the index on every switch between full-text and substring mode (which a single swapped-`SearchType` engine would force on each keystroke that crosses the length threshold), at the price of a second resident index. Merge Entry keeps the same two-index model, both engines filtering out the starting entry.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via Bash script or MSBuild).
- [x] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1069)
<!-- Reviewable:end -->
