### PR TITLE
Anchor dev code and data directories on the running source tree

### DIFF
--- a/.claude/skills/fieldworks-winapp/SKILL.md
+++ b/.claude/skills/fieldworks-winapp/SKILL.md
@@ -120,6 +120,7 @@ verifies that launch will succeed.
 - `scripts/Set-FieldWorksLegacyMode.ps1`: forces `UIMode=Legacy` — run before EVERY launch.
 - `scripts/Resolve-FieldWorksDevRegistry.ps1`: aligns the dev registry (`RootCodeDir`/`RootDataDir`) to
   this worktree before launch; auto-realigns when the other worktree is idle, else prints `RESULT=ASK_USER`.
+  Current builds anchor on their own source tree, so this now matters mainly for older builds.
 - `references/headless-rendering.md`: why FieldWorks needs a display-bound desktop; what works/doesn't for
   invisible capture (winforms-mcp HEADLESS does NOT render FieldWorks; a Virtual Display Driver was tried
   and abandoned — see the doc for why; use visible capture, or RDP for true invisibility). Starts with the

--- a/.claude/skills/fieldworks-winapp/SKILL.md
+++ b/.claude/skills/fieldworks-winapp/SKILL.md
@@ -120,7 +120,8 @@ verifies that launch will succeed.
 - `scripts/Set-FieldWorksLegacyMode.ps1`: forces `UIMode=Legacy` — run before EVERY launch.
 - `scripts/Resolve-FieldWorksDevRegistry.ps1`: aligns the dev registry (`RootCodeDir`/`RootDataDir`) to
   this worktree before launch; auto-realigns when the other worktree is idle, else prints `RESULT=ASK_USER`.
-  Current builds anchor on their own source tree, so this now matters mainly for older builds.
+  A build running from inside a source tree resolves code and data from that tree and
+  ignores these values; they govern a build launched from outside one.
 - `references/headless-rendering.md`: why FieldWorks needs a display-bound desktop; what works/doesn't for
   invisible capture (winforms-mcp HEADLESS does NOT render FieldWorks; a Virtual Display Driver was tried
   and abandoned — see the doc for why; use visible capture, or RDP for true invisibility). Starts with the

--- a/.claude/skills/fieldworks-winapp/navigation/launch-or-attach.md
+++ b/.claude/skills/fieldworks-winapp/navigation/launch-or-attach.md
@@ -28,6 +28,9 @@ returns empty and `winforms_take_screenshot` is blank even though the process is
   when the other worktree is NOT active (no FieldWorks.exe running from it) and was NOT used in the last 24h
   (registry key write time). If it prints `RESULT=ASK_USER`, the other worktree may be active — **ask the
   user** before realigning, then re-run with `-Force` if they approve.
+  Since `FwDirectoryFinder` learned to anchor on the source tree it runs from, an exe built from a current
+  worktree already reads its own `DistFiles`; keep running the script for older builds, and for the other
+  registry values (`ProjectsDir`), which are still shared across worktrees.
 
 See the script headers and `../references/mcp-setup.md`.
 

--- a/Src/Common/FwUtils/FwDirectoryFinder.cs
+++ b/Src/Common/FwUtils/FwDirectoryFinder.cs
@@ -315,9 +315,15 @@ namespace SIL.FieldWorks.Common.FwUtils
 					ResourceHelper.GetResourceString("kstidInvalidInstallation")
 				);
 			}
