### PR TITLE
Export Get-VsToolchainInfo so installer and patch builds run

### DIFF
--- a/Build/Agent/FwBuildEnvironment.psm1
+++ b/Build/Agent/FwBuildEnvironment.psm1
@@ -724,6 +724,7 @@ Export-ModuleMember -Function @(
     'Test-VsDevEnvironmentActive',
     'Initialize-VsDevEnvironment',
 	'Test-CvtresCompatibility',
+	'Get-CvtresDiagnostics',
     'Get-MSBuildPath',
     'Invoke-MSBuild',
     'Get-VSTestPath'

--- a/Build/Agent/FwBuildHelpers.psm1
+++ b/Build/Agent/FwBuildHelpers.psm1
@@ -749,6 +749,7 @@ function Convert-CoberturaPathsToRepoRelative {
 Export-ModuleMember -Function @(
 	# From FwBuildEnvironment.psm1
 	'Initialize-VsDevEnvironment',
+	'Get-VsToolchainInfo',
 	'Get-MSBuildPath',
 	'Invoke-MSBuild',
 	'Get-VSTestPath',


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
build.ps1 imports only FwBuildHelpers.psm1, which imports FwBuildEnvironment.psm1 privately and re-exports a whitelist of its functions. Get-VsToolchainInfo was missing from that whitelist, so the toolset warning added in #1067 failed with "The term 'Get-VsToolchainInfo' is not recognized". CI never caught it because the only call site sits behind the -BuildInstaller/-BuildPatch guard, which CI.yml does not exercise.

Also export Get-CvtresDiagnostics from FwBuildEnvironment.psm1. FwBuildHelpers already lists it for re-export, but the inner module never exported it, so the name silently resolved to nothing and the next caller from build.ps1 would have hit the same failure.

## CI-ready checklist

- [ ] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [ ] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via `build.ps1`/`test.ps1` or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1072)
<!-- Reviewable:end -->
