### PR TITLE
Fix UpdateStatusPanelProgress

### DIFF
--- a/Src/LexText/ParserUI/ParserListener.cs
+++ b/Src/LexText/ParserUI/ParserListener.cs
@@ -231,8 +231,19 @@ namespace SIL.FieldWorks.LexText.Controls
 													app.ActiveMainWindow, false);
 				}
 			}
-			if (ParserActivityString == ParserUIStrings.ksIdle_ && m_timer.Enabled)
+			if (ParserActivityString == ParserUIStrings.ksIdle_ && m_timer.Enabled && QueuesAreEmpty())
 				StopUpdateProgressTimer();
+		}
+
+		private bool QueuesAreEmpty()
+		{
+			if (m_parserConnection == null)
+			{
+				return true;
+			}
+			return m_parserConnection.GetQueueSize(ParserPriority.Low) == 0
+				&& m_parserConnection.GetQueueSize(ParserPriority.Medium) == 0
+				&& m_parserConnection.GetQueueSize(ParserPriority.High) == 0;
 		}
 
 		//note that the Parser also supports an event oriented system


### PR DESCRIPTION
I noticed that the status progress panel in the lower left corner would sometimes stop updating when I was parsing a text.  This was intermittent, so I couldn't construct an acceptance test for it.  Looking at the code, it seemed like one possible explanation was that the ParserActivityString could equal ksIdle_ if the timer happened to sample the parsing activity between words (e.g. after parsing one word but before parsing the next).  I fixed this by adding QueuesAreEmpty in the conditional.  This prevents it from stopping if there are still words to parse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1085)
<!-- Reviewable:end -->