-			// Hundreds of callers of this method are using Path.Combine with the results.
-			// Combine only works with a root directory if it is followed by \ (e.g., c:\)
-			// so we don't want to trim the \ in this situation.
+			return TidyRootDir(rootDir);
+		}
+
+		/// <summary>
+		/// Strips the trailing separator that hundreds of callers would otherwise pass on to
+		/// Path.Combine, except on a root directory (e.g. c:\), where Combine needs it.
+		/// </summary>
+		private static string TidyRootDir(string rootDir)
+		{
 			string dir = rootDir.TrimEnd(
 				Path.DirectorySeparatorChar,
 				Path.AltDirectorySeparatorChar
@@ -325,15 +331,46 @@ namespace SIL.FieldWorks.Common.FwUtils
 			return dir.Length > 2 ? dir : dir + Path.DirectorySeparatorChar;
 		}
 
+		/// <summary>The file that marks the root of a FieldWorks source tree.</summary>
+		private const string ksSolutionFilename = "FieldWorks.sln";
+
+		/// <summary>Set this to let the registry name the directories again.</summary>
+		private const string ksUseRegistryDirsVariable = "FW_USE_REGISTRY_DIRS";
+
+		/// <summary>
+		/// Gets the DistFiles folder of the source tree that <paramref name="startDirectory"/>
+		/// lies in, or <c>null</c> if it lies outside a source tree (the installed case).
+		/// </summary>
+		/// <remarks>
+		/// Walking up to the tree root, rather than assuming a fixed depth, finds
+		/// DistFiles from Output/&lt;Configuration&gt;, from its architecture
+		/// subfolders, and from a project's own bin folder alike.
+		/// </remarks>
+		/// <param name="startDirectory">The directory to start searching upwards from.</param>
+		public static string FindDevDistFiles(string startDirectory)
+		{
+			for (
+				string dir = startDirectory;
+				!string.IsNullOrEmpty(dir);
+				dir = Path.GetDirectoryName(dir)
+			)
+			{
+				string distFiles = Path.Combine(dir, "DistFiles");
+				// The solution file is what keeps an installed FieldWorks from matching here.
+				if (Directory.Exists(distFiles)
+					&& File.Exists(Path.Combine(dir, ksSolutionFilename)))
+					return distFiles;
+			}
+			return null;
+		}
+
 		private static string GetDevDistFilesPath()
 		{
+			if (EnvironmentVariables.IsTrue(ksUseRegistryDirsVariable))
+				return null;
+
 			string assemblyDir = Path.GetDirectoryName(FileUtils.StripFilePrefix(Assembly.GetExecutingAssembly().CodeBase));
-			// Check if we are in Output/Debug or Output/Release
-			// DistFiles is at ../../DistFiles
-			string distFiles = Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", "DistFiles"));
-			if (Directory.Exists(distFiles))
-				return distFiles;
-			return null;
+			return FindDevDistFiles(assemblyDir);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -349,15 +386,16 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			get
 			{
+				// The tree the assembly runs from owns its DistFiles, so it beats the registry.
+				string devDistFiles = GetDevDistFilesPath();
+				if (devDistFiles != null)
+					return TidyRootDir(devDistFiles);
+
 				string defaultDir = Path.Combine(
 					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
 					CompanyName,
 					$"FieldWorks {FwUtils.SuiteVersion}"
 				);
-
-				string devDistFiles = GetDevDistFilesPath();
-				if (devDistFiles != null)
-					defaultDir = devDistFiles;
 
 				return GetDirectory("RootCodeDir", defaultDir);
 			}
@@ -377,11 +415,12 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			get
 			{
-				string defaultDir = Path.Combine(LcmFileHelper.CommonApplicationData, CompanyName, ksFieldWorks);
-
+				// See CodeDirectory: the running tree outranks the shared registry.
 				string devDistFiles = GetDevDistFilesPath();
 				if (devDistFiles != null)
-					defaultDir = devDistFiles;
+					return TidyRootDir(devDistFiles);
+
+				string defaultDir = Path.Combine(LcmFileHelper.CommonApplicationData, CompanyName, ksFieldWorks);
 
 				return GetDirectory(
 					ksRootDataDir,

--- a/Src/Common/FwUtils/FwDirectoryFinder.cs
+++ b/Src/Common/FwUtils/FwDirectoryFinder.cs
@@ -463,6 +463,24 @@ namespace SIL.FieldWorks.Common.FwUtils
 			}
 		}
 
+		/// <summary>
+		/// The Src directory of the source tree <paramref name="startDirectory"/> lies in.
+		/// </summary>
+		/// <exception cref="ApplicationException">There is no source tree above
+		/// <paramref name="startDirectory"/>, or the tree has no Src directory.</exception>
+		internal static string FindSourceDirectory(string startDirectory)
+		{
+			string distFiles = FindDevDistFiles(startDirectory);
+			string dir = distFiles == null
+				? null
+				: Path.Combine(Path.GetDirectoryName(distFiles), "Src");
+			if (dir == null || !Directory.Exists(dir))
+				throw new ApplicationException(
+					"Could not find the Src directory.  Was expecting it at: "
+					+ (dir ?? "(no source tree above " + startDirectory + ")"));
+			return dir;
+		}
+
 		private static string m_srcdir;
 
 		/// ------------------------------------------------------------------------------------
@@ -481,16 +499,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 				// The same walk the code and data directories use, so every layout it supports
 				// resolves here too.
-				string distFiles = FindDevDistFiles(ExeOrDllDirectory);
-				string dir = distFiles == null
-					? null
-					: Path.Combine(Path.GetDirectoryName(distFiles), "Src");
-				if (dir == null || !Directory.Exists(dir))
-					throw new ApplicationException(
-						"Could not find the Src directory.  Was expecting it at: "
-						+ (dir ?? "(no source tree above " + ExeOrDllDirectory + ")")
-					);
-				m_srcdir = dir;
+				m_srcdir = FindSourceDirectory(ExeOrDllDirectory);
 
 				return m_srcdir;
 			}

--- a/Src/Common/FwUtils/FwDirectoryFinder.cs
+++ b/Src/Common/FwUtils/FwDirectoryFinder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2003-2018 SIL International
+﻿// Copyright (c) 2003-2018 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 //
@@ -319,8 +319,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 		}
 
 		/// <summary>
