### PR TITLE
LT-22714: Stop the IPA populate path duplicating phoneme features

### DIFF
--- a/DistFiles/Templates/BasicIPAInfo.xml
+++ b/DistFiles/Templates/BasicIPAInfo.xml
@@ -340,13 +340,11 @@
 		 <FeatureValuePair feature="fPAConsonantal" value="vPAConsonantalPositive"/>
 		 <FeatureValuePair feature="fPASyllabic" value="vPASyllabicNegative"/>
 		 <FeatureValuePair feature="fPASonorant" value="vPASonorantPositive"/>
-		  <FeatureValuePair feature="fPAAnterior" value="vPAAnteriorNegative"/>
-		  <FeatureValuePair feature="fPACoronal" value="vPACoronalPositive"/>
-		  <FeatureValuePair feature="fPAHigh" value="vPAHighPositive"/>
-		 <FeatureValuePair feature="fPABack" value="vPABackNegative"/>
-		 <FeatureValuePair feature="fPALow" value="vPALowNegative"/>
 		 <FeatureValuePair feature="fPAAnterior" value="vPAAnteriorNegative"/>
 		 <FeatureValuePair feature="fPACoronal" value="vPACoronalPositive"/>
+		 <FeatureValuePair feature="fPAHigh" value="vPAHighPositive"/>
+		 <FeatureValuePair feature="fPABack" value="vPABackNegative"/>
+		 <FeatureValuePair feature="fPALow" value="vPALowNegative"/>
 		 <FeatureValuePair feature="fPAVoice" value="vPAVoicePositive"/>
 		 <FeatureValuePair feature="fPANasal" value="vPANasalNegative"/>
 		 <FeatureValuePair feature="fPADelayedRelease" value="vPADelayedReleasePositive"/>

--- a/Src/LexText/Morphology/BasicIPASymbolSlice.cs
+++ b/Src/LexText/Morphology/BasicIPASymbolSlice.cs
@@ -128,7 +128,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 						var sFeature = (string) feature.Attribute("feature");
 						var sValue = (string) feature.Attribute("value");
 						IFsFeatDefn featDefn = m_cache.LanguageProject.PhFeatureSystemOA.GetFeature(sFeature);
-						if (featDefn == null)
+						var closedFeat = featDefn as IFsClosedFeature;
+						if (closedFeat == null)
 							continue;
 
 						IFsSymFeatVal symVal = m_cache.LanguageProject.PhFeatureSystemOA.GetSymbolicValue(sValue);
@@ -138,9 +139,10 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 						{
 							phoneme.FeaturesOA = m_cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
 						}
-						IFsClosedValue value = m_cache.ServiceLocator.GetInstance<IFsClosedValueFactory>().Create();
-						phoneme.FeaturesOA.FeatureSpecsOC.Add(value);
-						value.FeatureRA = featDefn;
+						// Reuse any spec already held for this feature, so that repopulating a
+						// phoneme cannot leave it with two specs for one feature (LT-22714).
+						IFsClosedValue value = phoneme.FeaturesOA.GetOrCreateValue(closedFeat);
+						value.FeatureRA = closedFeat;
 						value.ValueRA = symVal;
 						m_justChangedFeatures = true;
 					}

--- a/Src/LexText/Morphology/BasicIPASymbolSlice.cs
+++ b/Src/LexText/Morphology/BasicIPASymbolSlice.cs
@@ -27,6 +27,8 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		}
 
 		private bool m_justChangedDescription;
+		/// True when this slice populated the phoneme's features from the IPA symbol, so
+		/// clearing the symbol may clear them. False means the user chose them; leave them.
 		private bool m_justChangedFeatures;
 
 		/// <summary>
@@ -110,12 +112,6 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		/// <summary>
 		/// Populates or clears the phoneme's features to match the BasicIPASymbol field.
 		/// </summary>
-		/// <remarks>
-		/// WHEN to write belongs here because it depends on slice state: the latch records that
-		/// this slice populated the features, which is what lets clearing the symbol clear them
-		/// again without discarding features a user set through the chooser. The writing itself
-		/// is in PhonemeFeaturePopulator, so the LT-22716 repair can reuse it.
-		/// </remarks>
 		public void SetFeaturesBasedOnIPA()
 		{
 			var phoneme = (IPhPhoneme)m_obj;

--- a/Src/LexText/Morphology/BasicIPASymbolSlice.cs
+++ b/Src/LexText/Morphology/BasicIPASymbolSlice.cs
@@ -108,51 +108,30 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 		}
 
 		/// <summary>
