### PR TITLE
LT-22691: Fix command routing through the hidden DataTree adapter

### DIFF
--- a/Src/Common/Controls/DetailControls/DataTree.cs
+++ b/Src/Common/Controls/DetailControls/DataTree.cs
@@ -769,7 +769,7 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				CheckDisposed();
 
 				if (value == null)
-					throw new ArgumentException("CurrentSlice on DataTree cannot be set to null. Set the underlying data member to null, if you really want it to be null.");
+					throw new ArgumentException("CurrentSlice on DataTree cannot be set to null. Call ClearCurrentSlice(), if you really want it to be null.");
 				Debug.Assert(!value.IsDisposed, "Setting CurrentSlice to a disposed slice -- not a good idea!");
 
 				// don't set the current slice until we're all setup to do so (LT-7307)
@@ -4411,11 +4411,57 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			Subscriber.Subscribe(EventConstants.JumpToField, JumpToField, m_propertyTable.GetWindow());
 		}
 
+		/// <summary>
+		/// Drops the current slice so command handlers see no target and no-op. The deliberate
+		/// counterpart to the <see cref="CurrentSlice"/> setter, which rejects null.
+		/// </summary>
+		public void ClearCurrentSlice()
+		{
+			CheckDisposed();
+
+			m_currentSliceNew = null;
+			m_fSetCurrentSliceNew = false;
+			if (m_currentSlice != null && !m_currentSlice.IsDisposed)
+				m_currentSlice.SetCurrentState(false);
+			m_currentSlice = null;
+		}
+
+		/// <summary>
+		/// Points <see cref="CurrentSlice"/> at <paramref name="slice"/> for command targeting.
+		/// The ordinary setter is suspended between <c>ShowObject</c> and an idle callback
+		/// (LT-3915), which would silently discard the assignment, and its scroll/tab-stop work
+		/// needs a laid-out tree.
+		/// </summary>
+		public void SetCurrentSliceForCommandTarget(Slice slice)
+		{
+			CheckDisposed();
+
+			if (slice == null)
+			{
+				ClearCurrentSlice();
+				return;
+			}
+
+			m_currentSliceNew = null;
+			m_fSetCurrentSliceNew = false;
+			if (m_currentSlice == slice)
+				return;
+
+			if (m_currentSlice != null && !m_currentSlice.IsDisposed)
+				m_currentSlice.SetCurrentState(false);
+
+			m_currentSlice = slice;
+			m_currentSlice.SetCurrentState(true);
+			m_descendant = DescendantForSlice(m_currentSlice);
+		}
+
 		public IxCoreColleague[] GetMessageTargets()
 		{
 			CheckDisposed();
 
-			if (Visible)
+			// A command adapter is never shown, yet still drives this tree, so excluding
+			// it for invisibility would silence the handlers defined on the tree itself.
+			if (Visible || IsExternalCommandAdapter)
 			{
 				if (m_currentSlice != null)
 					return new IxCoreColleague[] { m_currentSlice, this };
@@ -5366,6 +5412,17 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			{
 				CheckDisposed();
 				return false;
+			}
+		}
+
+		/// <summary>This slice stands in for objects not yet built; its Object is the
+		/// OWNER.</summary>
+		public override bool IsLazyPlaceholder
+		{
+			get
+			{
+				CheckDisposed();
+				return true;
 			}
 		}
 

--- a/Src/Common/Controls/DetailControls/DetailControlsTests/DataTreeCommandAdapterTests.cs
+++ b/Src/Common/Controls/DetailControls/DetailControlsTests/DataTreeCommandAdapterTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using System.Windows.Forms;
+using NUnit.Framework;
+using XCore;
+
+namespace SIL.FieldWorks.Common.Framework.DetailControls
+{
+	/// <summary>
+	/// Message targeting for a hidden <see cref="DataTree"/>: an ordinary hidden tree stays out
+	/// of the colleague chain, but one flagged <see cref="DataTree.IsExternalCommandAdapter"/>
+	/// stays in so its command handlers remain reachable.
+	/// </summary>
+	[TestFixture]
+	public class DataTreeCommandAdapterTests
+	{
+		private DataTree m_dtree;
+		private Mediator m_mediator;
+		private PropertyTable m_propertyTable;
+		private Form m_parent;
+
+		[SetUp]
+		public void SetUp()
+		{
+			m_dtree = new DataTree();
+			m_mediator = new Mediator();
+			m_propertyTable = new PropertyTable(m_mediator);
+			m_dtree.Init(m_mediator, m_propertyTable, null);
+			// Parented but never shown -- the state a host leaves the adapter tree in.
+			m_parent = new Form();
+			m_parent.Controls.Add(m_dtree);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			m_parent?.Dispose();
+			m_parent = null;
+			m_dtree = null; // owned by the form
+			m_propertyTable?.Dispose();
+			m_propertyTable = null;
+			m_mediator?.Dispose();
+			m_mediator = null;
+		}
+
+		[Test]
+		public void HiddenTree_WithNoCurrentSlice_IsNotAMessageTarget()
+		{
+			Assert.That(m_dtree.Visible, Is.False, "precondition: the tree is not shown");
+
+			Assert.That(m_dtree.GetMessageTargets(), Is.Empty,
+				"an ordinary hidden tree keeps out of the colleague chain");
+		}
+
+		[Test]
+		public void HiddenTree_AsExternalCommandAdapter_IsAMessageTarget()
+		{
+			Assert.That(m_dtree.Visible, Is.False, "precondition: the tree is not shown");
+
+			m_dtree.IsExternalCommandAdapter = true;
+
+			Assert.That(m_dtree.GetMessageTargets().ToList(), Does.Contain(m_dtree),
+				"the adapter tree must stay reachable so its own command handlers still run");
+		}
+
+		[Test]
+		public void ClearCurrentSlice_IsTheSanctionedWayToHaveNoCurrentSlice()
+		{
+			// The setter rejects null; ClearCurrentSlice is the deliberate no-target path.
+			Assert.That(() => m_dtree.CurrentSlice = null, Throws.ArgumentException);
+
+			Assert.That(() => m_dtree.ClearCurrentSlice(), Throws.Nothing);
+			Assert.That(m_dtree.CurrentSlice, Is.Null);
+		}
+	}
+}

--- a/Src/Common/Controls/DetailControls/MultiLevelConc.cs
+++ b/Src/Common/Controls/DetailControls/MultiLevelConc.cs
@@ -369,6 +369,16 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 				}
 			}
 
