### PR TITLE
Fix LT-22649

### DIFF
--- a/Src/Utilities/pcpatrflex/PcPatrFLExDll/FLExUtility.cs
+++ b/Src/Utilities/pcpatrflex/PcPatrFLExDll/FLExUtility.cs
@@ -1,12 +1,6 @@
-// Copyright (c) 2018 SIL International
+// Copyright (c) 2018-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SIL.FieldWorks.FwCoreDlgs;
 using SIL.LCModel;
 
@@ -51,6 +45,7 @@ namespace SIL.PcPatrFLEx
 		{
 			var pcpatrFlexForm = new PcPatrFLExForm();
 			pcpatrFlexForm.Cache = m_dlg.PropTable.GetValue<LcmCache>("cache");
+			pcpatrFlexForm.PropTable = m_dlg.PropTable;
 			pcpatrFlexForm.PrepareForm();
 			//pcpatrFlexForm.FillTextsListBox();
 			pcpatrFlexForm.Show();

--- a/Src/Utilities/pcpatrflex/PcPatrFLExDll/PcPatrFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/PcPatrFLExDll/PcPatrFLExForm.cs
@@ -1,25 +1,23 @@
+// Copyright (c) 2018-2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
 using Microsoft.Win32;
 using SIL.DisambiguateInFLExDB;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
-using SIL.LCModel.Core.Text;
-using SIL.LCModel.Core.WritingSystems;
-using SIL.LCModel.DomainServices;
 using SIL.PcPatrBrowser;
 using SIL.PrepFLExDB;
-using SIL.WritingSystems;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using XCore;
 
 namespace SIL.PcPatrFLEx
 {
@@ -69,6 +67,7 @@ namespace SIL.PcPatrFLEx
 		public int MaxAmbiguities { get; set; }
 		public int TimeLimit { get; set; }
 		public bool RunIndividually { get; set; }
+		public PropertyTable PropTable { get; set; }
 
 		private RegistryKey regkey;
 
@@ -220,8 +219,10 @@ namespace SIL.PcPatrFLEx
 		private void EnsureDatabaseHasBeenPrepped()
 		{
 			var preparer = new Preparer(Cache, false);
+			preparer.PropTable = PropTable;
 			preparer.AddPCPATRList();
 			preparer.AddPCPATRSenseCustomField();
+			FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, PropTable.GetWindow()));
 		}
 
 		public void PrepareForm()

--- a/Src/Utilities/pcpatrflex/PrepFLExDBDll/PrepFLExDBTests/PreparerTests.cs
+++ b/Src/Utilities/pcpatrflex/PrepFLExDBDll/PrepFLExDBTests/PreparerTests.cs
@@ -29,7 +29,10 @@ namespace SIL.PrepFLExDBTests
 		public ProjectId ProjId { get; set; }
 		private List<FieldDescription> customFields;
 		Preparer Preparer { get; set; }
+		Mediator Mediator { get; set; }
+		PropertyTable PropertyTable { get; set; }
 
+		[SetUp]
 		public override void FixtureSetup()
 		{
 			base.FixtureSetup();
@@ -48,16 +51,21 @@ namespace SIL.PrepFLExDBTests
 			var progress = new DisambiguateInFLExDBTests.NullThreadedProgress(synchronizeInvoke);
 			MyCache = LcmCache.CreateCacheFromExistingData(ProjId, "en", logger, dirs, settings, progress);
 			Preparer = new Preparer(MyCache, false);
-			Preparer.PropTable = new XCore.PropertyTable(new XCore.Mediator());
+			Mediator = new Mediator();
+			PropertyTable = new PropertyTable(Mediator);
+			Preparer.PropTable = PropertyTable;
 
 		}
 
 		/// <summary></summary>
+		[TearDown]
 		public override void FixtureTeardown()
 		{
 			//Directory.Delete(m_projectsDirectory, true);
 			base.FixtureTeardown();
 			MyCache.Dispose();
+			Mediator.Dispose();
+			PropertyTable.Dispose();
 		}
 
 		/// <summary>