-		/// Set description based on the content of the BasicIPASymbol field and the BasicIPAInfo document
+		/// Populates or clears the phoneme's features to match the BasicIPASymbol field.
 		/// </summary>
+		/// <remarks>
+		/// WHEN to write belongs here because it depends on slice state: the latch records that
+		/// this slice populated the features, which is what lets clearing the symbol clear them
+		/// again without discarding features a user set through the chooser. The writing itself
+		/// is in PhonemeFeaturePopulator, so the LT-22716 repair can reuse it.
+		/// </remarks>
 		public void SetFeaturesBasedOnIPA()
 		{
 			var phoneme = (IPhPhoneme)m_obj;
 
 			if (phoneme.BasicIPASymbol.Length > 0 && (m_justChangedFeatures || phoneme.FeaturesOA == null || phoneme.FeaturesOA.FeatureSpecsOC.Count == 0))
 			{
-				// Mono XPath processing crashes when the expression starts out with // here.  See FWNX-730.
-				string sXPath = "/SegmentDefinitions/SegmentDefinition[Representations/Representation[.='" +
-					XmlUtils.MakeSafeXmlAttribute(phoneme.BasicIPASymbol.Text) +
-					"']]/Features";
-				XElement features = s_ipaInfoDocument.XPathSelectElement(sXPath);
-				if (features != null)
+				if (PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(m_cache, phoneme,
+						s_ipaInfoDocument) > 0)
 				{
-					foreach (XElement feature in features.Elements("FeatureValuePair"))
-					{
-						var sFeature = (string) feature.Attribute("feature");
-						var sValue = (string) feature.Attribute("value");
-						IFsFeatDefn featDefn = m_cache.LanguageProject.PhFeatureSystemOA.GetFeature(sFeature);
-						var closedFeat = featDefn as IFsClosedFeature;
-						if (closedFeat == null)
-							continue;
-
-						IFsSymFeatVal symVal = m_cache.LanguageProject.PhFeatureSystemOA.GetSymbolicValue(sValue);
-						if (symVal == null)
-							continue;
-						if (phoneme.FeaturesOA == null)
-						{
-							phoneme.FeaturesOA = m_cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
-						}
-						// Reuse any spec already held for this feature, so that repopulating a
-						// phoneme cannot leave it with two specs for one feature (LT-22714).
-						IFsClosedValue value = phoneme.FeaturesOA.GetOrCreateValue(closedFeat);
-						value.FeatureRA = closedFeat;
-						value.ValueRA = symVal;
-						m_justChangedFeatures = true;
-					}
+					m_justChangedFeatures = true;
 				}
 			}
 			else if (phoneme.BasicIPASymbol.Length == 0 && m_justChangedFeatures)
 			{
-				if (phoneme.FeaturesOA != null)
-					// user has cleared the basic IPA symbol; clear the features
-					phoneme.FeaturesOA.FeatureSpecsOC.Clear();
+				// user has cleared the basic IPA symbol; clear the features
+				PhonemeFeaturePopulator.ClearFeatures(phoneme);
 				m_justChangedFeatures = true;
 			}
 			else

--- a/Src/LexText/Morphology/MorphologyEditorDllTests/BasicIPASymbolSliceTests.cs
+++ b/Src/LexText/Morphology/MorphologyEditorDllTests/BasicIPASymbolSliceTests.cs
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwUtils;
+using SIL.LCModel;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.Infrastructure;
+
+namespace SIL.FieldWorks.XWorks.MorphologyEditor
+{
+	/// <summary>
+	/// Tests that populating a phoneme's phonological features from its Basic IPA Symbol
+	/// leaves at most one feature specification per phonological feature (LT-22714).
+	/// </summary>
+	[TestFixture]
+	public class BasicIPASymbolSliceTests : MemoryOnlyBackendProviderTestBase
+	{
+		private IPhPhoneme m_phoneme;
+
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+			{
+				var langProject = Cache.LanguageProject;
+				if (langProject.PhonologicalDataOA == null)
+				{
+					langProject.PhonologicalDataOA =
+						Cache.ServiceLocator.GetInstance<IPhPhonDataFactory>().Create();
+				}
+				if (langProject.PhFeatureSystemOA == null)
+				{
+					langProject.PhFeatureSystemOA =
+						Cache.ServiceLocator.GetInstance<IFsFeatureSystemFactory>().Create();
+				}
+				var phonemeSet = Cache.ServiceLocator.GetInstance<IPhPhonemeSetFactory>().Create();
+				langProject.PhonologicalDataOA.PhonemeSetsOS.Add(phonemeSet);
+				m_phoneme = Cache.ServiceLocator.GetInstance<IPhPhonemeFactory>().Create();
+				phonemeSet.PhonemesOC.Add(m_phoneme);
+			});
+		}
+
+		public override void TestTearDown()
+		{
+			m_phoneme = null;
+			base.TestTearDown();
+		}
+
+		/// <summary>
+		/// The shipped IPA inventory must not name the same feature twice for one segment,
+		/// because each pair becomes a separate feature specification on the phoneme.
+		/// </summary>
+		[Test]
+		public void BasicIPAInfo_NoSegmentNamesTheSameFeatureTwice()
+		{
+			var offenders = new List<string>();
+			foreach (var segment in IpaInfoDocument().XPathSelectElements(
+				"/SegmentDefinitions/SegmentDefinition"))
+			{
+				var featureIds = segment.XPathSelectElements("Features/FeatureValuePair")
+					.Select(pair => (string)pair.Attribute("feature"))
+					.ToList();
+				var duplicated = featureIds.GroupBy(id => id)
+					.Where(group => group.Count() > 1)
+					.Select(group => group.Key)
+					.ToList();
+				if (duplicated.Count > 0)
+				{
+					var representation = segment.XPathSelectElement("Representations/Representation");
+					offenders.Add(string.Format("{0}: {1}",
+						representation == null ? "?" : representation.Value.Trim(),
+						string.Join(", ", duplicated)));
+				}
+			}
+			Assert.That(offenders, Is.Empty,
+				"segments naming a feature more than once: " + string.Join("; ", offenders));
+		}
+
+		[Test]
+		public void SettingSymbol_AddsEachFeatureOnce()
+		{
+			CreateFeatureSystemFor("j");
+			using (CreateSlice())
+			{
+				SetSymbol("j");
+
+				AssertNoFeatureIsSpecifiedTwice();
+			}
+		}
+
+		/// <summary>
+		/// Reproduces the reported sequence: once a symbol has populated the features, the
+		/// slice re-enters its populate branch on every later call.
+		/// </summary>
+		[Test]
+		public void RepopulatingSameSymbol_DoesNotDuplicateFeatures()
+		{
+			CreateFeatureSystemFor("p");
+			using (var slice = CreateSlice())
+			{
+				SetSymbol("p");
+				var countAfterFirstPopulate = m_phoneme.FeaturesOA.FeatureSpecsOC.Count;
+
+				NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+				{
+					slice.SetFeaturesBasedOnIPA();
+					slice.SetFeaturesBasedOnIPA();
+				});
+
+				AssertNoFeatureIsSpecifiedTwice();
+				Assert.That(m_phoneme.FeaturesOA.FeatureSpecsOC.Count,
+					Is.EqualTo(countAfterFirstPopulate));
+			}
+		}
+
+		/// <summary>
+		/// Correcting a symbol must not leave the phoneme carrying two specifications, with
+		/// contradictory values, for the features the two symbols share.
+		/// </summary>
+		[Test]
+		public void ChangingSymbol_DoesNotDuplicateSharedFeatures()
+		{
+			CreateFeatureSystemFor("p", "t");
+			using (CreateSlice())
+			{
+				SetSymbol("p");
+				SetSymbol("t");
+
+				AssertNoFeatureIsSpecifiedTwice();
+				foreach (var pair in FeaturePairsFor("t"))
+				{
+					var spec = m_phoneme.FeaturesOA.FeatureSpecsOC.OfType<IFsClosedValue>()
+						.SingleOrDefault(value => value.FeatureRA.CatalogSourceId == pair.Key);
+					Assert.That(spec, Is.Not.Null, "no specification for " + pair.Key);
+					Assert.That(spec.ValueRA.CatalogSourceId, Is.EqualTo(pair.Value),
+						"wrong value for " + pair.Key);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Features set through the chooser leave the slice unaware that the feature structure
+		/// is already populated, so a later symbol edit must still not duplicate anything.
+		/// </summary>
+		[Test]
+		public void SymbolEditAfterFeaturesAlreadySet_DoesNotDuplicateFeatures()
+		{
+			CreateFeatureSystemFor("p", "t");
+			using (var slice = CreateSlice())
+			{
+				SetSymbol("p");
+				NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+				{
+					var voice = Cache.LanguageProject.PhFeatureSystemOA.GetFeature("fPAVoice");
+					var closedValue = m_phoneme.FeaturesOA.GetOrCreateValue((IFsClosedFeature)voice);
+					closedValue.FeatureRA = voice;
+					closedValue.ValueRA = ((IFsClosedFeature)voice).ValuesOC.First();
+				});
+
+				SetSymbol("t");
+
+				AssertNoFeatureIsSpecifiedTwice();
+			}
+		}
+
+		private void AssertNoFeatureIsSpecifiedTwice()
+		{
+			Assert.That(m_phoneme.FeaturesOA, Is.Not.Null, "no features were populated");
+			var duplicated = m_phoneme.FeaturesOA.FeatureSpecsOC
+				.GroupBy(spec => spec.FeatureRA)
+				.Where(group => group.Count() > 1)
+				.Select(group => group.Key.CatalogSourceId)
+				.ToList();
+			Assert.That(duplicated, Is.Empty,
+				"features specified more than once: " + string.Join(", ", duplicated));
+		}
+
+		private BasicIPASymbolSlice CreateSlice()
+		{
+			var slice = new BasicIPASymbolSlice(Cache, "customWithParams",
+				PhPhonemeTags.kflidBasicIPASymbol, null, m_phoneme, null,
+				Cache.DefaultPronunciationWs);
+			slice.Cache = Cache;
+			return slice;
+		}
+
+		private void SetSymbol(string ipaSymbol)
+		{
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+			{
+				m_phoneme.BasicIPASymbol =
+					TsStringUtils.MakeString(ipaSymbol, Cache.DefaultPronunciationWs);
+			});
+		}
+
+		private static XDocument IpaInfoDocument()
+		{
+			return XDocument.Load(Path.Combine(FwDirectoryFinder.TemplateDirectory,
+				PhPhonemeTags.ksBasicIPAInfoFile));
+		}
+
+		/// <summary>
+		/// Gets the feature-to-value catalog ids the shipped inventory lists for a symbol,
+		/// keeping the first value where a symbol names the same feature more than once.
+		/// </summary>
+		private static IDictionary<string, string> FeaturePairsFor(string ipaSymbol)
+		{
+			var pairs = new Dictionary<string, string>();
+			var features = IpaInfoDocument().XPathSelectElement(
+				"/SegmentDefinitions/SegmentDefinition[Representations/Representation[.='"
+				+ ipaSymbol + "']]/Features");
+			Assert.That(features, Is.Not.Null, "no inventory entry for " + ipaSymbol);
+			foreach (var pair in features.Elements("FeatureValuePair"))
+			{
+				var featureId = (string)pair.Attribute("feature");
+				if (!pairs.ContainsKey(featureId))
+					pairs.Add(featureId, (string)pair.Attribute("value"));
+			}
+			return pairs;
+		}
+
+		/// <summary>
+		/// Builds the closed features and symbolic values the given symbols refer to, since a
+		/// memory-only project starts with an empty phonological feature system.
+		/// </summary>
+		private void CreateFeatureSystemFor(params string[] ipaSymbols)
+		{
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+			{
+				var featureSystem = Cache.LanguageProject.PhFeatureSystemOA;
+				foreach (var ipaSymbol in ipaSymbols)
+				{
+					foreach (var pair in FeaturePairsFor(ipaSymbol))
+					{
+						var closedFeature =
+							featureSystem.GetFeature(pair.Key) as IFsClosedFeature;
+						if (closedFeature == null)
+						{
+							closedFeature = Cache.ServiceLocator
+								.GetInstance<IFsClosedFeatureFactory>().Create();
+							featureSystem.FeaturesOC.Add(closedFeature);
+							closedFeature.CatalogSourceId = pair.Key;
+							closedFeature.Name.SetAnalysisDefaultWritingSystem(pair.Key);
+						}
+						if (closedFeature.GetSymbolicValue(pair.Value) == null)
+						{
+							var symbolicValue = Cache.ServiceLocator
+								.GetInstance<IFsSymFeatValFactory>().Create();
+							closedFeature.ValuesOC.Add(symbolicValue);
+							symbolicValue.CatalogSourceId = pair.Value;
+							symbolicValue.Name.SetAnalysisDefaultWritingSystem(pair.Value);
+						}
+					}
+				}
+			});
+		}
+	}
+}