+			/// <summary>This slice stands in for a node not yet built (see BecomeReal).</summary>
+			public override bool IsLazyPlaceholder
+			{
+				get
+				{
+					CheckDisposed();
+					return true;
+				}
+			}
+
 			public override Slice BecomeReal(int index)
 			{
 				CheckDisposed();

--- a/Src/Common/Controls/DetailControls/Slice.cs
+++ b/Src/Common/Controls/DetailControls/Slice.cs
@@ -715,6 +715,22 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 		}
 
 		/// <summary>
+		/// True for a lazy placeholder standing in for objects not yet built. It reports its
+		/// OWNER as its Object, so object lookups must skip it. Distinct from
+		/// <see cref="IsRealSlice"/>, which for view slices reports layout state, not
+		/// placeholder-ness.
+		/// </summary>
+		public virtual bool IsLazyPlaceholder
+		{
+			get
+			{
+				CheckDisposed();
+
+				return false;
+			}
+		}
+
+		/// <summary>
 		/// In some contexts, we use a "ghost" slice to represent data that
 		/// has not yet been created.  These are "real" slices, but they don't
 		/// represent "real" data.  Thus, for example, the underlying object
@@ -2815,7 +2831,12 @@ namespace SIL.FieldWorks.Common.Framework.DetailControls
 			// hides the data tree but does not remove slices when no record is current.
 			// Thus, a slice that is not visible might belong to a display of a deleted
 			// or unavailable object, so be very careful what you enable!