-		/// Strips the trailing separator that hundreds of callers would otherwise pass on to
-		/// Path.Combine, except on a root directory (e.g. c:\), where Combine needs it.
+		/// The directory without a trailing separator, except at a drive root (e.g. c:\), where
+		/// Path.Combine requires one.
 		/// </summary>
 		private static string TidyRootDir(string rootDir)
 		{
@@ -334,19 +334,27 @@ namespace SIL.FieldWorks.Common.FwUtils
 		/// <summary>The file that marks the root of a FieldWorks source tree.</summary>
 		private const string ksSolutionFilename = "FieldWorks.sln";
 
-		/// <summary>Set this to let the registry name the directories again.</summary>
-		private const string ksUseRegistryDirsVariable = "FW_USE_REGISTRY_DIRS";
-
 		/// <summary>
 		/// Gets the DistFiles folder of the source tree that <paramref name="startDirectory"/>
 		/// lies in, or <c>null</c> if it lies outside a source tree (the installed case).
 		/// </summary>
 		/// <remarks>
-		/// Walking up to the tree root, rather than assuming a fixed depth, finds
-		/// DistFiles from Output/&lt;Configuration&gt;, from its architecture
-		/// subfolders, and from a project's own bin folder alike.
+		/// The solution file is what distinguishes a source tree from an install, so an
+		/// installed FieldWorks never matches here however deep its DistFiles sits.
 		/// </remarks>
-		/// <param name="startDirectory">The directory to start searching upwards from.</param>
+		/// <summary>
+		/// The directory holding the assembly at <paramref name="codeBase"/>, a file:// URI.
+		/// </summary>
+		/// <remarks>
+		/// Unescapes before returning: a repo path containing a space arrives here as %20, and
+		/// a start directory that still holds it matches no directory at all.
+		/// </remarks>
+		internal static string AssemblyDirectoryFromCodeBase(string codeBase)
+		{
+			var uri = new Uri(codeBase);
+			return Path.GetDirectoryName(Uri.UnescapeDataString(uri.AbsolutePath));
+		}
+
 		public static string FindDevDistFiles(string startDirectory)
 		{
 			for (
@@ -366,11 +374,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 		private static string GetDevDistFilesPath()
 		{
-			if (EnvironmentVariables.IsTrue(ksUseRegistryDirsVariable))
-				return null;
-
-			string assemblyDir = Path.GetDirectoryName(FileUtils.StripFilePrefix(Assembly.GetExecutingAssembly().CodeBase));
-			return FindDevDistFiles(assemblyDir);
+			return FindDevDistFiles(AssemblyDirectoryFromCodeBase(
+				Assembly.GetExecutingAssembly().CodeBase));
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -462,8 +467,10 @@ namespace SIL.FieldWorks.Common.FwUtils
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets the src dir (for running tests)
+		/// The Src directory of the source tree this assembly is running from (for tests).
 		/// </summary>
+		/// <exception cref="ApplicationException">The assembly is not inside a source tree, or
+		/// the tree has no Src directory.</exception>
 		/// ------------------------------------------------------------------------------------
 		public static string SourceDirectory
 		{
@@ -472,15 +479,16 @@ namespace SIL.FieldWorks.Common.FwUtils
 				if (!string.IsNullOrEmpty(m_srcdir))
 					return m_srcdir;
 
-				// We'll assume the executing assembly is $FW/Output/Debug/FwUtils.dll,
-				// and the source dir is $FW/Src.
-				var dir = ExeOrDllDirectory;
-				dir = Path.GetDirectoryName(dir); // strip the parent directory name (Debug)
-				dir = Path.GetDirectoryName(dir); // strip the parent directory again (Output)
-				dir = Path.Combine(dir, "Src");
-				if (!Directory.Exists(dir))
+				// The same walk the code and data directories use, so every layout it supports
+				// resolves here too.
+				string distFiles = FindDevDistFiles(ExeOrDllDirectory);
+				string dir = distFiles == null
+					? null
+					: Path.Combine(Path.GetDirectoryName(distFiles), "Src");
+				if (dir == null || !Directory.Exists(dir))
 					throw new ApplicationException(
-						"Could not find the Src directory.  Was expecting it at: " + dir
+						"Could not find the Src directory.  Was expecting it at: "
+						+ (dir ?? "(no source tree above " + ExeOrDllDirectory + ")")
 					);
 				m_srcdir = dir;
 

--- a/Src/Common/FwUtils/FwUtils.cs
+++ b/Src/Common/FwUtils/FwUtils.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2018 SIL International
+﻿// Copyright (c) 2009-2018 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -221,6 +221,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 					return null;
 
 				var ver = CustomIcu.Version.ToString(CultureInfo.InvariantCulture);
+				// Not FwDirectoryFinder.FindDevDistFiles: on the InitIcuDataDir bootstrap path
+				// that dependency is an initialisation-order question. See LT-22768.
 				var distFiles = Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", "DistFiles"));
 				if (!Directory.Exists(distFiles))
 					return null;

--- a/Src/Common/FwUtils/FwUtils.cs
+++ b/Src/Common/FwUtils/FwUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2009-2018 SIL International
+// Copyright (c) 2009-2018 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 

--- a/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2017 SIL International
+﻿// Copyright (c) 2008-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -37,6 +37,60 @@ namespace SIL.FieldWorks.Common.FwUtils
 			FwRegistryHelper.Manager.SetRegistryHelper(new DummyFwRegistryHelper());
 			FwRegistryHelper.FieldWorksRegistryKey.SetValue("RootDataDir", Path.GetFullPath(Path.Combine(UtilsAssemblyDir, "../../DistFiles")));
 			FwRegistryHelper.FieldWorksRegistryKey.SetValue("RootCodeDir", Path.GetFullPath(Path.Combine(UtilsAssemblyDir, "../../DistFiles")));
+		}
+
+		/// <summary>
+		/// The solution file is the only thing telling a source tree from an install, so if it is
+		/// ever renamed every dev build silently reverts to the registry. This makes that a red
+		/// build instead. Three FwAvalonia fixtures also walk up to it to find the repo root, so
+		/// a
+		/// rename would break four things at once, all of them confusingly.
+		/// </summary>
+		[Test]
+		public void SourceTreeMarker_StillExistsAtTheRepoRoot()
+		{
+			var distFiles = FwDirectoryFinder.FindDevDistFiles(UtilsAssemblyDir);
+			Assert.That(distFiles, Is.Not.Null,
+				"the test assembly is not inside a source tree, so the marker cannot be checked");
+
+			var repoRoot = Path.GetDirectoryName(distFiles);
+			Assert.That(File.Exists(Path.Combine(repoRoot, "FieldWorks.sln")), Is.True,
+				"FieldWorks.sln is what FwDirectoryFinder uses to recognise a source tree. If it "
+				+ "was renamed or removed, update ksSolutionFilename in the same commit -- "
+				+ "otherwise dev builds fall back to the machine registry with no diagnostic.");
+		}
+
+		/// <summary>
+		/// A space in the repo path must not defeat the walk: the assembly path comes from a
+		/// file:// URI, so it has to be unescaped before any directory is probed.
+		/// </summary>
+		[Test]
+		public void FindDevDistFiles_UnderAPathContainingASpace_FindsTreeDistFiles()
+		{
+			var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(),
+				"FwDirectoryFinderTests", "My Repos " + Guid.NewGuid().ToString("N"))).FullName;
+			try
+			{
+				Directory.CreateDirectory(Path.Combine(root, "DistFiles"));
+				File.WriteAllText(Path.Combine(root, "FieldWorks.sln"), string.Empty);
+				var start = Directory.CreateDirectory(
+					Path.Combine(root, "Output", "Debug", "x64")).FullName;
+
+				// Through the same conversion production uses, from a file:// URI -- the walk
+				// itself never saw the escaping, so testing it alone would prove nothing.
+				var codeBase = new Uri(Path.Combine(start, "FwUtils.dll")).AbsoluteUri;
+				Assert.That(codeBase, Does.Contain("%20"),
+					"the fixture path must actually round-trip an escaped space");
+
+				var derived = FwDirectoryFinder.AssemblyDirectoryFromCodeBase(codeBase);
+				Assert.That(derived, Is.SamePath(start));
+				Assert.That(FwDirectoryFinder.FindDevDistFiles(derived),
+					Is.SamePath(Path.Combine(root, "DistFiles")));
+			}
+			finally
+			{
+				Directory.Delete(root, true);
+			}
 		}
 
 		///-------------------------------------------------------------------------------------
@@ -122,7 +176,12 @@ namespace SIL.FieldWorks.Common.FwUtils
 		[TestCase("RootDataDir")]
 		public void CodeAndDataDirectory_PreferSourceTreeOverRegistry(string registryValueName)
 		{
-			var expectedDir = Path.GetFullPath(Path.Combine(UtilsAssemblyDir, "../../DistFiles"));
+			// Derived the way production derives it, not by re-encoding the ../../DistFiles
+			// depth this change exists to remove -- that would pass today and mislead tomorrow.
+			var expectedDir = FwDirectoryFinder.FindDevDistFiles(UtilsAssemblyDir);
+			Assert.That(expectedDir, Is.Not.Null,
+				"the test assembly must itself be inside a source tree for this test to mean "
+				+ "anything");
 			using (var fwHKCU = FwRegistryHelper.FieldWorksRegistryKey)
 			{
 				var originalValue = fwHKCU.GetValue(registryValueName);
@@ -134,7 +193,13 @@ namespace SIL.FieldWorks.Common.FwUtils
 				}
 				finally
 				{
-					fwHKCU.SetValue(registryValueName, originalValue);
+					// SetValue(name, null) throws, so an absent original must be deleted instead
+					// --
+					// otherwise the cleanup masks whichever assertion actually failed.
+					if (originalValue == null)
+						fwHKCU.DeleteValue(registryValueName, false);
+					else
+						fwHKCU.SetValue(registryValueName, originalValue);
 				}
 			}
 		}

--- a/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
@@ -65,6 +65,96 @@ namespace SIL.FieldWorks.Common.FwUtils
 			Assert.That(FwDirectoryFinder.CodeDirectory, Is.SamePath(currentDir));
 		}
 