--- a/Src/LexText/Morphology/MorphologyEditorDllTests/BasicIPASymbolSliceTests.cs
+++ b/Src/LexText/Morphology/MorphologyEditorDllTests/BasicIPASymbolSliceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 SIL International
+﻿// Copyright (c) 2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -21,6 +21,9 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 	/// leaves at most one feature specification per phonological feature (LT-22714).
 	/// </summary>
 	[TestFixture]
+	// Some tests here build a real Slice, which is a UserControl whose rootsite creates
+	// apartment-threaded Views COM objects. NUnit 3 defaults to MTA.
+	[Apartment(System.Threading.ApartmentState.STA)]
 	public class BasicIPASymbolSliceTests : MemoryOnlyBackendProviderTestBase
 	{
 		private IPhPhoneme m_phoneme;
@@ -181,6 +184,91 @@ namespace SIL.FieldWorks.XWorks.MorphologyEditor
 				.ToList();
 			Assert.That(duplicated, Is.Empty,
 				"features specified more than once: " + string.Join(", ", duplicated));
+		}
+
+		/// <summary>
+		/// The populate service must be idempotent on its own terms, whatever the slice's gate
+		/// decides. These drive it directly, so they do not construct a UserControl and do not
+		/// depend on the latch -- which is what the LT-22716 repair will do too.
+		/// </summary>
+		[Test]
+		public void Populator_AppliedRepeatedly_WritesEachFeatureOnce()
+		{
+			CreateFeatureSystemFor("p");
+			SetSymbol("p");
+
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+			{
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument());
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument());
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument());
+			});
+
+			AssertNoFeatureIsSpecifiedTwice();
+			Assert.That(PhonemeFeaturePopulator.DuplicatedFeatureIds(m_phoneme), Is.Empty);
+		}
+
+		[Test]
+		public void Populator_AfterASymbolChange_KeepsOneSpecPerFeatureWithTheNewValue()
+		{
+			CreateFeatureSystemFor("p", "t");
+			SetSymbol("p");
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument()));
+
+			SetSymbol("t");
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument()));
+
+			AssertNoFeatureIsSpecifiedTwice();
+			foreach (var pair in FeaturePairsFor("t"))
+			{
+				var spec = m_phoneme.FeaturesOA.FeatureSpecsOC.OfType<IFsClosedValue>()
+					.SingleOrDefault(value => value.FeatureRA.CatalogSourceId == pair.Key);
+				Assert.That(spec, Is.Not.Null, "no specification for " + pair.Key);
+				Assert.That(spec.ValueRA.CatalogSourceId, Is.EqualTo(pair.Value),
+					"wrong value for " + pair.Key);
+			}
+		}
+
+		/// <summary>An empty symbol writes nothing, so the repair cannot blank a
+		/// phoneme.</summary>
+		[Test]
+		public void Populator_WithNoSymbol_WritesNothing()
+		{
+			CreateFeatureSystemFor("p");
+			SetSymbol(string.Empty);
+
+			int written = 0;
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+				written = PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme,
+					IpaInfoDocument()));
+
+			Assert.That(written, Is.Zero);
+		}
+
+		/// <summary>
+		/// DuplicatedFeatureIds is what a repair would report, so it has to actually see damage
+		/// rather than always returning empty.
+		/// </summary>
+		[Test]
+		public void DuplicatedFeatureIds_ReportsAnInjectedDuplicate()
+		{
+			CreateFeatureSystemFor("p");
+			SetSymbol("p");
+			NonUndoableUnitOfWorkHelper.Do(m_actionHandler, () =>
+			{
+				PhonemeFeaturePopulator.ApplyFeaturesFromIpaSymbol(Cache, m_phoneme, IpaInfoDocument());
+				// The pre-fix behaviour: a second spec for a feature already specified.
+				var existing = m_phoneme.FeaturesOA.FeatureSpecsOC.OfType<IFsClosedValue>().First();
+				var extra = Cache.ServiceLocator.GetInstance<IFsClosedValueFactory>().Create();
+				m_phoneme.FeaturesOA.FeatureSpecsOC.Add(extra);
+				extra.FeatureRA = existing.FeatureRA;
+				extra.ValueRA = existing.ValueRA;
+			});
+
+			Assert.That(PhonemeFeaturePopulator.DuplicatedFeatureIds(m_phoneme),
+				Has.Length.EqualTo(1));
 		}
 
 		private BasicIPASymbolSlice CreateSlice()