-			if (Visible && ContainingDataTree.Visible)
+			//
+			// Exception: a hidden command-adapter tree still needs its slice handlers
+			// reachable; its owner points CurrentSlice at the acted-on row first, so the
+			// deleted-object hazard above does not apply.
+			var isCommandAdapter = ContainingDataTree != null && ContainingDataTree.IsExternalCommandAdapter;
+			if ((Visible && ContainingDataTree.Visible) || isCommandAdapter)
 			{
 				if (Control != null && Control.IsDisposed)
 					throw new ObjectDisposedException(ToString() + GetHashCode(), "Trying to use object that no longer exists: ");

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -17,6 +17,7 @@ using SIL.FieldWorks.Common.Framework.DetailControls;
 // Bare DataTree in this file means the legacy WinForms tree; the Avalonia twin stays qualified.
 using DataTree = SIL.FieldWorks.Common.Framework.DetailControls.DataTree;
 using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Utils;
 using XCore;
 using System.Collections.Generic;
@@ -439,7 +440,7 @@ namespace SIL.FieldWorks.XWorks
 				// colleague chain disable, everything else still works (and the failure is logged).
 				try
 				{
-					EnsureMenuCommandAdapter(request.Field.ObjectHvo);
+					EnsureMenuCommandAdapter(request.Field.ObjectHvo, request.Field.Field);
 				}
 				catch (Exception adapterError)
 				{
@@ -690,7 +691,7 @@ namespace SIL.FieldWorks.XWorks
 		// DTMenuHandler provide the colleague chain and CurrentSlice context the legacy command
 		// handlers require. Created lazily on first right-click; never attached/visible while the
 		// Avalonia is active.
-		private void EnsureMenuCommandAdapter(int targetHvo)
+		private void EnsureMenuCommandAdapter(int targetHvo, string fieldName)
 		{
 			// The active-host contract is enforced, not just documented: driving the hidden
 			// legacy DataTree is legal only through an adapter id the host's contract lists. The
@@ -710,11 +711,20 @@ namespace SIL.FieldWorks.XWorks
 
 			var current = Clerk?.CurrentObject;
 			if (current == null)
+			{
+				// No current record: drop any target left by a previous interaction, same
+				// fail-loud rule as the no-slice-found path below.
+				m_dataEntryForm.ClearCurrentSlice();
 				return;
+			}
 			m_dataEntryForm.ShowObject(current, m_layoutName, m_layoutChoiceField, current, true);
 
 			if (targetHvo == 0)
+			{
+				// The row carries no object, so no slice can be its target.
+				m_dataEntryForm.ClearCurrentSlice();
 				return;
+			}
 
 			// Targeting hardening: the legacy command handlers act on m_dataEntryForm.CurrentSlice,
 			// so the adapter must point CurrentSlice at the slice bound to the clicked row's object. A first
@@ -725,51 +735,113 @@ namespace SIL.FieldWorks.XWorks
 			// retry rather
 			// than silently leaving the wrong (or stale) CurrentSlice pointed, which would make the command
 			// mutate the wrong object or, for Merge's class guard, silently fail.
-			if (TrySetCurrentSliceForHvo(targetHvo))
+			if (TrySetCurrentSliceForRow(targetHvo, fieldName))
 				return;
 
-			if (RealizeLazySlicesAndRetry(targetHvo))
+			if (RealizeLazySlicesAndRetry(targetHvo, fieldName))
 				return;
 
 			// Fail loud, not silent: if we still cannot produce a slice for the target we must NOT leave
 			// CurrentSlice pointed at whatever the previous interaction selected (it would mis-target the
 			// command). Clear it so command handlers see "no current slice" and no-op, and log so the
 			// degradation is diagnosable from the field rather than only in a debugger.
-			m_dataEntryForm.CurrentSlice = null;
+			m_dataEntryForm.ClearCurrentSlice();
 			Logger.WriteEvent(string.Format(
-				"Detail menu command adapter found no DataTree slice for target hvo {0}; CurrentSlice was "
-				+ "cleared so the command no-ops rather than mis-targeting another object.", targetHvo));
+				"Detail menu command adapter found no DataTree slice for target hvo {0} field '{1}'; "
+				+ "CurrentSlice was cleared so the command no-ops rather than mis-targeting another object.",
+				targetHvo, fieldName ?? string.Empty));
 		}
 
