### PR TITLE
commit-guidelines fix: Document the minimum commit body length gitlint enforces

### DIFF
--- a/.github/commit-guidelines.md
+++ b/.github/commit-guidelines.md
@@ -12,6 +12,7 @@ These align with the gitlint rules run in CI.
 ## Body (optional)
 
 - Blank line after the subject.
+- At least 20 characters, if present.
 - Wrap lines at 80 characters.
 - Explain what and why over how; link issues like "Fixes #1234" when applicable.
 - No hard tabs, no trailing whitespace.


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
Adding minimum commit body length to commit guidelines. Gitlint's B5 rule rejects a body under 20 characters. The guidelines listed the other body rules but not this one, so a short body failed CI with no documented reason.

## CI-ready checklist

- [x] Commit messages follow `.github/commit-guidelines.md` (subject ≤ 72 chars, no trailing punctuation; if body present, blank line then ≤ 80-char lines).
- [x] No whitespace warnings locally:
  ```powershell
  git fetch origin
  git log --check --pretty=format:"---% h% s" origin/<base>..
  git diff --check --cached
  ```
- [ ] Builds/tests pass locally (or I've run the CI-style build via `build.ps1`/`test.ps1` or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1090)
<!-- Reviewable:end -->