--- a/Src/LexText/Morphology/PhonemeFeaturePopulator.cs
+++ b/Src/LexText/Morphology/PhonemeFeaturePopulator.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using SIL.LCModel;
+using SIL.LCModel.DomainServices;
+using SIL.Utils;
+
+namespace SIL.FieldWorks.XWorks.MorphologyEditor
+{
+	/// <summary>
+	/// Writes the phonological features the Basic IPA inventory defines for a phoneme's
+	/// Basic IPA symbol.
+	/// </summary>
+	/// <remarks>
+	/// A plain service rather than a method on BasicIPASymbolSlice so that the repair for
+	/// phonemes already carrying duplicates (LT-22716) has something to call: neither a
+	/// Tools &gt; Utilities utility nor a FixData rule can call a UserControl, which every
+	/// Slice is.
+	///
+	/// Callers own the unit of work. Nothing here starts one.
+	/// </remarks>
+	public static class PhonemeFeaturePopulator
+	{
+		/// <summary>
+		/// Applies the inventory's feature specifications for <paramref name="phoneme"/>'s
+		/// current Basic IPA symbol, and returns how many it wrote.
+		/// </summary>
+		/// <remarks>
+		/// Idempotent by construction: an existing specification for a feature is updated
+		/// rather than joined by a second one, so calling this repeatedly cannot leave a
+		/// phoneme with two contradictory values for one feature (LT-22714). That holds
+		/// however the caller decides when to call it.
+		///
+		/// A feature or value the project's phonological feature system does not define is
+		/// skipped, since a memory-only or partially-configured project need not have every
+		/// feature the shipped inventory names.
+		/// </remarks>
+		public static int ApplyFeaturesFromIpaSymbol(LcmCache cache, IPhPhoneme phoneme,
+			XDocument ipaInfo)
+		{
+			var symbol = phoneme.BasicIPASymbol;
+			if (symbol == null || symbol.Length == 0)
+				return 0;
+
+			// Mono XPath processing crashes when the expression starts out with // here.
+			// See FWNX-730.
+			var xpath = "/SegmentDefinitions/SegmentDefinition[Representations/Representation[.='"
+				+ XmlUtils.MakeSafeXmlAttribute(symbol.Text) + "']]/Features";
+			var features = ipaInfo.XPathSelectElement(xpath);
+			if (features == null)
+				return 0;
+
+			var featureSystem = cache.LanguageProject.PhFeatureSystemOA;
+			var written = 0;
+			foreach (var feature in features.Elements("FeatureValuePair"))
+			{
+				var closedFeat = featureSystem.GetFeature((string)feature.Attribute("feature"))
+					as IFsClosedFeature;
+				if (closedFeat == null)
+					continue;
+				var symVal = featureSystem.GetSymbolicValue((string)feature.Attribute("value"));
+				if (symVal == null)
+					continue;
+
+				if (phoneme.FeaturesOA == null)
+					phoneme.FeaturesOA = cache.ServiceLocator.GetInstance<IFsFeatStrucFactory>().Create();
+
+				var value = phoneme.FeaturesOA.GetOrCreateValue(closedFeat);
+				value.FeatureRA = closedFeat;
+				value.ValueRA = symVal;
+				written++;
+			}
+			return written;
+		}
+
+		/// <summary>Removes every feature specification the phoneme holds.</summary>
+		public static void ClearFeatures(IPhPhoneme phoneme)
+		{
+			if (phoneme.FeaturesOA != null)
+				phoneme.FeaturesOA.FeatureSpecsOC.Clear();
+		}
+
+		/// <summary>
+		/// The features this phoneme specifies more than once, by catalog id. Empty is the
+		/// healthy state; a non-empty result is the LT-22714 damage.
+		/// </summary>
+		public static string[] DuplicatedFeatureIds(IPhPhoneme phoneme)
+		{
+			if (phoneme.FeaturesOA == null)
+				return new string[0];
+			return phoneme.FeaturesOA.FeatureSpecsOC
+				.GroupBy(spec => spec.FeatureRA)
+				.Where(group => group.Count() > 1)
+				.Select(group => group.Key == null ? "(none)" : group.Key.CatalogSourceId)
+				.ToArray();
+		}
+	}
+}