-		// Points CurrentSlice at the (already-realized) slice whose bound object is targetHvo. Returns
-		// false when no realized slice matches (the target may still be inside an unrealized dummy).
-		private bool TrySetCurrentSliceForHvo(int targetHvo)
+		/// <summary>
+		/// Picks the slice a menu request targets. Sibling rows can share one object (a MoForm's
+		/// Form, Morph Type, ...) while handlers key on <c>CurrentSlice.Flid</c>, so prefer a
+		/// match on object AND field; fall back to object alone (headers, ghosts, custom rows).
+		/// Returns -1 when nothing matches.
+		/// </summary>
+		internal static int ChooseTargetSliceIndex(IReadOnlyList<(int Hvo, string FieldName)> candidates,
+			int targetHvo, string fieldName)
 		{
-			foreach (var sliceObj in m_dataEntryForm.Slices)
+			if (candidates == null)
+				return -1;
+
+			if (!string.IsNullOrEmpty(fieldName))
 			{
-				if (sliceObj is Slice slice && slice.IsRealSlice && slice.Object != null
-					&& slice.Object.Hvo == targetHvo)
+				for (var i = 0; i < candidates.Count; i++)
 				{
-					m_dataEntryForm.CurrentSlice = slice;
-					return true;
+					if (candidates[i].Hvo == targetHvo
+						&& string.Equals(candidates[i].FieldName, fieldName, StringComparison.Ordinal))
+					{
+						return i;
+					}
 				}
 			}
-			return false;
+
+			for (var i = 0; i < candidates.Count; i++)
+			{
+				if (candidates[i].Hvo == targetHvo)
+					return i;
+			}
+			return -1;
 		}
 
-		// Forces every lazy DummyObjectSlice to become real, then retries the hvo match. A dummy stands
-		// in for a run of objects in a sequence and reports its OWNER as its Object, so the target hvo
-		// cannot match until the dummy is realized into the per-object slices. DataTree.FieldAt(i)
-		// realizes the slice at index i in place (replacing the dummy); we walk by index because the
-		// collection mutates as dummies expand.
-		private bool RealizeLazySlicesAndRetry(int targetHvo)
+		// Targets the best realized slice for the row; false when nothing matches (the
+		// target may still sit inside a lazy placeholder).
+		private bool TrySetCurrentSliceForRow(int targetHvo, string fieldName)
+		{
+			// Not filtered on Slice.IsRealSlice: for a view slice that is
+			// RootSite.AllowLayout, false forever in a tree that never lays out. Lazy
+			// placeholders report their OWNER, so exclude them by type instead.
+			var candidates = new List<Slice>();
+			foreach (var sliceObj in m_dataEntryForm.Slices)
+			{
+				if (sliceObj is Slice slice && slice.Object != null && !slice.IsLazyPlaceholder)
+					candidates.Add(slice);
+			}
+
+			// Field names are only ever compared for hvo matches, so skip the metadata
+			// lookup for every other slice (and entirely when no field name was requested).
+			var index = ChooseTargetSliceIndex(
+				candidates.Select(s => (
+					s.Object.Hvo,
+					s.Object.Hvo == targetHvo && !string.IsNullOrEmpty(fieldName)
+						? SliceFieldName(s)
+						: null)).ToList(),
+				targetHvo, fieldName);
+			if (index < 0)
+				return false;
+
+			// ShowObject suspends ordinary CurrentSlice assignment until idle; the
+			// command-target setter applies immediately.
+			m_dataEntryForm.SetCurrentSliceForCommandTarget(candidates[index]);
+			return true;
+		}
+
+		// The model field name a slice edits, or null (header/object rows, unknown flids).
+		private string SliceFieldName(Slice slice)
+		{
+			var flid = slice.Flid;
+			// A ViewPropertySlice can carry its field only in FieldId, with no "field"
+			// attribute on its configuration node.
+			if (flid == 0 && slice is ViewPropertySlice viewPropertySlice)
+				flid = viewPropertySlice.FieldId;
+			// Virtual and decorator-only flids are absent from the MDC and never field-match.
+			var mdc = (IFwMetaDataCacheManaged)Cache.MetaDataCacheAccessor;
+			return flid != 0 && mdc.FieldExists(flid) ? mdc.GetFieldName(flid) : null;
+		}
+
+		/// <summary>
+		/// Expands every lazy placeholder in place, then retries the match: a placeholder reports
+		/// its OWNER as its Object, so the target cannot match until expansion. Walks by index
+		/// because the collection mutates as placeholders expand.
+		/// </summary>
+		private bool RealizeLazySlicesAndRetry(int targetHvo, string fieldName)
 		{
 			try
 			{
 				for (var i = 0; i < m_dataEntryForm.Slices.Count; i++)
 				{
-					if (m_dataEntryForm.Slices[i] is Slice slice && !slice.IsRealSlice)
-						m_dataEntryForm.FieldAt(i); // realizes the dummy at i in place
+					if (m_dataEntryForm.Slices[i] is Slice slice && slice.IsLazyPlaceholder)
+						m_dataEntryForm.FieldAt(i); // expands the placeholder at i in place
 				}
 			}
 			catch (Exception e)
@@ -778,7 +850,7 @@ namespace SIL.FieldWorks.XWorks
 				return false;
 			}
 