+		///-------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests that FindDevDistFiles locates DistFiles from anywhere inside a source tree,
+		/// not only from the Output/&lt;Configuration&gt; folder two levels below its root.
+		/// </summary>
+		///-------------------------------------------------------------------------------------
+		[TestCase("Output/Debug")]
+		[TestCase("Output/Debug/x64")]
+		[TestCase("Src/Common/FwUtils/bin/Debug/net8.0")]
+		public void FindDevDistFiles_InsideSourceTree_FindsTreeDistFiles(string startSubDirectory)
+		{
+			var treeRoot = CreateFakeSourceTree(withSolutionFile: true);
+			try
+			{
+				var startDir = Directory.CreateDirectory(Path.Combine(treeRoot, startSubDirectory)).FullName;
+
+				Assert.That(FwDirectoryFinder.FindDevDistFiles(startDir),
+					Is.SamePath(Path.Combine(treeRoot, "DistFiles")));
+			}
+			finally
+			{
+				Directory.Delete(treeRoot, true);
+			}
+		}
+
+		///-------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests that FindDevDistFiles ignores a DistFiles folder that is not part of a source
+		/// tree, which is what keeps an installed FieldWorks on its registry directories.
+		/// </summary>
+		///-------------------------------------------------------------------------------------
+		[Test]
+		public void FindDevDistFiles_OutsideSourceTree_ReturnsNull()
+		{
+			var installRoot = CreateFakeSourceTree(withSolutionFile: false);
+			try
+			{
+				var startDir = Directory.CreateDirectory(Path.Combine(installRoot, "Output", "Debug")).FullName;
+
+				Assert.That(FwDirectoryFinder.FindDevDistFiles(startDir), Is.Null);
+			}
+			finally
+			{
+				Directory.Delete(installRoot, true);
+			}
+		}
+
+		///-------------------------------------------------------------------------------------
+		/// <summary>
+		/// Tests that the source tree the assembly runs from wins over a registry value naming
+		/// another tree, so that worktrees do not read each other's DistFiles.
+		/// </summary>
+		///-------------------------------------------------------------------------------------
+		[TestCase("RootCodeDir")]
+		[TestCase("RootDataDir")]
+		public void CodeAndDataDirectory_PreferSourceTreeOverRegistry(string registryValueName)
+		{
+			var expectedDir = Path.GetFullPath(Path.Combine(UtilsAssemblyDir, "../../DistFiles"));
+			using (var fwHKCU = FwRegistryHelper.FieldWorksRegistryKey)
+			{
+				var originalValue = fwHKCU.GetValue(registryValueName);
+				fwHKCU.SetValue(registryValueName, Path.Combine(Path.GetTempPath(), "SomeOtherWorktree", "DistFiles"));
+				try
+				{
+					Assert.That(FwDirectoryFinder.CodeDirectory, Is.SamePath(expectedDir));
+					Assert.That(FwDirectoryFinder.DataDirectory, Is.SamePath(expectedDir));
+				}
+				finally
+				{
+					fwHKCU.SetValue(registryValueName, originalValue);
+				}
+			}
+		}
+
+		///-------------------------------------------------------------------------------------
+		/// <summary>
+		/// Creates a throw-away directory holding a DistFiles folder, and the solution file that
+		/// marks a source tree unless <paramref name="withSolutionFile"/> says otherwise.
+		/// </summary>
+		///-------------------------------------------------------------------------------------
+		private static string CreateFakeSourceTree(bool withSolutionFile)
+		{
+			var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(),
+				"FwDirectoryFinderTests", Guid.NewGuid().ToString("N"))).FullName;
+			Directory.CreateDirectory(Path.Combine(root, "DistFiles"));
+			if (withSolutionFile)
+				File.WriteAllText(Path.Combine(root, "FieldWorks.sln"), string.Empty);
+			return root;
+		}
+
 		/// <summary>
 		/// Verify that the user project key falls back to the local machine.
 		/// </summary>