### PR DESCRIPTION
Setting or correcting a phoneme's Basic IPA Symbol no longer leaves it holding
the same phonological feature twice. Changing a symbol from `p` to `t`
previously appended `t`'s entire standard feature set on top of `p`'s: 16
duplicated features from one ordinary edit, many carrying contradictory values.

**The unknown you are starting with** is whether this is the whole cause or a
symptom. Every writer to `PhPhoneme.FeaturesOA` was audited. Both feature
choosers and the bulk-edit path clear or upsert before writing; the IPA
populate loop was the only one that appended blind. Two defects compound there
- the shipped inventory names two features twice for IPA `j`, and a slice-local
latch short-circuits the "features are not already filled" gate and can never
reset while the symbol is non-empty. Review is better spent on whether an
upsert is the right containment than on hunting for other writers.

**Where to look**

- `BasicIPASymbolSlice.cs` upserts through `IFsFeatStruc.GetOrCreateValue`, the
  helper the choosers and bulk edit already use.
- The feature lookup now requires an `IFsClosedFeature`, which subsumes the old
  null check and skips anything with no symbolic value to assign.
- In `BasicIPAInfo.xml` the retained `j` rows are the ones in canonical
  position; its first eight features now match the order `k` uses.
- All five new tests were verified to fail without the fix. One initially
  passed for the wrong reason and was corrected before being trusted.