-			return TrySetCurrentSliceForHvo(targetHvo);
+			return TrySetCurrentSliceForRow(targetHvo, fieldName);
 		}
 
 		private bool? GetPersistedExpansionState(string stableId)

--- a/Src/xWorks/DTMenuHandler.cs
+++ b/Src/xWorks/DTMenuHandler.cs
@@ -432,6 +432,10 @@ namespace SIL.FieldWorks.XWorks
 			string className = command.GetParameter("className");
 			string ownerClassName = command.GetParameter("ownerClass", "");
 			Slice current = m_dataEntryForm.CurrentSlice;
+			// On the hidden command adapter a null CurrentSlice is the deliberate no-target
+			// state; substituting another slice would insert relative to the wrong object.
+			if (current == null && m_dataEntryForm.IsExternalCommandAdapter)
+				return false;
 			if (current != null)
 			{
 				current.Validate();
@@ -855,8 +859,13 @@ namespace SIL.FieldWorks.XWorks
 		{
 			XCore.Command command = commandObject as XCore.Command;
 			Slice slice = m_dataEntryForm.CurrentSlice;
-			if (slice == null && m_dataEntryForm.Slices.Count > 0)
+			// On the hidden command adapter a null CurrentSlice is the deliberate no-target
+			// state; substituting the first slice would enable the insert against another object.
+			if (slice == null && m_dataEntryForm.Slices.Count > 0
+				&& !m_dataEntryForm.IsExternalCommandAdapter)
+			{
 				slice = m_dataEntryForm.FieldAt(0);
+			}
 
 			int index = -1;
 			// 15.4: the hidden command-routing adapter tree counts as active -- the user-visible
@@ -888,8 +897,13 @@ namespace SIL.FieldWorks.XWorks
 		{
 			XCore.Command command = commandObject as XCore.Command;
 			Slice slice = m_dataEntryForm.CurrentSlice;
-			if (slice == null && m_dataEntryForm.Slices.Count > 0)
+			// Same no-target rule as OnDisplayDataTreeInsert: on the hidden command adapter,
+			// never substitute the first slice for a deliberately cleared CurrentSlice.
+			if (slice == null && m_dataEntryForm.Slices.Count > 0
+				&& !m_dataEntryForm.IsExternalCommandAdapter)
+			{
 				slice = m_dataEntryForm.FieldAt(0);
+			}
 
 			int index = -1;
 			if (command != null && slice != null && !slice.IsDisposed && this.CanInsert(command, slice, out index))

--- a/Src/xWorks/RecordEditView.cs
+++ b/Src/xWorks/RecordEditView.cs
@@ -393,6 +393,10 @@ namespace SIL.FieldWorks.XWorks
 					m_detailEditContext.Clear();
 					EnsureAvaloniaEntryFormActive();
 					m_avaloniaEntryForm.Clear();
+					// Adapter hygiene: drop slices over a possibly deleted record,
+					// or menu-enablement polls touch a deleted object.
+					if (m_dataTreeInitialized && m_dataEntryForm != null)
+						m_dataEntryForm.Reset();
 				}
 				else
 				{
@@ -511,6 +515,10 @@ namespace SIL.FieldWorks.XWorks
 		private void EnsureDataTreeVisible()
 		{
 			SyncActiveHostContract();
+
+			// A New-to-Legacy flip reuses the adapter tree; the visible legacy tree must
+			// not keep the adapter's widened message targeting.
+			m_dataEntryForm.IsExternalCommandAdapter = false;
 
 			AttachDataTreeToPanel();
 			m_avaloniaEntryForm?.Hide();

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailCommandAdapterHardeningTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailCommandAdapterHardeningTests.cs
@@ -237,12 +237,12 @@ namespace SIL.FieldWorks.XWorks
 			}
 		}
 
-		private void EnsureAdapter(int targetHvo)
+		private void EnsureAdapter(int targetHvo, string fieldName = null)
 		{
 			var method = typeof(RecordEditView).GetMethod("EnsureMenuCommandAdapter",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			Assert.That(method, Is.Not.Null);
-			method.Invoke(m_view, new object[] { targetHvo });
+			method.Invoke(m_view, new object[] { targetHvo, fieldName });
 		}
 
 		private void LoadRecordEditView(string toolValue)

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailMenuTargetingTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailMenuTargetingTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// Which slice a detail-menu request targets in the hidden command adapter. Sibling rows
+	/// share one MoForm, so an object-only match returns whichever slice comes first, while
+	/// legacy handlers key on <c>CurrentSlice.Flid</c>.
+	/// </summary>
+	[TestFixture]
+	public class DetailMenuTargetingTests
+	{
+		// The Lexeme Form section's slice order: the Form row, then rows sharing its MoForm.
+		private const int MorphHvo = 4242;
+		private const int EntryHvo = 11;
+
+		private static IReadOnlyList<(int Hvo, string FieldName)> LexemeFormSection()
+			=> new List<(int, string)>
+			{
+				(EntryHvo, "CitationForm"),
+				(MorphHvo, "Form"),
+				(MorphHvo, "IsAbstract"),
+				(MorphHvo, "MorphType"),
+				(MorphHvo, "PhoneEnv")
+			};
+
+		[Test]
+		public void FieldMatch_WinsOverEarlierSlicesOnTheSameObject()
+		{
+			var index = RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), MorphHvo, "MorphType");
+
+			Assert.That(index, Is.EqualTo(3),
+				"the Morph Type row must target its own slice, not the first slice on the same MoForm");
+		}
+
+		[Test]
+		public void LexemeFormRow_TargetsTheFormSlice()
+		{
+			var index = RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), MorphHvo, "Form");
+
+			Assert.That(index, Is.EqualTo(1),
+				"GetGuidForJumpToTool requires CurrentSlice.Flid to be the MoForm Form field");
+		}
+
+		[Test]
+		public void UnknownFieldName_FallsBackToTheObjectMatch()
+		{
+			// Rows with no slice counterpart (headers, ghosts) fall back to object-only.
+			var index = RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), MorphHvo, "NoSuchField");
+
+			Assert.That(index, Is.EqualTo(1), "falls back to the first slice bound to the object");
+		}
+
+		[Test]
+		public void NoFieldName_FallsBackToTheObjectMatch()
+		{
+			Assert.That(RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), MorphHvo, null),
+				Is.EqualTo(1));
+			Assert.That(RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), MorphHvo, string.Empty),
+				Is.EqualTo(1));
+		}
+
+		[Test]
+		public void NoObjectMatch_ReportsNoTarget()
+		{
+			// The caller then clears CurrentSlice so handlers no-op rather than mis-target.
+			Assert.That(RecordEditView.ChooseTargetSliceIndex(LexemeFormSection(), 999, "Form"),
+				Is.EqualTo(-1));
+			Assert.That(RecordEditView.ChooseTargetSliceIndex(null, MorphHvo, "Form"), Is.EqualTo(-1));
+		}
+
+		[Test]
+		public void FieldNameMatch_IsScopedToTheRequestedObject()
+		{
+			// Another object's slice with the SAME field name must not be picked up.
+			var candidates = new List<(int, string)>
+			{
+				(EntryHvo, "Form"),
+				(MorphHvo, "Form")
+			};
+
+			Assert.That(RecordEditView.ChooseTargetSliceIndex(candidates, MorphHvo, "Form"), Is.EqualTo(1));
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -18,6 +18,8 @@ using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Infrastructure;
 using XCore;
+// Both namespaces above define DataTree; the adapter tests mean the legacy WinForms one.
+using LegacyDataTree = SIL.FieldWorks.Common.Framework.DetailControls.DataTree;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -277,6 +279,59 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		// -----------------------------------------------------------------
+		// Lexeme Form slice menu: adapter reachability, Writing Systems
+		// -----------------------------------------------------------------
+
+		// The adapter tree is never shown, so message-target selection must keep it in the
+		// colleague chain for handlers defined on DataTree itself, such as OnJumpToTool.
+		[Test]
+		public void HiddenAdapterTree_StaysInTheColleagueChain_SoItsOwnHandlersAreReachable()
+		{
+			EnsureAdapter(m_entry.LexemeFormOA.Hvo, "Form");
+
+			var dataTree = (LegacyDataTree)GetField(m_view, "m_dataEntryForm");
+			Assert.That(dataTree.Visible, Is.False,
+				"precondition: the adapter tree is hidden while Avalonia is the active host");
+			Assert.That(dataTree.IsExternalCommandAdapter, Is.True,
+				"precondition: the host flagged it as the command-routing adapter");
+			Assert.That(dataTree.GetMessageTargets(), Does.Contain(dataTree),
+				"handlers defined on the tree itself (JumpToTool, Delete, Insert) must stay reachable");
+		}
+
+		// The Lexeme Form row and its indented siblings share one MoForm, so matching by
+		// object alone is ambiguous; the concordance jump and the Writing Systems list
+		// both need the Form slice.
+		[Test]
+		public void LexemeFormRow_TargetsTheFormSlice_NotJustSomeSliceOnTheSameMorph()
+		{
+			EnsureAdapter(m_entry.LexemeFormOA.Hvo, "Form");
+
+			var dataTree = (LegacyDataTree)GetField(m_view, "m_dataEntryForm");
+			var current = dataTree.CurrentSlice;
+			Assert.That(current, Is.Not.Null, "a slice must be targeted for the Lexeme Form row");
+			Assert.That(current.Object?.Hvo, Is.EqualTo(m_entry.LexemeFormOA.Hvo));
+			Assert.That(current.Flid, Is.EqualTo(MoFormTags.kflidForm),
+				"the targeted slice must be the Form field's own slice");
+		}
+
+		// DataTree.OnDisplayJumpToTool offers the jump only when CurrentSlice.Flid is the
+		// MoForm's Form field, so an enabled item proves the tree is reachable and the row
+		// targeted that slice.
+		[Test]
+		public void ConcordanceCommand_OnTheLexemeFormRow_IsEnabledByItsRealHandler()
+		{
+			EnsureAdapter(m_entry.LexemeFormOA.Hvo, "Form");
+
+			var jump = FindItem(BuildItems(new[] { "mnuDataTree-LexemeForm", "mnuDataTree-MultiStringSlice" }),
+				"Show Lexeme Form in Concordance");
+
+			Assert.That(jump, Is.Not.Null, "the command materializes on the Lexeme Form row");
+			Assert.That(jump.IsEnabled, Is.True,
+				"DataTree.OnDisplayJumpToTool must run and resolve a concordance target for the Form field");
+			Assert.That(jump.Execute, Is.Not.Null, "and it carries a mediator-dispatch action");
+		}
+
+		// -----------------------------------------------------------------
 		// Helpers -- production-path command drivers
 		// -----------------------------------------------------------------
 
@@ -317,12 +372,12 @@ namespace SIL.FieldWorks.XWorks
 			return true;
 		}
 