--- a/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
+++ b/Src/Common/FwUtils/FwUtilsTests/FwDirectoryFinderTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using SIL.PlatformUtilities;
 
@@ -193,8 +194,7 @@ namespace SIL.FieldWorks.Common.FwUtils
 				}
 				finally
 				{
-					// SetValue(name, null) throws, so an absent original must be deleted instead
-					// --
+					// SetValue(name, null) throws, so an absent original is deleted instead;
 					// otherwise the cleanup masks whichever assertion actually failed.
 					if (originalValue == null)
 						fwHKCU.DeleteValue(registryValueName, false);
@@ -277,6 +277,48 @@ namespace SIL.FieldWorks.Common.FwUtils
 		{
 			var currentDir = Path.GetFullPath(Path.Combine(UtilsAssemblyDir, "../../DistFiles"));
 			Assert.That(FwDirectoryFinder.DataDirectory, Is.SamePath(currentDir));
+		}
+
+		/// <summary>
+		/// SourceDirectory resolves from every layout the walk supports, including the
+		/// Output/Debug/x64 that FindDevDistFiles_InsideSourceTree also claims.
+		/// </summary>
+		[TestCase("Output", "Debug")]
+		[TestCase("Output", "Debug", "x64")]
+		[TestCase("Src", "SomeProject", "bin", "Debug")]
+		public void FindSourceDirectory_FromASupportedLayout_FindsTreeSrc(params string[] startSubDirectory)
+		{
+			var root = CreateFakeSourceTree(true);
+			try
+			{
+				Directory.CreateDirectory(Path.Combine(root, "Src"));
+				var start = Directory.CreateDirectory(
+					Path.Combine(new[] { root }.Concat(startSubDirectory).ToArray())).FullName;
+
+				Assert.That(FwDirectoryFinder.FindSourceDirectory(start),
+					Is.SamePath(Path.Combine(root, "Src")));
+			}
+			finally
+			{
+				Directory.Delete(root, true);
+			}
+		}
+
+		/// <summary>Outside a source tree it throws rather than returning something
+		/// wrong.</summary>
+		[Test]
+		public void FindSourceDirectory_OutsideASourceTree_Throws()
+		{
+			var root = CreateFakeSourceTree(false);
+			try
+			{
+				Assert.That(() => FwDirectoryFinder.FindSourceDirectory(root),
+					Throws.TypeOf<ApplicationException>());
+			}
+			finally
+			{
+				Directory.Delete(root, true);
+			}
 		}
 
 		///-------------------------------------------------------------------------------------

--- a/Src/Common/FwUtils/StringTable.cs
+++ b/Src/Common/FwUtils/StringTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2003-2017 SIL International
+// Copyright (c) 2003-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 

--- a/Src/Common/FwUtils/StringTable.cs
+++ b/Src/Common/FwUtils/StringTable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2003-2017 SIL International
+﻿// Copyright (c) 2003-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -91,6 +91,8 @@ namespace SIL.FieldWorks.Common.FwUtils
 					}
 					if (!installedBinary)
 					{
+						// Walks to the LAST 'output' segment, not to a solution file like
+						// FwDirectoryFinder. See LT-22769.
 						while (parentOfLanguageExplorerFolder.ToLowerInvariant().LastIndexOf("output") > -1)
 						{
 							// If a dev machine, move up to parent of 'output' folder.


### PR DESCRIPTION
A Debug build now reads the `DistFiles` of the source tree it was built in. Before this, it read whichever tree the shared registry value `HKCU\SOFTWARE\SIL\FieldWorks\9\RootCodeDir` happened to name — on the machine that prompted this, a build in the main repo was loading parts, layouts, and configuration from an unrelated worktree under `.tmp/worktrees/`.

The reviewer's question here is "what did this break for installed FieldWorks?", and the answer is nothing: the new probe only matches a directory that has both `DistFiles` and `FieldWorks.sln` beside it, which no install has. The question worth your time is whether making the source tree outrank the registry is the right default.

**Where to look**

- `CodeDirectory` / `DataDirectory` now return before consulting the registry when the running assembly is inside a source tree — the deliberate behavior change. There is no opt-out: `FW_USE_REGISTRY_DIRS` was dropped in review as undiscoverable and unused.
- `FindDevDistFiles` walks up instead of assuming `<assembly>/../../DistFiles`, so it also works from `Output/Debug/x64` and from a project's own `bin` folder. Three layouts pinned by tests.
- The installed case is pinned by its own test: `DistFiles` present, no solution file, result `null`.
- `TidyRootDir` is extracted from `GetDirectory` so both paths normalize trailing separators identically — the ~100 `Path.Combine` callers see no difference.
- `ProjectsDirectory`'s **code** is untouched, but its behavior is not, and the earlier claim that it was untouched was wrong. `FwDirectoryFinder.cs:541` is `GetDirectory(ksProjectsDir, Path.Combine(DataDirectory, ksProjects))`, so its default derives from `DataDirectory`, which this PR changes. Where the HKCU/HKLM `ProjectsDir` value is **set**, nothing changes — which is most established dev machines. Where it is **absent** — a fresh dev box, a CI agent, a container — the projects directory moves from `%ProgramData%\SIL\FieldWorks\Projects` to `<tree>\DistFiles\Projects`.

**Deliberately not here**

- `Src/FwParatextLexiconPlugin/ParatextLexiconPluginDirectoryFinder.cs` keeps its registry-only resolution; it runs inside Paratext, never from a source tree.
- No log line or warning when an existing `RootCodeDir` override stops applying.
- `Build/mkall.targets` still carries the `setKeysInHKCU` target that writes `RootCodeDir`/`RootDataDir`, though `mkall.targets:277` says those targets appear unused by the modernized build; either way a source-tree build now ignores those values.

**Verification**

`.\build.ps1 -CommentHygiene -BuildTests` succeeded (0 warnings, 0 errors; comment-hygiene clean). `.\test.ps1 -CommentHygiene -SkipNative -TestProject Src\Common\FwUtils\FwUtilsTests\FwUtilsTests.csproj` — 407/407 passed, including 6 new cases. Not run: the full suite, native tests, installer validation. Not done: a manual two-worktree launch.

---

<details>
<summary><b>Reading this a year from now</b> — start here</summary>

This started as a question, not a bug report: "my local Debug build still looks at DistFiles — could it look at `Output` instead?" The investigation said no to the literal request and yes to the problem behind it. Both halves are recorded below, because the rejected half is the one that will otherwise be re-proposed.

There were no working documents to delete; the reasoning never existed anywhere but here.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

**The registry loses to the source tree, rather than the probe merely being fixed.** Fixing the anchoring alone would have changed nothing on a real dev machine: `GetDevDistFilesPath()` only ever fed `defaultDir`, and `GetDirectory` returns the registry value whenever it is non-empty. On a dev machine it is always non-empty. `Build/mkall.targets` (`setKeysInHKCU`) has historically written it, but `mkall.targets:277` carries a `REVIEW (Hasso) 2026.03` noting those targets "appear unused by the recently-modernized build process", so the live writers are more likely the MSI (`FLExInstaller/Overrides.wxi:11-12`) and `Resolve-FieldWorksDevRegistry.ps1:54-55`, plus the winapp skill's launch script. The value is a single machine-wide slot shared by every worktree, so it names whichever tree ran last. That is the actual defect; the fixed-depth probe is a second, independent one.

**`FieldWorks.sln` as the tree marker.** The probe needs something that exists in a source tree and never beside an install. The installer harvests `DistFiles\**\*` — the *contents*, into the install root — so an install has neither a `DistFiles` folder nor a solution file at that level. Requiring both makes the installed path unreachable by construction rather than by convention.


**No memoization.** Each `CodeDirectory` get now walks up doing `Directory.Exists` + `File.Exists` per level. The old path opened and read a registry key on every get, so this is not a regression. Revisit only with a measurement.

</details>

<details>
<summary><b>Paths not taken</b></summary>

**Pointing the code directory at `Output/<Configuration>` — the literal request.** `Output` holds build artifacts only; the code/data payload exists solely in `DistFiles`. Counted in the tree at the time: `Language Explorer` 10 entries in `DistFiles` vs absent from `Output/Debug`; `Parts` 4 vs absent; `Helps` 7 vs absent; `Icu70` present vs absent; `Templates` 42 vs 1. `FlexStylesPath`, `FlexFolder`, `TemplateDirectory`, and `EditorialChecksDirectory` would all have broken.

**An overlay that probes `Output` first, then falls back to `DistFiles`.** This cannot be expressed through the current API: `CodeDirectory` returns one string that ~100 call sites `Path.Combine` onto. An overlay needs a `ResolveCodeFile(relativePath)` seam instead — a much larger change, for a duplication problem that does not currently exist (only `Templates` overlaps at all, with one entry).

**Just fixing the registry and stopping there.** That is what unblocked the reporter (`Resolve-FieldWorksDevRegistry.ps1 -Force`, run before this branch existed), and it is what every worktree switch will need again tomorrow. It treats the symptom.

</details>

<details>
<summary><b>Evidence</b></summary>

**Precedence, before this change** — `GetDirectory(RegistryKey, string, string)` in `Src/Common/FwUtils/FwDirectoryFinder.cs`: `rootDir` is read from the registry, and `defaultDir` is used only `if (string.IsNullOrEmpty(rootDir))`. `GetDevDistFilesPath()` fed `defaultDir`. Hence: registry set → probe irrelevant.

**The shared slot** — `HKCU\SOFTWARE\SIL\FieldWorks\$(FWMAJOR)` holds `RootCodeDir`, `RootDataDir` and `ProjectsDir`. `Build/mkall.targets` target `setKeysInHKCU` writes them from `$(dir-fwdistfiles)`, though `mkall.targets:277` says those targets appear unused now; the MSI (`FLExInstaller/Overrides.wxi:11-12`) and `Resolve-FieldWorksDevRegistry.ps1:54-55` are the likelier live writers. Nothing in `Src/` writes those two values at runtime (searching for `SetValue("RootCodeDir"` outside tests returns no hits), so the value persists from whichever tree last built or launched.

**Existing tests keep passing for a non-trivial reason** — `FwDirectoryFinderTests` sets the registry to `UtilsAssemblyDir/../../DistFiles`, and `InitializeFwRegistryHelperAttribute` does the same. Under the new precedence those values are ignored, but the walk-up returns the same path for a test run out of `Output/Debug`, so the assertions still hold.

**New coverage** — `FindDevDistFiles_InsideSourceTree_FindsTreeDistFiles` (`Output/Debug`, `Output/Debug/x64`, `Src/Common/FwUtils/bin/Debug/net8.0`), `FindDevDistFiles_OutsideSourceTree_ReturnsNull`, and `CodeAndDataDirectory_PreferSourceTreeOverRegistry` (`RootCodeDir`, `RootDataDir`), which points the registry at a fabricated other worktree and asserts both directories still resolve to this tree.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
# Code Review Summary

**Branch**: fix/dev-dir-anchoring

**Base**: origin/main

**Date**: 2026-08-28

**Review model**: Claude Opus 5

**Files changed**: 6

## Overview

A dev build resolves its code and data directories from a machine-wide registry
slot, so a build run from one worktree can silently read another worktree's
DistFiles. The branch walks up from the running assembly to the enclosing source
tree instead, identified by `FieldWorks.sln`, and falls back to the registry only
outside a tree.

This pass responded to a ten-item CHANGES_REQUESTED review. Every item was
verified against the code before being acted on; one was confirmed by executing
the suspect function, and one review claim did not hold. A later self-audit,
prompted by the author, found that this pass's own `SourceDirectory` change had
shipped without coverage of what it changed. That is fixed in `c32048433`.

## Contract/API Changes

- `FwDirectoryFinder.FindDevDistFiles(string)` — public, added by the first
  commit on this branch.
- `FwDirectoryFinder.AssemblyDirectoryFromCodeBase(string)` — new `internal`,
  visible to `FwUtilsTests` via existing `InternalsVisibleTo`.
- `FwDirectoryFinder.FindSourceDirectory(string)` — new `internal`, same
  visibility.
- `FW_USE_REGISTRY_DIRS` — removed. It was introduced on this branch and never
  shipped, so no external contract is broken.
- `FwDirectoryFinder.SourceDirectory` — unchanged signature; resolution now
  follows the source-tree walk rather than two fixed parent hops.
- `ProjectsDirectory` — unchanged code, changed behaviour where the registry
  value is absent. Recorded in the PR body.

## Findings

### Critical - Must address before merge

- [x] **The walk-up was a no-op on any path containing a space** _(fixed during
  review: derived through `AssemblyDirectoryFromCodeBase`, which unescapes)_.
  Confirmed by calling the function:
  `StripFilePrefix('file:///C:/My%20Repos/...')` returns the path with `%20`
  intact, so every `Directory.Exists` missed and resolution fell back to the
  registry with no diagnostic — the bug this branch exists to remove.

### Important - Should address before merge

- [x] **`SourceDirectory` still used two fixed parent hops and threw** _(fixed
  during review: routed through the same walk)_. A build from
  `Output/Debug/x64` resolved code and data but failed here, contradicting the
  layout `FindDevDistFiles_InsideSourceTree_FindsTreeDistFiles` claims.
- [x] **That reroute shipped with no test of its own** _(fixed during review in
  `c32048433`: `FindSourceDirectory` seam plus three layout cases and a throws
  case)_. Found by self-audit, not by the reviewer. A pre-existing test caught an
  outright break but nothing exercised the layouts, which was the point of the
  change.
- [x] **The registry test re-encoded the fixed depth it was meant to retire, and
  its cleanup could mask a real failure** _(fixed during review: expectation
  derived the way production derives it; an absent original value is deleted
  rather than passed to `SetValue`, which throws on null)_.
- [x] **Nothing failed if the source-tree marker disappeared** _(fixed during
  review: added a test naming `ksSolutionFilename`)_. Sharper than reported:
  `CanonicalJsonTests`, `EngineIsolationAuditTests` and
  `LayoutImportCoverageTests` already walk up to `FieldWorks.sln`, so a rename
  breaks four things at once.
- [x] **The PR body claimed `ProjectsDirectory` was untouched** _(fixed during
  review: body now states that where the registry value is absent the projects
  directory moves to `<tree>\DistFiles\Projects`)_.
- [x] **`FW_USE_REGISTRY_DIRS` was undiscoverable and unused** _(fixed during
  review: removed)_.
- [ ] ~~Tests constructing a WinForms control break a standing rule~~ _(the
  facts hold but the framing does not: no such rule is written down, and
  `DataTreeTests`, `SliceTests` and `ReversalEntryViewTests` all construct
  slices without STA. Not a reason to act; the `UserControl` argument stands on
  its own and was acted on elsewhere.)_

### Minor - Consider

- [x] **Three probes for one question** _(decided per site)_. `SourceDirectory`
  routed through the walk; ICU left alone with a reason and LT-22768 (it runs on
  the `CustomIcu.InitIcuDataDir` bootstrap path, so the dependency is an
  initialisation-order question); `StringTable` left alone with a reason and
  LT-22769 (walks to the last "output" segment, feeding a different fallback
  chain).
- [x] **`TidyRootDir`'s doc comment described what it does to its callers**
  _(fixed during review: states its own contract)_.
- [x] **Four comment items narrating removed behaviour or restating names**
  _(fixed during review)_.
- [x] **Temporal framing in the winapp skill doc, and the body naming the wrong
  registry writer** _(fixed during review: `mkall.targets:277` carries a
  `REVIEW (Hasso) 2026.03` saying those targets appear unused, so the body now
  points at the MSI and `Resolve-FieldWorksDevRegistry.ps1`)_.

## Required Validation / Evidence

Run:

- `./build.ps1 -CommentHygiene -BuildTests -SkipNative` — clean, comment-hygiene
  clean.
- `./test.ps1 -CommentHygiene -NoBuild -SkipNative -TestProject FwUtilsTests` —
  413/413 (was 409 before the added layout cases).
- Consumer projects of `SourceDirectory`, which the first pass skipped:
  `XMLViewsTests` 114/114, `DetailControlsTests` 119/120, `xCoreTests` 17/17,
  `LexTextControlsTests` 353/356. The shortfalls are pre-existing ignores at the
  same counts as an unrelated branch.

Ablation sweep, one production change at a time:

| Ablation | Caught by |
| --- | --- |
| Remove the unescaping | `FindDevDistFiles_UnderAPathContainingASpace` |
| Restore the registry's precedence | `CodeAndDataDirectory_PreferSourceTreeOverRegistry("RootDataDir")` |
| `SourceDirectory` returns the wrong directory | 4 tests, including all three layout cases |

Known limits, stated rather than implied:

- `CodeDirectory`/`DataDirectory` read the running assembly, so their unescaping
  is covered through the extracted seam, not end to end. Relocating a running
  assembly is out of reach for a unit test.
- The marker test guards removal of `FieldWorks.sln`; it does not test
  production logic.
- Five of the ten-plus projects consuming `SourceDirectory` were run locally. CI
  covers the rest.
- Not run locally: native tests (no native change), installer validation (no
  installer change).

## Positive Observations

- The original "Paths not taken" section rejected two designs with file counts
  and a call-site count rather than taste.
- Worktree behaviour is correct: the walk stops at the innermost match, so an
  assembly under a nested worktree resolves that worktree's DistFiles.
- Installed-build safety holds. Independently confirmed: nothing in installer or
  patch staging runs the packaged managed binaries from inside the checkout —
  the only executed step, `Remove-StaleDlls.ps1`, reads assembly metadata via
  `AssemblyName.GetAssemblyName()` and never loads them.

## Interview Notes

The author made each scoping decision in session: fix `SourceDirectory` and file
tickets for the other two probe sites; drop `FW_USE_REGISTRY_DIRS`. No author
interview was run in this pass, because the decisions were already recorded and
the one open finding was the reviewer's own verification gap rather than the
author's.

Author challenge worth recording: after being shown a passing test suite, the
author asked whether the testing was actually sound. It was not — see the third
Important finding. The audit that followed produced the ablation sweep above.

Two errors of mine during this pass, both caught before merge:

1. The first space-path test called the walk with an already-clean path, so it
   passed with the fix reverted. Rewritten to drive the derivation.
2. A commit message body line was 81 characters and would have failed
   `Check commit messages`. Amended; that is the one force-push on this branch
   (`2b1098f37` -> `94145a678`, identical tree).

## In-Review Quality Check

`c32048433` adds the `FindSourceDirectory` seam and four tests. Build,
comment-hygiene, `FwUtilsTests` and the four consumer projects were re-run after
it; results above.

## Suggested Review Focus

- [ ] Whether `SourceDirectory` changing resolution strategy is acceptable given
      its ~30 call sites across ten-plus test projects, five of which were
      exercised locally.
- [ ] Whether leaving the ICU probe alone is the right call, or whether
      LT-22768 should block this branch rather than follow it.
- [ ] `ProjectsDirectory`'s behaviour change on machines with no registry value
      — fresh dev boxes, CI agents, containers.
<!-- pr-preflight:summary:end -->

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1093)
<!-- Reviewable:end -->