- A data test covers all 245 segment definitions, so a duplicated pair cannot
  be reintroduced silently.

**Deliberately not here**

- The `m_justChangedFeatures` latch stays.
- Features set in the chooser first still cause a later IPA symbol to populate
  nothing at all (recorded on LT-22714).
- Phonemes already corrupted are not repaired (LT-22716).

**Verification.** Build clean, 0 warnings. `MorphologyEditorDllTests` 12/12.
Red and green confirmed in both directions. The full suite was not run.
`build.ps1 -CommentHygiene` could not complete: it trips on an untracked
scratch file that predates this branch, and that run confirmed zero violations
in these three files.

---

<details>
<summary><b>Reading this a year from now</b> - start here</summary>

This branch is the containment half of a two-part story. The duplication had
two independent causes, and only the cheap one is fixed here. The expensive one
- a UI-local flag standing in for knowledge the model does not record - is
still present by choice.

If you are here because the duplication came back, check first whether the
latch is still in `BasicIPASymbolSlice.SetFeaturesBasedOnIPA`. If it is, the
bug you are looking at is probably not a duplicate but a *stale* feature: one
the previous IPA symbol specified and the current one does not name, which the
upsert has no reason to remove.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

**Upsert rather than skip.** The obvious guard - "if this feature already
exists, skip it" - is wrong in a way that is easy to miss. On a `p` to `t`
edit it prevents the duplicate but silently discards `t`'s values for every
shared feature, leaving the phoneme still described as `p`. Any guard here has
to update the existing specification, not step over it.

