### PR TITLE
Randomize GITHUB_ENV delimiter in commit-message check

### DIFF
--- a/.github/workflows/CommitMessage.yml
+++ b/.github/workflows/CommitMessage.yml
@@ -36,10 +36,14 @@ jobs:
         Set-Content -Path check_results.log -Value $log -NoNewline
         # Put the results into the job summary
         Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $log
-        # Put the results into a multi-line environment variable to use in the next step
-        Add-Content -Path $env:GITHUB_ENV -Value 'check_results<<###LINT_DELIMITER###'
+        # Put the results into a multi-line environment variable to use in the next step.
+        # $log echoes the PR's own commit messages, so a static heredoc marker could be
+        # reproduced in a commit to close the block early and inject arbitrary variables.
+        # A random per-run delimiter cannot be known in advance, so the content is inert.
+        $delimiter = "LINT_EOF_$([guid]::NewGuid().ToString('N'))"
+        Add-Content -Path $env:GITHUB_ENV -Value "check_results<<$delimiter"
         Add-Content -Path $env:GITHUB_ENV -Value $log
-        Add-Content -Path $env:GITHUB_ENV -Value '###LINT_DELIMITER###'
+        Add-Content -Path $env:GITHUB_ENV -Value $delimiter
     # add a comment on the PR if the commit message linting failed
     - name: Comment on PR
       if: failure()


### PR DESCRIPTION
## What

The `Commit messages check` workflow wrote `gitlint` output into a `GITHUB_ENV` multi-line variable using a **fixed heredoc delimiter (`###LINT_DELIMITER###`) that is committed to the repo**. This replaces it with a per-run random delimiter derived from a GUID.

```diff
-        Add-Content -Path $env:GITHUB_ENV -Value 'check_results<<###LINT_DELIMITER###'
-        Add-Content -Path $env:GITHUB_ENV -Value $log
-        Add-Content -Path $env:GITHUB_ENV -Value '###LINT_DELIMITER###'
+        $delimiter = "LINT_EOF_$([guid]::NewGuid().ToString('N'))"
+        Add-Content -Path $env:GITHUB_ENV -Value "check_results<<$delimiter"
+        Add-Content -Path $env:GITHUB_ENV -Value $log
+        Add-Content -Path $env:GITHUB_ENV -Value $delimiter
```

## Why it matters

`gitlint` echoes the PR's **own commit messages** into that output. Because the delimiter was a static, publicly-known string, a crafted commit message containing a line equal to the delimiter could close the heredoc early and append attacker-chosen `NAME=value` lines to `GITHUB_ENV` — injecting arbitrary environment variables into the job. The PR is checked out on disk (`fetch-depth: 0`) and a later step runs a Node action, so an injected `NODE_OPTIONS` (or similar) is a plausible path to code execution on the runner. This is the exact class of bug GitHub's random-delimiter guidance for `GITHUB_ENV` is meant to prevent.

A per-run GUID delimiter cannot be predicted or reproduced in commit content, so the multi-line value stays inert regardless of what the commit messages contain.

## Scope / validation

- One file: `.github/workflows/CommitMessage.yml`.
- YAML validated with a parser. Behavior is unchanged for legitimate input — same variable name, same consumer, same PR comment.

---

This is one of two PRs from a GitHub Actions security audit. The other PR (least-privilege `permissions:` blocks) also edits `CommitMessage.yml`, but in a different region (top of file), so the two merge independently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1073)
<!-- Reviewable:end -->
