### PR TITLE
Add least-privilege permissions to workflows missing them

### DIFF
--- a/.github/workflows/CommitMessage.yml
+++ b/.github/workflows/CommitMessage.yml
@@ -3,6 +3,12 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+  # pull-requests: write lets the sticky-comment step post and clear the
+  # commit-message feedback comment on the PR.
+  pull-requests: write
+
 jobs:
   gitlint:
     name: Check commit messages

--- a/.github/workflows/base-installer-cd.yml
+++ b/.github/workflows/base-installer-cd.yml
@@ -43,6 +43,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # contents: write is required to tag the repo and publish the GitHub Release
+  # (softprops/action-gh-release); no other GITHUB_TOKEN write is needed here.
+  contents: write
+
 jobs:
   debug_build_and_test:
     env:

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -9,6 +9,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     check-whitespace:
         runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     lychee:
         runs-on: ubuntu-latest

--- a/.github/workflows/openspec-validate.yml
+++ b/.github/workflows/openspec-validate.yml
@@ -6,6 +6,9 @@ on:
       - 'openspec/**'
       - '**/AGENTS.md'
 
+permissions:
+  contents: read
+
 jobs:
   validate-refs:
     runs-on: windows-2022

--- a/.github/workflows/stray-docs.yml
+++ b/.github/workflows/stray-docs.yml
@@ -8,6 +8,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     stray-docs:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Six workflows declared no `permissions:` block, so their `GITHUB_TOKEN` fell back to the repository/organization default scope. This adds an explicit least-privilege block to each.

| Workflow | Permissions granted | Why |
|---|---|---|
| `base-installer-cd.yml` | `contents: write` | Tags the repo and publishes a GitHub Release (`softprops/action-gh-release`) |
| `CommitMessage.yml` | `contents: read`, `pull-requests: write` | Posts and clears a sticky PR comment |
| `link-check.yml` | `contents: read` | Checkout only |
| `openspec-validate.yml` | `contents: read` | Checkout only |
| `check-whitespace.yml` | `contents: read` | Checkout only |
| `stray-docs.yml` | `contents: read` | Checkout only |

## Why it matters

Without an explicit block, a workflow inherits whatever the default token permissions are. If that default is read/write (the legacy default), every one of these jobs — including ones that only lint or check out code — runs with a broadly-writable token. Declaring the minimum each job needs limits the blast radius if a step or a third-party action is compromised.

`CI.yml` and `patch-installer-cd.yml` already declared explicit permissions and are left unchanged.

## Scope / validation

- Six workflow files; additive only (new `permissions:` blocks, no logic changes).
- All six validated with a YAML parser; resolved scopes confirmed to match the table above.

---

This is one of two PRs from a GitHub Actions security audit. The other PR (`Randomize GITHUB_ENV delimiter in commit-message check`) also edits `CommitMessage.yml` in a different region, so the two merge independently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1074)
<!-- Reviewable:end -->