**The latch was kept deliberately.** `m_justChangedFeatures` is a crude record
of "these features are mine, not the user's". Deleting it would make the
mechanism idempotent, but it would also mean an IPA symbol overwrites
hand-picked feature values, and it would force a decision about whether a
symbol change owns the whole feature set or only the features the new symbol
names. The durable answer is a view showing where a phoneme's declared features
diverge from the standard features of its IPA symbol. There is nowhere to
present that today, so the latch remains a placeholder for the missing view
rather than an oversight to clean up.

**Which duplicate rows to delete from the inventory.** The two duplicated pairs
for `j` were byte-identical, so the choice looked arbitrary. It was not: `j`'s
feature order was compared against neighbouring segments, and positions 1-8
match `k` exactly, with Anterior, Coronal and High at 4, 5 and 6. The
oddly-indented block was therefore in canonical position and the later,
normally-indented pair was the intruder - the opposite of what the stray
indentation suggests.

</details>

<details>
<summary><b>Paths not taken</b></summary>

Three fixes were costed on LT-22714.

**Categorical, in the slice.** Remove the latch from the gate and upsert. This
closes the bug class rather than the instance and also fixes the chooser-first
defect. Rejected for now only because it forces the ownership-semantics
decision described above, which wants the divergence view first.

**Model invariant in liblcm.** Enforce one specification per feature inside
`FsFeatStruc` so no caller anywhere can duplicate. Attractive, and the only
universal option, but it hits a concrete obstacle: every call site reviewed
adds the specification *before* setting its feature (`FeatureSpecsOC.Add(value);
value.FeatureRA = featDefn;`). At `Add` time `FeatureRA` is still null, so an
add-time check cannot see the feature at all; the invariant would have to hook
the `FeatureRA` setter. Throwing there also risks breaking incremental object
construction during project load, XML import and undo replay. It is worth doing
later as a debug-only assertion, not a runtime invariant.

