### PR TITLE
LT-22651: Fix Dictionary letter headings only Uppercase if sorting is Custom Simple Shoebox

### DIFF
--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -133,10 +133,13 @@ namespace SIL.FieldWorks.XWorks
 			if (firstLetter != lastHeader && !string.IsNullOrEmpty(firstLetter))
 			{
 				var headerTextBuilder = new StringBuilder();
-				var upperCase =
-					new CaseFunctions(cache.ServiceLocator.WritingSystemManager.Get(wsString))
-						.ToTitle(firstLetter);
-				var lowerCase = firstLetter.Normalize();
+				var caseFunctions =
+					new CaseFunctions(cache.ServiceLocator.WritingSystemManager.Get(wsString));
+				var upperCase = caseFunctions.ToTitle(firstLetter);
+				// GetLeadChar returns whatever case the sort rules use for the
+				// primary character, and Shoebox-style simple rules are
+				// conventionally uppercase-first. LT-22651
+				var lowerCase = caseFunctions.ToLower(firstLetter).Normalize();
 				headerTextBuilder.Append(upperCase);
 				if (lowerCase != upperCase)
 				{

--- a/Src/xWorks/ConfiguredLcmGenerator.cs
+++ b/Src/xWorks/ConfiguredLcmGenerator.cs
@@ -136,9 +136,6 @@ namespace SIL.FieldWorks.XWorks
 				var caseFunctions =
 					new CaseFunctions(cache.ServiceLocator.WritingSystemManager.Get(wsString));
 				var upperCase = caseFunctions.ToTitle(firstLetter);
-				// GetLeadChar returns whatever case the sort rules use for the
-				// primary character, and Shoebox-style simple rules are
-				// conventionally uppercase-first. LT-22651
 				var lowerCase = caseFunctions.ToLower(firstLetter).Normalize();
 				headerTextBuilder.Append(upperCase);
 				if (lowerCase != upperCase)

--- a/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
@@ -5323,37 +5323,74 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var ws = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
 			var originalCollation = ws.DefaultCollation;
-			// Shoebox simple rules name the uppercase form first, so it is the uppercase
-			// form that reaches the heading builder as the primary character. LT-22651
+			// Rule set and headwords mirror the project attached to LT-22651: the uppercase
+			// form is named first, so it is the form that reaches the heading builder.
 			ws.DefaultCollation = new SimpleRulesCollationDefinition("standard")
 			{
-				SimpleRules = "A a" + Environment.NewLine + "B b" + Environment.NewLine + "Ch ch"
+				SimpleRules = "A a" + Environment.NewLine + "B b" + Environment.NewLine
+					+ "C c" + Environment.NewLine + "Ch ch"
 			};
 			try
 			{
-				var plainEntry = CreateInterestingLexEntry(Cache, "air");
-				var digraphEntry = CreateInterestingLexEntry(Cache, "chico");
-				using (var col = new CollatorForTest(ws.Id))
-				using (var XHTMLWriter = XmlWriter.Create(XHTMLStringBuilder))
-				{
-					// SUT
-					string last = null;
-					XHTMLWriter.WriteStartElement("TestElement");
-					LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(plainEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
-					LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(digraphEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
-					XHTMLWriter.WriteEndElement();
-					XHTMLWriter.Flush();
-					var plainHeadingXpath = string.Format(
-						"//div[@class='letHead']/span[@class='letter' and @lang='{0}' and text()='A a']", ws.Id);
-					AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(plainHeadingXpath, 1);
-					var digraphHeadingXpath = string.Format(
-						"//div[@class='letHead']/span[@class='letter' and @lang='{0}' and text()='Ch ch']", ws.Id);
-					AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(digraphHeadingXpath, 1);
-				}
+				AssertHeadingsCarryBothCases(ws);
 			}
 			finally
 			{
 				ws.DefaultCollation = originalCollation;
+			}
+		}
+
+		[Test]
+		public void GenerateLetterHeaderIfNeeded_UppercaseFirstIcuRules_GeneratesHeadingWithBothCases()
+		{
+			var ws = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
+			var originalCollation = ws.DefaultCollation;
+			// The compiled form of the LT-22651 rules names the uppercase letter as the
+			// primary and the lowercase as a secondary, so it collapses the pair too.
+			var icuCollation = new IcuRulesCollationDefinition("standard")
+			{
+				IcuRules = "&[before 1] [first regular] < A << a < B << b < C << c < Ch << ch",
+				OwningWritingSystemDefinition = ws
+			};
+			icuCollation.Validate(out _);
+			ws.DefaultCollation = icuCollation;
+			try
+			{
+				AssertHeadingsCarryBothCases(ws);
+			}
+			finally
+			{
+				ws.DefaultCollation = originalCollation;
+			}
+		}
+
+		/// <summary>
+		/// Asserts that a plain letter, a letter sharing its first character with a digraph,
+		/// and the digraph itself each produce a heading carrying both cases.
+		/// </summary>
+		private void AssertHeadingsCarryBothCases(CoreWritingSystemDefinition ws)
+		{
+			var plainEntry = CreateInterestingLexEntry(Cache, "aussi");
+			var sharedFirstCharEntry = CreateInterestingLexEntry(Cache, "couleur");
+			var digraphEntry = CreateInterestingLexEntry(Cache, "chat");
+			using (var col = new CollatorForTest(ws.Id))
+			using (var XHTMLWriter = XmlWriter.Create(XHTMLStringBuilder))
+			{
+				// SUT
+				string last = null;
+				XHTMLWriter.WriteStartElement("TestElement");
+				LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(plainEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
+				LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(sharedFirstCharEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
+				LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(digraphEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
+				XHTMLWriter.WriteEndElement();
+				XHTMLWriter.Flush();
+				var xhtml = XHTMLStringBuilder.ToString();
+				foreach (var heading in new[] { "A a", "C c", "Ch ch" })
+				{
+					var headingXpath = string.Format(
+						"//div[@class='letHead']/span[@class='letter' and @lang='{0}' and text()='{1}']", ws.Id, heading);
+					AssertThatXmlIn.String(xhtml).HasSpecifiedNumberOfMatchesForXpath(headingXpath, 1);
+				}
 			}
 		}
 

--- a/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/ConfiguredXHTMLGeneratorTests.cs
@@ -5319,6 +5319,45 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		[Test]
+		public void GenerateLetterHeaderIfNeeded_ShoeboxSortRules_GeneratesHeadingWithBothCases()
+		{
+			var ws = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
+			var originalCollation = ws.DefaultCollation;
+			// Shoebox simple rules name the uppercase form first, so it is the uppercase
+			// form that reaches the heading builder as the primary character. LT-22651
+			ws.DefaultCollation = new SimpleRulesCollationDefinition("standard")
+			{
+				SimpleRules = "A a" + Environment.NewLine + "B b" + Environment.NewLine + "Ch ch"
+			};
+			try
+			{
+				var plainEntry = CreateInterestingLexEntry(Cache, "air");
+				var digraphEntry = CreateInterestingLexEntry(Cache, "chico");
+				using (var col = new CollatorForTest(ws.Id))
+				using (var XHTMLWriter = XmlWriter.Create(XHTMLStringBuilder))
+				{
+					// SUT
+					string last = null;
+					XHTMLWriter.WriteStartElement("TestElement");
+					LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(plainEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
+					LcmXhtmlGenerator.GenerateLetterHeaderIfNeeded(digraphEntry, ref last, XHTMLWriter, col, DefaultSettings, m_Clerk);
+					XHTMLWriter.WriteEndElement();
+					XHTMLWriter.Flush();
+					var plainHeadingXpath = string.Format(
+						"//div[@class='letHead']/span[@class='letter' and @lang='{0}' and text()='A a']", ws.Id);
+					AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(plainHeadingXpath, 1);
+					var digraphHeadingXpath = string.Format(
+						"//div[@class='letHead']/span[@class='letter' and @lang='{0}' and text()='Ch ch']", ws.Id);
+					AssertThatXmlIn.String(XHTMLStringBuilder.ToString()).HasSpecifiedNumberOfMatchesForXpath(digraphHeadingXpath, 1);
+				}
+			}
+			finally
+			{
+				ws.DefaultCollation = originalCollation;
+			}
+		}
+
+		[Test]
 		public void GenerateLetterHeaderIfNeeded_GeneratesHeaderLexemeFormSorting()
 		{
 			var entry = CreateInterestingLexEntry(Cache);


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
Letter headings under "Custom Sorting (Shoebox style)" showed only the uppercase
letter — `A` instead of `A a`. Digraphs were unaffected (`Ch ch`).

https://jira.sil.org/browse/LT-22651

## Fix

`GenerateLetterHeaderIfNeeded` built the lowercase half of the pair by
*normalizing* the lead character rather than lowercasing it, assuming
`GetLeadChar` had already returned a lowercase form. It doesn't: it returns the
primary representative of the writing system's sort rules, in whatever case
those rules were written.

Shoebox rules name the uppercase form first (`A a`), so the equivalence map
folds headwords onto the uppercase letter. Both halves of the heading then
matched, the pair collapsed, and only `A` rendered.

Digraphs escaped because their lookup lowercases the graph and runs *before*
the equivalence replacement — which is why only non-digraph headings
were affected.

Deriving the lowercase form through `CaseFunctions` is correct whichever case
the collation happens to use. The XHTML and Word generators share this method,
so both are covered.

## Tests

Two cases in `ConfiguredXHTMLGeneratorTests`, both using the rule set and
headwords from the project attached to the issue. Each asserts three headings:
a plain letter (`A a`), a letter sharing its first character with a digraph
(`C c`), and the digraph itself (`Ch ch`).

- **`..._ShoeboxSortRules_...`** — `SimpleRulesCollationDefinition`. Reproduces
  the reported symptom directly.
- **`..._UppercaseFirstIcuRules_...`** — `IcuRulesCollationDefinition`. Not
  redundant: that project's compiled collation (`< A << a < ... < Ch << ch`)
  names the uppercase letter as primary too, so the digraph parsing folds
  headwords onto it exactly as the simple rules do. The ICU path fails
  identically without the fix.

Both were verified failing before the fix and passing after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [x] Builds/tests pass locally (or I've run the CI-style build via `build.ps1`/`test.ps1` or MSBuild).
- [x] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1089)
<!-- Reviewable:end -->
