### PR TITLE
Clean up Setup-Developer-Machine.ps1 and set $env:LcmRootDir

### DIFF
--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -174,24 +174,39 @@ if ($toolchain) {
 Write-Host "`n--- Checking Helper Repositories ---" -ForegroundColor Yellow
 
 $helperRepos = @(
-	@{ Name = "FwHelps"; Path = "DistFiles/Helps"; Required = $true },
-	@{ Name = "FwLocalizations"; Path = "Localizations"; Required = $true },
-	@{ Name = "liblcm"; Path = "Localizations/LCMRepo"; Required = $true }
+	@{ Name = "FwHelps"; Path = "DistFiles/Helps" },
+	@{ Name = "FwLocalizations"; Path = "Localizations" },
+	@{ Name = "liblcm"; Path = "Localizations/LCMRepo" }
 )
 
 $missingRepos = @()
 foreach ($repo in $helperRepos) {
-	$fullPath = Join-Path $repoRoot $repo.Path
+	if ($repo.Name -eq 'liblcm') {
+		if (-not $env:LcmRootDir) {
+			Write-Host '[MISSING] environment variable $LcmRootDir' -ForegroundColor Red
+			$missingRepos += $repo
+			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir, which is not set)"
+			continue
+		}
+		$fullPath = $env:LcmRootDir
+		$displayPath = $fullPath
+	} else {
+		$fullPath = Join-Path $repoRoot $repo.Path
+		$displayPath = $repo.Path
+	}
+
 	$gitPath = Join-Path $fullPath ".git"
 	$isJunction = (Test-Path $fullPath) -and ((Get-Item $fullPath -Force -ErrorAction SilentlyContinue).Attributes -band [IO.FileAttributes]::ReparsePoint)
 
 	if ((Test-Path $gitPath) -or $isJunction) {
 		$status = if ($isJunction) { "junction" } else { "git repo" }
-		Write-Host "[OK] $($repo.Name): $($repo.Path) ($status)" -ForegroundColor Green
+		Write-Host "[OK] $($repo.Name): $displayPath ($status)" -ForegroundColor Green
 	} else {
-		Write-Host "[MISSING] $($repo.Name): $($repo.Path)" -ForegroundColor Red
+		Write-Host "[MISSING] $($repo.Name): $displayPath" -ForegroundColor Red
 		$missingRepos += $repo
-		if ($repo.Required) {
+		if ($repo.Name -eq 'liblcm') {
+			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir=$env:LcmRootDir)"
+		} else {
 			$issues += "Missing helper repository: $($repo.Name)"
 		}
 	}

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -181,13 +181,7 @@ $helperRepos = @(
 
 $missingRepos = @()
 foreach ($repo in $helperRepos) {
-	if ($repo.Name -eq 'liblcm') {
-		if (-not $env:LcmRootDir) {
-			Write-Host '[MISSING] environment variable $LcmRootDir' -ForegroundColor Red
-			$missingRepos += $repo
-			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir, which is not set)"
-			continue
-		}
+	if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir) {
 		$fullPath = $env:LcmRootDir
 		$displayPath = $fullPath
 	} else {

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -182,7 +182,7 @@ $helperRepos = @(
 
 $missingRepos = @()
 foreach ($repo in $helperRepos) {
-	if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir) {
+	if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir -and (Test-Path (Join-Path $env:LcmRootDir '.git'))) {
 		$fullPath = $env:LcmRootDir
 		$displayPath = $fullPath
 	} else {

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -182,7 +182,7 @@ $helperRepos = @(
 
 $missingRepos = @()
 foreach ($repo in $helperRepos) {
-	if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir -and (Test-Path (Join-Path $env:LcmRootDir '.git'))) {
+	if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir) {
 		$fullPath = $env:LcmRootDir
 		$displayPath = $fullPath
 	} else {

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -176,6 +176,7 @@ Write-Host "`n--- Checking Helper Repositories ---" -ForegroundColor Yellow
 $helperRepos = @(
 	@{ Name = "FwHelps"; Path = "DistFiles/Helps" },
 	@{ Name = "FwLocalizations"; Path = "Localizations" },
+	@{ Name = "genericinstaller"; Path = "PatchableInstaller" },
 	@{ Name = "liblcm"; Path = "Localizations/LCMRepo" }
 )
 
@@ -198,7 +199,7 @@ foreach ($repo in $helperRepos) {
 	} else {
 		Write-Host "[MISSING] $($repo.Name): $displayPath" -ForegroundColor Red
 		$missingRepos += $repo
-		if ($repo.Name -eq 'liblcm') {
+		if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir) {
 			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir=$env:LcmRootDir)"
 		} else {
 			$issues += "Missing helper repository: $($repo.Name)"

--- a/Build/Agent/Setup-InstallerBuild.ps1
+++ b/Build/Agent/Setup-InstallerBuild.ps1
@@ -199,10 +199,10 @@ foreach ($repo in $helperRepos) {
 	} else {
 		Write-Host "[MISSING] $($repo.Name): $displayPath" -ForegroundColor Red
 		$missingRepos += $repo
-		if ($repo.Name -eq 'liblcm' -and $env:LcmRootDir) {
-			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir=$env:LcmRootDir)"
+		if ($repo.Name -eq 'liblcm') {
+			$issues += "Missing helper repository: $($repo.Name) (expected at LcmRootDir='$env:LcmRootDir' or $($repo.Path))"
 		} else {
-			$issues += "Missing helper repository: $($repo.Name)"
+			$issues += "Missing helper repository: $($repo.Name) (expected at $($repo.Path))"
 		}
 	}
 }

--- a/Build/Localize.targets
+++ b/Build/Localize.targets
@@ -35,6 +35,7 @@
 		<ListsDirectory>$(L10nsBaseDir)/lists</ListsDirectory>
 		<GoldEticDir>$(ListsDirectory)/GramCats</GoldEticDir>
 		<MessagesPot>$(L10nsBaseDir)/messages.pot</MessagesPot>
+		<LcmRootDir Condition="'$(LcmRootDir)'==''">$(L10nsBaseDir)/LCMRepo</LcmRootDir>
 		<LcmSrcDir>$(LcmRootDir)/src</LcmSrcDir>
 		<WarnForMissingDD Condition="'$(DownloadsDir)'==''">true</WarnForMissingDD>
 		<DownloadsDir>$(fwrt)/Downloads</DownloadsDir><!-- TODO (Hasso) 2026.02: figure out why this isn't getting set elsewhere -->

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -291,7 +291,7 @@ $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [En
 Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
 
 if ($env:LcmRootDir -and (Test-Path (Join-Path $env:LcmRootDir ".git")) -and
-		$PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir for the current user')) {
+		$PSCmdlet.ShouldProcess('LcmRootDir', "Set LcmRootDir to '$env:LcmRootDir' for the current user")) {
 	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
 }
 

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -206,14 +206,17 @@ if ($InstallerDeps) {
 	$localizationsPath = Join-Path $scriptDir "Localizations"
 	$lcmTarget = Join-Path $localizationsPath "LCMRepo"
 	if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir)) {
-		Write-Host "[OK] LCMRepo already exists at $env:LcmRootDir" -ForegroundColor Green
+		Write-Host "[OK] liblcm already exists at $env:LcmRootDir" -ForegroundColor Green
 	} elseif (Test-Path $lcmTarget) {
 		$env:LcmRootDir = $lcmTarget
 		Write-Host "[OK] Localizations/LCMRepo already exists" -ForegroundColor Green
 	} elseif ((Test-Path $localizationsPath)) {
 		if ($isWorktree) {
 			$sharedLcm = Join-Path $repoRoot "liblcm"
-			if (-not (Test-Path $sharedLcm)) {
+			if ((Test-Path $sharedLcm)) {
+				$env:LcmRootDir = $sharedLcm
+				Write-Host "[OK] liblcm already exists at $sharedLcm" -ForegroundColor Green
+			} else {
 				if ($PSCmdlet.ShouldProcess($sharedLcm, "Clone to $sharedLcm")) {
 					Write-Host "Cloning liblcm to shared location..." -ForegroundColor Cyan
 					git clone https://github.com/sillsdev/liblcm.git $sharedLcm 2>&1 | Out-Null
@@ -272,6 +275,19 @@ if ($PSCmdlet.ShouldProcess("$pathScope PATH", "Save changes")) {
 	[Environment]::SetEnvironmentVariable('PATH', $currentPath, $pathScope)
 	# Also update current session
 	$env:PATH = "$env:PATH;$($pathsToAdd -join ';')"
+}
+
+#endregion
+
+#region Environment Variables
+
+Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
+
+if ($PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir')) {
+	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
+}
+if ($PSCmdlet.ShouldProcess('FEEDBACK', 'Turn off production analytics for SIL software')) {
+	[Environment]::SetEnvironmentVariable('FEEDBACK', 'off', $pathScope)
 }
 
 #endregion

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -210,32 +210,36 @@ if ($InstallerDeps) {
 	} elseif (Test-Path $lcmTarget) {
 		$env:LcmRootDir = $lcmTarget
 		Write-Host "[OK] Localizations/LCMRepo already exists" -ForegroundColor Green
-	} elseif ((Test-Path $localizationsPath)) {
-		if ($isWorktree) {
-			$sharedLcm = Join-Path $repoRoot "liblcm"
-			if ((Test-Path $sharedLcm)) {
-				$env:LcmRootDir = $sharedLcm
-				Write-Host "[OK] liblcm already exists at $sharedLcm" -ForegroundColor Green
-			} else {
-				if ($PSCmdlet.ShouldProcess($sharedLcm, "Clone to $sharedLcm")) {
-					Write-Host "Cloning liblcm to shared location..." -ForegroundColor Cyan
-					git clone https://github.com/sillsdev/liblcm.git $sharedLcm 2>&1 | Out-Null
-					if ($LASTEXITCODE -eq 0) {
-						$env:LcmRootDir = $sharedLcm
-						Write-Host "[OK] Cloned liblcm to $sharedLcm" -ForegroundColor Green
-					}
-				}
-			}
+	} elseif ($isWorktree) {
+		$sharedLcm = Join-Path $repoRoot "liblcm"
+		if ((Test-Path $sharedLcm)) {
+			$env:LcmRootDir = $sharedLcm
+			Write-Host "[OK] liblcm already exists at $sharedLcm" -ForegroundColor Green
 		} else {
-			if ($PSCmdlet.ShouldProcess("liblcm", "Clone to $lcmTarget")) {
-				Write-Host "Cloning liblcm..." -ForegroundColor Cyan
-				git clone https://github.com/sillsdev/liblcm.git $lcmTarget 2>&1 | Out-Null
+			if ($PSCmdlet.ShouldProcess("liblcm", "Clone to $sharedLcm")) {
+				Write-Host "Cloning liblcm to shared location..." -ForegroundColor Cyan
+				git clone https://github.com/sillsdev/liblcm.git $sharedLcm 2>&1 | Out-Null
 				if ($LASTEXITCODE -eq 0) {
-					$env:LcmRootDir = $lcmTarget
-					Write-Host "[OK] Cloned liblcm to $lcmTarget" -ForegroundColor Green
+					$env:LcmRootDir = $sharedLcm
+					Write-Host "[OK] Cloned liblcm to $sharedLcm" -ForegroundColor Green
+				} else {
+					Write-Host "[ERROR] Failed to clone liblcm" -ForegroundColor Red
 				}
 			}
 		}
+	} elseif ((Test-Path $localizationsPath)) {
+		if ($PSCmdlet.ShouldProcess("LCMRepo", "Clone to $lcmTarget")) {
+			Write-Host "Cloning liblcm..." -ForegroundColor Cyan
+			git clone https://github.com/sillsdev/liblcm.git $lcmTarget 2>&1 | Out-Null
+			if ($LASTEXITCODE -eq 0) {
+				$env:LcmRootDir = $lcmTarget
+				Write-Host "[OK] Cloned liblcm to $lcmTarget" -ForegroundColor Green
+			} else {
+				Write-Host "[ERROR] Failed to clone liblcm" -ForegroundColor Red
+			}
+		}
+	} else {
+		Write-Host "[ERROR] Failed to clone liblcm because Localizations does not exist" -ForegroundColor Red
 	}
 }
 
@@ -286,7 +290,8 @@ $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [En
 
 Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
 
-if ($PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir')) {
+if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir) -and
+		$PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir for the current user')) {
 	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
 }
 

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -202,7 +202,7 @@ if ($InstallerDeps) {
 		}
 	}
 
-	# Special case: liblcm goes inside Localizations
+	# Special case: liblcm is found via the LcmRootDir environment variable
 	$localizationsPath = Join-Path $scriptDir "Localizations"
 	$lcmTarget = Join-Path $localizationsPath "LCMRepo"
 	if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir)) {
@@ -283,24 +283,17 @@ Write-Host "`n--- Verification ---" -ForegroundColor Yellow
 # Refresh PATH for this session
 $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User')
 
-$allGood = $true
-
-# WiX (v6) is acquired via NuGet restore; no PATH verification needed.
-Write-Host "[OK] WiX v6: acquired via NuGet restore during build" -ForegroundColor Green
-
 #endregion
 
 Write-Host "`n========================================" -ForegroundColor Cyan
-if ($allGood) {
-	Write-Host " Setup Complete!" -ForegroundColor Green
-} else {
-	Write-Host " Setup Complete (restart terminal for PATH changes)" -ForegroundColor Yellow
-}
+Write-Host " Setup Complete!" -ForegroundColor Green
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor White
-Write-Host "  1. Restart VS Code (or your terminal) for PATH changes to take effect"
+Write-Host "  1. Restart your IDE and your terminal (not necessary for this terminal) for PATH and environment changes to take effect"
 Write-Host "  2. Build: .\build.ps1"
 Write-Host ""
-Write-Host "Before building installers, run: .\Setup-Developer-Machine.ps1 -InstallerDeps" -ForegroundColor Gray
+if (-not $InstallerDeps) {
+	Write-Host "Before building installers, run: .\Setup-Developer-Machine.ps1 -InstallerDeps" -ForegroundColor Gray
+}
 Write-Host "For Serena MCP support, see Docs/mcp.md" -ForegroundColor Gray

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -277,6 +277,9 @@ if ($PSCmdlet.ShouldProcess("$pathScope PATH", "Save changes")) {
 	$env:PATH = "$env:PATH;$($pathsToAdd -join ';')"
 }
 
+# Refresh PATH for this session
+$env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User')
+
 #endregion
 
 #region Environment Variables
@@ -286,18 +289,10 @@ Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
 if ($PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir')) {
 	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
 }
+
 if ($PSCmdlet.ShouldProcess('FEEDBACK', 'Turn off production analytics for SIL software')) {
 	[Environment]::SetEnvironmentVariable('FEEDBACK', 'off', $pathScope)
 }
-
-#endregion
-
-#region Verification
-
-Write-Host "`n--- Verification ---" -ForegroundColor Yellow
-
-# Refresh PATH for this session
-$env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User')
 
 #endregion
 

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -205,7 +205,7 @@ if ($InstallerDeps) {
 	# Special case: liblcm is found via the LcmRootDir environment variable
 	$localizationsPath = Join-Path $scriptDir "Localizations"
 	$lcmTarget = Join-Path $localizationsPath "LCMRepo"
-	if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir)) {
+	if ($env:LcmRootDir -and (Test-Path Join-Path $env:LcmRootDir ".git")) {
 		Write-Host "[OK] liblcm already exists at $env:LcmRootDir" -ForegroundColor Green
 	} elseif (Test-Path $lcmTarget) {
 		$env:LcmRootDir = $lcmTarget

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -205,7 +205,7 @@ if ($InstallerDeps) {
 	# Special case: liblcm is found via the LcmRootDir environment variable
 	$localizationsPath = Join-Path $scriptDir "Localizations"
 	$lcmTarget = Join-Path $localizationsPath "LCMRepo"
-	if ($env:LcmRootDir -and (Test-Path Join-Path $env:LcmRootDir ".git")) {
+	if ($env:LcmRootDir -and (Test-Path (Join-Path $env:LcmRootDir ".git"))) {
 		Write-Host "[OK] liblcm already exists at $env:LcmRootDir" -ForegroundColor Green
 	} elseif (Test-Path $lcmTarget) {
 		$env:LcmRootDir = $lcmTarget
@@ -290,7 +290,7 @@ $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [En
 
 Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
 
-if ($env:LcmRootDir -and (Test-Path Join-Path $env:LcmRootDir ".git") -and
+if ($env:LcmRootDir -and (Test-Path (Join-Path $env:LcmRootDir ".git")) -and
 		$PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir for the current user')) {
 	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
 }

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -203,21 +203,24 @@ if ($InstallerDeps) {
 	}
 
 	# Special case: liblcm goes inside Localizations
-	$lcmTarget = Join-Path $scriptDir "Localizations/LCMRepo"
 	$localizationsPath = Join-Path $scriptDir "Localizations"
-	if ((Test-Path $localizationsPath) -and -not (Test-Path $lcmTarget)) {
+	$lcmTarget = Join-Path $localizationsPath "LCMRepo"
+	if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir)) {
+		Write-Host "[OK] LCMRepo already exists at $env:LcmRootDir" -ForegroundColor Green
+	} elseif (Test-Path $lcmTarget) {
+		$env:LcmRootDir = $lcmTarget
+		Write-Host "[OK] Localizations/LCMRepo already exists" -ForegroundColor Green
+	} elseif ((Test-Path $localizationsPath)) {
 		if ($isWorktree) {
 			$sharedLcm = Join-Path $repoRoot "liblcm"
 			if (-not (Test-Path $sharedLcm)) {
-				if ($PSCmdlet.ShouldProcess("liblcm", "Clone to $sharedLcm")) {
+				if ($PSCmdlet.ShouldProcess($sharedLcm, "Clone to $sharedLcm")) {
 					Write-Host "Cloning liblcm to shared location..." -ForegroundColor Cyan
 					git clone https://github.com/sillsdev/liblcm.git $sharedLcm 2>&1 | Out-Null
-				}
-			}
-			if (Test-Path $sharedLcm) {
-				if ($PSCmdlet.ShouldProcess("Localizations/LCMRepo", "Create junction to $sharedLcm")) {
-					New-Item -ItemType Junction -Path $lcmTarget -Target $sharedLcm -Force | Out-Null
-					Write-Host "[OK] Created junction: Localizations/LCMRepo -> $sharedLcm" -ForegroundColor Green
+					if ($LASTEXITCODE -eq 0) {
+						$env:LcmRootDir = $sharedLcm
+						Write-Host "[OK] Cloned liblcm to $sharedLcm" -ForegroundColor Green
+					}
 				}
 			}
 		} else {
@@ -225,12 +228,11 @@ if ($InstallerDeps) {
 				Write-Host "Cloning liblcm..." -ForegroundColor Cyan
 				git clone https://github.com/sillsdev/liblcm.git $lcmTarget 2>&1 | Out-Null
 				if ($LASTEXITCODE -eq 0) {
+					$env:LcmRootDir = $lcmTarget
 					Write-Host "[OK] Cloned liblcm to $lcmTarget" -ForegroundColor Green
 				}
 			}
 		}
-	} elseif (Test-Path $lcmTarget) {
-		Write-Host "[OK] Localizations/LCMRepo already exists" -ForegroundColor Green
 	}
 }
 
@@ -271,14 +273,6 @@ if ($PSCmdlet.ShouldProcess("$pathScope PATH", "Save changes")) {
 	# Also update current session
 	$env:PATH = "$env:PATH;$($pathsToAdd -join ';')"
 }
-
-#endregion
-
-#region Environment Variables
-
-Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
-
-Write-Host "[INFO] WIX env var is not required for WiX v6 SDK builds" -ForegroundColor Gray
 
 #endregion
 

--- a/Setup-Developer-Machine.ps1
+++ b/Setup-Developer-Machine.ps1
@@ -290,7 +290,7 @@ $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [En
 
 Write-Host "`n--- Configuring Environment Variables ---" -ForegroundColor Yellow
 
-if ($env:LcmRootDir -and (Test-Path $env:LcmRootDir) -and
+if ($env:LcmRootDir -and (Test-Path Join-Path $env:LcmRootDir ".git") -and
 		$PSCmdlet.ShouldProcess('LcmRootDir', 'Set LcmRootDir for the current user')) {
 	[Environment]::SetEnvironmentVariable('LcmRootDir', $env:LcmRootDir, 'User')
 }


### PR DESCRIPTION
* Remove the do-nothing environment variable setup region
* Remove the junction to LCMRepo--it is located by an environment var
* Check for LibLCM existence in more places before cloning
* Set $env:LcmRootDir after finding or cloning LibLCM

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] Builds/tests pass locally (or I've run the CI-style build via `build.ps1`/`test.ps1` or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.
- [x] All comments from an AI code reviewer have been considered (such as [Devin](https://app.devin.ai/review/sillsdev/FieldWorks/pull/1077))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1077)
<!-- Reviewable:end -->
