### PR TITLE
Ignore claude local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,9 @@ FLExInstaller/wix6/cabcache/*
 # Claude Code worktrees
 .claude/worktrees/*
 
+# Claude Code per-developer settings (holds machine-specific paths and grants)
+.claude/settings.local.json
+
 # Verify snapshot testing - received files are transient
 *.received.png
 *.diff.png


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
Adds `.claude/settings.local.json` to `.gitignore`.

`.claude/settings.json` is the shared, checked-in settings file;
`.claude/settings.local.json` is the per-developer one, holding absolute paths
and personal permission grants. Only the `.local` variant should be ignored.

No build, test, or installer impact.

Co-Authored-By: 🤖 [Claude Code](https://claude.com/claude-code)

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via `build.ps1`/`test.ps1` or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1086)
<!-- Reviewable:end -->