@@ -66,7 +74,6 @@ namespace SIL.PrepFLExDBTests
 		[Test]
 		public void PCPATRPreparerTest()
 		{
-			FixtureSetup();
 			Assert.IsNotNull(MyCache);
 			Assert.AreEqual(5, MyCache.LangProject.AllPartsOfSpeech.Count);
 			Assert.AreEqual(0, MyCache.LangProject.LexDbOA.Entries.Count());
@@ -131,11 +138,9 @@ namespace SIL.PrepFLExDBTests
 		[Test]
 		public void ToneParsPreparerTest()
 		{
-			FixtureSetup();
 			Assert.IsNotNull(MyCache);
 			Assert.AreEqual(5, MyCache.LangProject.AllPartsOfSpeech.Count);
 			Assert.AreEqual(0, MyCache.LangProject.LexDbOA.Entries.Count());
-			Preparer.PropTable = new XCore.PropertyTable(new XCore.Mediator());
 
 			// If we try to create the custom field before the master possibility list, the field is not created.
 			customFields = Preparer.GetListOfCustomFields();

--- a/Src/Utilities/pcpatrflex/PrepFLExDBDll/PrepFLExDBTests/PreparerTests.cs
+++ b/Src/Utilities/pcpatrflex/PrepFLExDBDll/PrepFLExDBTests/PreparerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 SIL International
+// Copyright (c) 2018-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -8,16 +8,13 @@ using SIL.FieldWorks;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Core.Cellar;
-using SIL.LCModel.Core.Text;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Utils;
 using SIL.PrepFLExDB;
-using SIL.WritingSystems;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
+using XCore;
 
 namespace SIL.PrepFLExDBTests
 {
@@ -31,6 +28,7 @@ namespace SIL.PrepFLExDBTests
 		LcmCache MyCache { get; set; }
 		public ProjectId ProjId { get; set; }
 		private List<FieldDescription> customFields;
+		Preparer Preparer { get; set; }
 
 		public override void FixtureSetup()
 		{
@@ -49,6 +47,9 @@ namespace SIL.PrepFLExDBTests
 			var settings = new LcmSettings { DisableDataMigration = true };
 			var progress = new DisambiguateInFLExDBTests.NullThreadedProgress(synchronizeInvoke);
 			MyCache = LcmCache.CreateCacheFromExistingData(ProjId, "en", logger, dirs, settings, progress);
+			Preparer = new Preparer(MyCache, false);
+			Preparer.PropTable = new XCore.PropertyTable(new XCore.Mediator());
+
 		}
 
 		/// <summary></summary>
@@ -69,28 +70,27 @@ namespace SIL.PrepFLExDBTests
 			Assert.IsNotNull(MyCache);
 			Assert.AreEqual(5, MyCache.LangProject.AllPartsOfSpeech.Count);
 			Assert.AreEqual(0, MyCache.LangProject.LexDbOA.Entries.Count());
-			var preparer = new Preparer(MyCache, false);
 
 			// If we try to create the custom field before the master possibility list, the field is not created.
-			customFields = preparer.GetListOfCustomFields();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
-			preparer.AddPCPATRSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddPCPATRSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
 
 			var possListRepository = MyCache.ServiceLocator.GetInstance<ICmPossibilityListRepository>();
 			Assert.AreEqual(34, possListRepository.AllInstances().Count());
-			preparer.AddPCPATRList();
+			Preparer.AddPCPATRList();
 			CheckPossibilityList(possListRepository);
 			// Invoke it again.  Only one copy should exist.
-			preparer.AddPCPATRList();
+			Preparer.AddPCPATRList();
 			CheckPossibilityList(possListRepository);
 
 			// Add custom field
-			customFields = preparer.GetListOfCustomFields();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
-			preparer.AddPCPATRSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddPCPATRSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(1, customFields.Count);
 			var cf = customFields.Find(fd => fd.Name == PcPatrConstants.PcPatrFeatureDescriptorCustomField);
 			Assert.IsNotNull(cf);
@@ -102,8 +102,8 @@ namespace SIL.PrepFLExDBTests
 			Assert.AreEqual(CmCustomItemTags.kClassId, cf.DstCls);
 			Assert.AreEqual(WritingSystemServices.kwsAnal, cf.WsSelector);
 			// Invoke it again.  Only one should exist.
-			preparer.AddPCPATRSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddPCPATRSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(1, customFields.Count);
 			FixtureTeardown();
 		}
@@ -135,31 +135,31 @@ namespace SIL.PrepFLExDBTests
 			Assert.IsNotNull(MyCache);
 			Assert.AreEqual(5, MyCache.LangProject.AllPartsOfSpeech.Count);
 			Assert.AreEqual(0, MyCache.LangProject.LexDbOA.Entries.Count());
-			var preparer = new Preparer(MyCache, false);
+			Preparer.PropTable = new XCore.PropertyTable(new XCore.Mediator());
 
 			// If we try to create the custom field before the master possibility list, the field is not created.
-			customFields = preparer.GetListOfCustomFields();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
-			preparer.AddToneParsSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
-			preparer.AddToneParsFormCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsFormCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
 
 			var possListRepository = MyCache.ServiceLocator.GetInstance<ICmPossibilityListRepository>();
 			Assert.AreEqual(34, possListRepository.AllInstances().Count());
-			preparer.AddToneParsList();
+			Preparer.AddToneParsList();
 			ToneParsCheckPossibilityList(possListRepository);
 			// Invoke it again.  Only one copy should exist.
-			preparer.AddToneParsList();
+			Preparer.AddToneParsList();
 			ToneParsCheckPossibilityList(possListRepository);
 
 			// Add sense custom field
-			customFields = preparer.GetListOfCustomFields();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(0, customFields.Count);
-			preparer.AddToneParsSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(1, customFields.Count);
 			var cf = customFields.Find(fd => fd.Name == ToneParsConstants.ToneParsPropertiesSenseCustomField);
 			Assert.IsNotNull(cf);
@@ -171,15 +171,15 @@ namespace SIL.PrepFLExDBTests
 			Assert.AreEqual(CmCustomItemTags.kClassId, cf.DstCls);
 			Assert.AreEqual(WritingSystemServices.kwsAnal, cf.WsSelector);
 			// Invoke it again.  Only one should exist.
-			preparer.AddToneParsSenseCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsSenseCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(1, customFields.Count);
 
 			// Add form custom field
-			customFields = preparer.GetListOfCustomFields();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(1, customFields.Count);
-			preparer.AddToneParsFormCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsFormCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(2, customFields.Count);
 			cf = customFields.Find(fd => fd.Name == ToneParsConstants.ToneParsPropertiesFormCustomField);
 			Assert.IsNotNull(cf);
@@ -191,8 +191,8 @@ namespace SIL.PrepFLExDBTests
 			Assert.AreEqual(CmCustomItemTags.kClassId, cf.DstCls);
 			Assert.AreEqual(WritingSystemServices.kwsAnal, cf.WsSelector);
 			// Invoke it again.  Only two should still exist.
-			preparer.AddToneParsFormCustomField();
-			customFields = preparer.GetListOfCustomFields();
+			Preparer.AddToneParsFormCustomField();
+			customFields = Preparer.GetListOfCustomFields();
 			Assert.AreEqual(2, customFields.Count);
 
 			FixtureTeardown();

--- a/Src/Utilities/pcpatrflex/PrepFLExDBDll/Preparer.cs
+++ b/Src/Utilities/pcpatrflex/PrepFLExDBDll/Preparer.cs
@@ -3,6 +3,7 @@
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
 using SIL.DisambiguateInFLExDB;
+using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.DomainServices;
@@ -10,11 +11,14 @@ using SIL.LCModel.Infrastructure;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using XCore;
 
 namespace SIL.PrepFLExDB
 {
 	public class Preparer
 	{
+		public PropertyTable PropTable{ get; set; }
+
 		private static readonly string[] ToneParsProperties = { "sampleToneParsAllomorphProperty", "sampleToneParsMorphemeProperty" };
 
 		private static readonly string[] FeatureDescriptors =
@@ -204,6 +208,7 @@ namespace SIL.PrepFLExDB
 					CreateNewPcPatrFeaturePossibility(ws, pcpatrList, factPoss, name);
 				}
 			});
+			ReloadListsArea();
 		}
 
 		private static void CreateNewPcPatrFeaturePossibility(int ws, ICmPossibilityList newList, ICmCustomItemFactory factPoss, string name)