</details>

<details>
<summary><b>Surprising findings</b></summary>

Several plausible culprits were checked and cleared, which is worth recording
so they are not re-investigated:

- **Event handler accumulation.** `BasicIPASymbolChanged` is an event on the
  long-lived model object subscribed from a UI slice, which is the classic leak
  shape. It does not leak: `DataTree.Reset` and `DataTree.RemoveSlice` both
  dispose, and the unsubscribe runs before `base.Dispose`.
- **Re-committing the same text.** Retyping an identical symbol does not
  re-fire the side effect; the generated setter does a value-equality check.
- **LIFT import.** It adds without a pre-check, but writes MSA inflection
  features into a freshly created structure, and LIFT carries no phonemes.
- **`PriorityUnion` matching.** It reads as matching on `FeatureRA.Name`, but
  `Name` is an accessor cached per object with no `operator==` overload, so the
  comparison is really feature-object identity. It works, but it will not
  collapse two distinct feature definitions that share a name.
- **`PriorityUnion` cannot repair.** It resolves matches with
  `myFeatureValues.First()`, so on an already-duplicated phoneme it updates one
  copy and leaves the twin. This is why bulk edit will not clean up existing
  corruption, and why LT-22716 exists.

</details>

<details>
<summary><b>Evidence</b></summary>

The regression tests were run against a reverted working tree to confirm they
are not vacuous. Pre-fix failures, which also quantify the defect:

| Test | Pre-fix result |
| --- | --- |
| `SettingSymbol_AddsEachFeatureOnce` | `j` duplicated 2 features on a fresh phoneme, from the data defect alone |
| `RepopulatingSameSymbol_DoesNotDuplicateFeatures` | repopulating `p` duplicated 18 features |
| `ChangingSymbol_DoesNotDuplicateSharedFeatures` | `p` to `t` duplicated 16 features |
| `SymbolEditAfterFeaturesAlreadySet_DoesNotDuplicateFeatures` | same 16 |
| `BasicIPAInfo_NoSegmentNamesTheSameFeatureTwice` | `j: fPAAnterior, fPACoronal` |

`RepopulatingSameSymbol` initially failed with `Not in the right state to
register a change` rather than on the assertion, because it called
`SetFeaturesBasedOnIPA` outside a unit of work. That also meant it passed green
for the wrong reason: post-fix the upsert writes the same value back, registers
no change, and so raised nothing. It was wrapped in a unit of work and both
directions re-run before being trusted.

A scripted audit of the shipped inventory found exactly one affected segment
out of 245.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
See `.review/summary.md` on the branch author's working copy. The findings it
records are reproduced in the pitch and accordions above: no Critical and no
Important findings; five Minor, of which three are the deliberate deferrals
listed under "Deliberately not here", one is a latent liblcm edge case that
this path cannot reach, and one is the comment-hygiene gate being blocked by an
untracked file predating the branch.
<!-- pr-preflight:summary:end -->

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1087)
<!-- Reviewable:end -->