-		private void EnsureAdapter(int targetHvo)
+		private void EnsureAdapter(int targetHvo, string fieldName = null)
 		{
 			var method = typeof(RecordEditView).GetMethod("EnsureMenuCommandAdapter",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			Assert.That(method, Is.Not.Null, "EnsureMenuCommandAdapter must exist (adapter targeting seam)");
-			method.Invoke(m_view, new object[] { targetHvo });
+			method.Invoke(m_view, new object[] { targetHvo, fieldName });
 		}
 
 		private IReadOnlyList<DetailMenuItem> BuildItems(string[] menuIds)


### PR DESCRIPTION
The Avalonia detail host drives the legacy DataTree as a hidden command-routing adapter, but Mediator message-target selection dropped invisible trees and slices from the colleague chain. Every handler defined on the tree itself (JumpToTool, Delete, Insert, Move Field) and every slice-level handler (the Writing Systems options list) was unreachable, so those menu items were inert or wrongly disabled.

Keep an adapter-flagged tree and its slices in the colleague chain via IsExternalCommandAdapter, and clear the flag when the legacy view reactivates so a runtime UI flip does not widen legacy targeting.

Target the adapter's CurrentSlice by object and field name: sibling rows share one MoForm, and handlers such as GetGuidForJumpToTool resolve the target from CurrentSlice.Flid. Add
SetCurrentSliceForCommandTarget because ShowObject suspends ordinary CurrentSlice assignment until an idle callback, silently discarding the adapter's targeting, and add ClearCurrentSlice as the sanctioned no-target state. Exclude lazy placeholders via the new Slice.IsLazyPlaceholder instead of IsRealSlice, which for view-backed slices reports layout state and is false forever in a tree that is never shown.

Note: Other changes are need to complete LT-22691.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1079)
<!-- Reviewable:end -->