@@ -292,6 +297,7 @@ namespace SIL.PrepFLExDB
 					CreateNewToneParsPropertyPossibility(ws, toneParsList, factPoss, name);
 				}
 			});
+			ReloadListsArea();
 		}
 
 		private static void CreateNewToneParsPropertyPossibility(int ws, ICmPossibilityList newList, ICmCustomItemFactory factPoss, string name)
@@ -379,5 +385,9 @@ namespace SIL.PrepFLExDB
 			});
 		}
 
+		private void ReloadListsArea()
+		{
+			FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", PropTable.GetWindow()));
+		}
 	}
 }

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/FLExUtility.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/FLExUtility.cs
@@ -1,12 +1,7 @@
-// Copyright (c) 2019 SIL International
+// Copyright (c) 2019-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SIL.FieldWorks.FwCoreDlgs;
 using SIL.LCModel;
 
@@ -53,6 +48,7 @@ namespace SIL.ToneParsFLEx
 		{
 			var toneParsFlexForm = new ToneParsFLExForm();
 			toneParsFlexForm.Cache = m_dlg.PropTable.GetValue<LcmCache>("cache");
+			toneParsFlexForm.PropTable = m_dlg.PropTable;
 			toneParsFlexForm.PrepareForm();
 			//pcpatrFlexForm.FillTextsListBox();
 			toneParsFlexForm.Show();

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 SIL International
+// Copyright (c) 2019-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -7,27 +7,18 @@ using SIL.DisambiguateInFLExDB;
 using SIL.FieldWorks.LexText.Controls;
 using SIL.FieldWorks.WordWorks.Parser;
 using SIL.LCModel;
-using SIL.LCModel.Core.Text;
-using SIL.LCModel.Core.WritingSystems;
-using SIL.LCModel.DomainServices;
 using SIL.PrepFLExDB;
-using SIL.WritingSystems;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Xml.Linq;
 using XCore;
-using XAmpleManagedWrapper;
 using System.Text.RegularExpressions;
 using SIL.LCModel.Infrastructure;
 using SIL.FieldWorks.Common.FwUtils;
@@ -38,7 +29,7 @@ namespace SIL.ToneParsFLEx
 	public partial class ToneParsFLExForm : Form
 	{
 		public LcmCache Cache { get; set; }
-
+		public PropertyTable PropTable { get; set; }
 		protected IList<IText> Texts { get; set; }
 		protected IList<SegmentToShow> SegmentsInListBox { get; set; }
 		protected FLExDBExtractor Extractor { get; set; }
@@ -301,9 +292,11 @@ namespace SIL.ToneParsFLEx
 		private void EnsureDatabaseHasBeenPrepped()
 		{
 			var preparer = new Preparer(Cache, false);
+			preparer.PropTable = PropTable;
 			preparer.AddToneParsList();
 			preparer.AddToneParsFormCustomField();
 			preparer.AddToneParsSenseCustomField();
+			FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, PropTable.GetWindow()));
 		}
 
 		public void PrepareForm()


### PR DESCRIPTION
Both PcPatr with FLEx and TonePars with FLEx added new unowned lists (as well as some custom fields).  They never broadcast this fact, though.  This code fixes that (and does some cleanup, too).
It also fixes the crashes reported in https://jira.sil.org/browse/LT-22649.

It is basically just adding a PropertyTable instance so we can publish the change via
`FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.MasterRefresh, null, PropTable.GetWindow()));`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1080)
<!-- Reviewable:end -->
