### PR TITLE
LT-22691: Open configured context menus from the label and value area

### DIFF
--- a/Src/Common/FwAvalonia/AvaloniaHostControlBase.cs
+++ b/Src/Common/FwAvalonia/AvaloniaHostControlBase.cs
@@ -125,10 +125,17 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 			_companionStrip.Visible = height > 0;
 		}
 
-		public void ShowContextMenu(IReadOnlyList<DetailMenuItem> items)
+		/// <summary>
+		/// Shows a context menu of 'items'.
+		/// </summary>
+		/// <param name="anchor">The control to anchor the menu to.</param>
+		/// <param name="atPointer">True: Open at the pointer location.
+		///                         False: Open under the anchor control.</param>
+		public void ShowContextMenu(IReadOnlyList<DetailMenuItem> items,
+			Avalonia.Controls.Control anchor, bool atPointer)
 		{
-			if (Host.Content is Avalonia.Controls.Control target)
-				DetailMenuFlyout.Show(items, target);
+			var target = anchor ?? Host.Content as Avalonia.Controls.Control;
+			DetailMenuFlyout.Show(items, target, atPointer);
 		}
 
 		public void ShowMessage(string message)

--- a/Src/Common/FwAvalonia/Detail/DataTree.cs
+++ b/Src/Common/FwAvalonia/Detail/DataTree.cs
@@ -288,9 +288,9 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 
 				AutomationProperties.SetAutomationId(header, automationId);
 				AutomationProperties.SetName(header, field.Label ?? string.Empty);
-				// 13.3/13.5: the section menu/hotlinks open from the hover "..." field-menu
-				// button (which
-				// replaced right-click), in a thin gutter to the left of the header.
+				// 13.3/13.5: the header answers right-click with its slice menu; the hover
+				// "..." field-menu button (in a thin gutter to the left of the header)
+				// opens the section menu/hotlinks.
 				var headerCell = WrapWithFieldMenu(header, field, automationId, out var headerKebab);
 
 				// Discoverability parity (legacy SummaryCommandControl): a section header with hotlinks
@@ -357,9 +357,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			AutomationProperties.SetAutomationId(labelBlock, automationId + ".Label");
 			AutomationProperties.SetName(labelBlock, field.Label ?? field.Field ?? string.Empty);
 			ToolTip.SetTip(labelBlock, field.Label ?? field.Field); // 11.17: legacy label tooltips
-			// 13.3: the field's slice menu opens from the hover "..." button in the left gutter
-			// (which
-			// replaced right-click on the label).
+			// 13.3: the field's slice menu opens from a right-click on the label cell
+			// or from the hover "..." button in the left gutter.
 			var labelCell = WrapWithFieldMenu(labelBlock, field, automationId, out var labelKebab);
 			Grid.SetRow(labelCell, row * 2);
 			Grid.SetColumn(labelCell, 0);
@@ -383,14 +382,13 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 				HoverReveal.Attach(hoverSources, provider.HoverAffordances);
 		}
 
-		// The width of the left gutter that holds the per-row field-options "..." button.
-		// Reserved on
-		// every row (when a host bridge is present) so labels align whether or not a row has a menu.
+		// The width of the left gutter holding the per-row field-options "..." button.
+		// Reserved on every row (when a host bridge is present) so labels align whether
+		// or not a row has a menu.
 		private const double FieldMenuGutterWidth = 18;
 
-		// The hover/keyboard-revealed "..." kebab replaces right-click, raising the
-		// same DetailMenuRequest; with no host bridge the content returns unwrapped
-		// so preview/test hosts stay unchanged.
+		// The label cell answers context-menu requests with the row's slice menu; the
+		// kebab opens its own menu or hotlinks. With no host bridge, content is unwrapped.
 		private Control WrapWithFieldMenu(Control inner, DetailField field, string automationId,
 			out Control kebab)
 		{
@@ -421,11 +419,9 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 				// affordance is fully keyboard-operable once Tab focus reveals it.
 				button.Click += (s, e) =>
 				{
-					// Anchor the menu to the icon (drop from its bottom-left) -- the
-					// screen-coordinate
-					// contract the host's DetailMenuRequest handler positions the xCore menu by.
-					var screen = button.PointToScreen(new Point(0, button.Bounds.Height));
-					_menuRequested(new DetailMenuRequest(field, kind, screen.X, screen.Y));
+					// No pointer position is available here, so the menu drops from the
+					// icon rather than from wherever the mouse sits.
+					_menuRequested(DetailMenuRequest.FromAnchor(button, field, kind));
 				};
 				rail.Child = button;
 				kebab = button;
@@ -435,7 +431,21 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			DockPanel.SetDock(rail, Dock.Left);
 			wrapper.Children.Add(rail);
 			wrapper.Children.Add(inner); // fills the width remaining after the gutter
+			WireLabelContextMenu(wrapper, field);
 			return wrapper;
+		}
+
+		/// <summary>
+		/// Wires up the Label context menu for a slice.
+		/// </summary>
+		private void WireLabelContextMenu(Control cell, DetailField field)
+		{
+			cell.AddHandler(Control.ContextRequestedEvent, (s, e) =>
+			{
+				_menuRequested(DetailMenuRequest.FromContextRequested(cell, e, field,
+					DetailMenuKind.SliceMenu));
+				e.Handled = true;
+			}, Avalonia.Interactivity.RoutingStrategies.Bubble);
 		}
 
 		// Legacy command-link blue (SummaryCommandControl LinkLabel) for the inline hotlinks strip.
@@ -470,10 +480,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			ToolTip.SetTip(link, FwAvaloniaStrings.FieldOptionsMenu);
 			link.Click += (s, e) =>
 			{
-				// Anchor the hotlinks menu to the link (drop from its bottom-left), the same
-				// screen-coordinate contract the kebab uses.
-				var screen = link.PointToScreen(new Point(0, link.Bounds.Height));
-				_menuRequested(new DetailMenuRequest(field, DetailMenuKind.Hotlinks, screen.X, screen.Y));
+				// Drops from the link's bottom-left.
+				_menuRequested(DetailMenuRequest.FromAnchor(link, field, DetailMenuKind.Hotlinks));
 			};
 			return link;
 		}

--- a/Src/Common/FwAvalonia/Detail/DetailMenuFlyout.cs
+++ b/Src/Common/FwAvalonia/Detail/DetailMenuFlyout.cs
@@ -63,12 +63,25 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			return flyout;
 		}
 
-		/// <summary>Shows the flyout at the current pointer position over the target control.</summary>
-		public static void Show(IReadOnlyList<DetailMenuItem> items, Control target)
+		/// <summary>
+		/// Shows the flyout over a target control: at the pointer for a right-click, dropped from
+		/// the target when the request carries no pointer position.
+		/// </summary>
+		/// <param name="items">The menu items; null or empty shows nothing.</param>
+		/// <param name="target">The control to open over; null shows nothing.</param>
+		/// <param name="atPointer">False drops the menu from the target's bottom-left corner --
+		/// the context-menu key, Shift+F10, and keyboard button activation.</param>
+		/// <returns>The flyout that was shown, or null when there was nothing to show.</returns>
+		public static MenuFlyout Show(IReadOnlyList<DetailMenuItem> items, Control target,
+			bool atPointer)
 		{
 			if (items == null || items.Count == 0 || target == null)
-				return;
-			Build(items).ShowAt(target, showAtPointer: true);
+				return null;
+			var flyout = Build(items);
+			if (!atPointer)
+				flyout.Placement = PlacementMode.BottomEdgeAlignedLeft;
+			flyout.ShowAt(target, showAtPointer: atPointer);
+			return flyout;
 		}
 
 		private static IEnumerable<Control> CreateControls(IReadOnlyList<DetailMenuItem> items)

--- a/Src/Common/FwAvalonia/Detail/DetailModel.cs
+++ b/Src/Common/FwAvalonia/Detail/DetailModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
 
 namespace SIL.FieldWorks.Common.FwAvalonia.Detail
@@ -1706,13 +1707,13 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		public IReadOnlyList<DetailChooserLink> ChooserLinks { get; }
 	}
 
-	/// <summary>Which legacy menu a right-click maps to.</summary>
+	/// <summary>Which configured menu a context-menu request maps to.</summary>
 	public enum DetailMenuKind
 	{
-		/// <summary>The slice menu (layout `menu=`), legacy right-click on the tree node/label.</summary>
+		/// <summary>The slice menu (layout `menu=`), opened from a row's label.</summary>
 		SliceMenu,
 
-		/// <summary>The in-string menu (`contextMenu=`), legacy right-click inside the value view.</summary>
+		/// <summary>The in-string menu (`contextMenu=`), opened inside a row's value.</summary>
 		ContextMenu,
 
 		/// <summary>The section hotlinks commands.</summary>
@@ -1720,24 +1721,63 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 	}
 
 	/// <summary>
-	/// A request to show a legacy-defined context menu for a detail row: the host
-	/// resolves the menu id against the xCore window configuration and shows the same menu the
-	/// legacy slice shows, at the given screen point, with the row's bound object as command target.
+	/// A request to show a configured context menu for a detail row: the host resolves the menu
+	/// id against the xCore window configuration and shows it with the row's bound object as
+	/// command target.
+	///
+	/// A right-click opens the menu at the pointer. A request with no pointer position (the
+	/// context-menu key, Shift+F10, or activating the field-options button) anchors it under
+	/// <see cref="AnchorControl"/> instead.
 	/// </summary>
 	public sealed class DetailMenuRequest
 	{
-		public DetailMenuRequest(DetailField field, DetailMenuKind kind, int screenX, int screenY)
+		private DetailMenuRequest(DetailField field, DetailMenuKind kind, Control anchorControl,
+			bool openAtPointer)
 		{
 			Field = field;
 			Kind = kind;
-			ScreenX = screenX;
-			ScreenY = screenY;
+			AnchorControl = anchorControl;
+			OpenAtPointer = openAtPointer;
 		}
+
+		/// <summary>
+		/// The request for a ContextRequested event: a right-click opens at the pointer, while
+		/// the context-menu key and Shift+F10 carry none, so the menu anchors under the surface.
+		/// </summary>
+		/// <param name="surface">The control the request arrived on; becomes the anchor.</param>
+		/// <param name="e">Read only for whether it carries a pointer position.</param>
+		/// <param name="field">The row the menu acts on.</param>
+		/// <param name="kind">Which configured menu the request maps to.</param>
+		public static DetailMenuRequest FromContextRequested(Control surface,
+			ContextRequestedEventArgs e, DetailField field, DetailMenuKind kind)
+			=> new DetailMenuRequest(field, kind, surface, e.TryGetPosition(surface, out _));
+
+		/// <summary>
+		/// The request for a pointer-less activation -- a button's mouse or keyboard Click, which
+		/// reports no pointer either way -- so the menu always anchors under the control.
+		/// </summary>
+		/// <param name="anchor">The control to drop the menu from.</param>
+		/// <param name="field">The row the menu acts on.</param>
+		/// <param name="kind">Which configured menu the activation maps to.</param>
+		public static DetailMenuRequest FromAnchor(Control anchor, DetailField field,
+			DetailMenuKind kind)
+			=> new DetailMenuRequest(field, kind, anchor, openAtPointer: false);
 
 		public DetailField Field { get; }
 		public DetailMenuKind Kind { get; }
-		public int ScreenX { get; }
-		public int ScreenY { get; }
+
+		/// <summary>
+		/// The control the request came from; the menu anchors under it when
+		/// <see cref="OpenAtPointer"/> is false. Null when the request had no source control.
+		/// </summary>
+		public Control AnchorControl { get; }
+
+		/// <summary>
+		/// False when the request carried no pointer position (context-menu key, Shift+F10, or
+		/// keyboard activation of the field-options button), which is when the menu anchors to
+		/// <see cref="AnchorControl"/> rather than opening at the pointer.
+		/// </summary>
+		public bool OpenAtPointer { get; }
 	}
 
 	/// <summary>

--- a/Src/Common/FwAvalonia/Detail/FwFieldControls.cs
+++ b/Src/Common/FwAvalonia/Detail/FwFieldControls.cs
@@ -35,9 +35,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 	/// (<see cref="DetailRichTextValue.CanEditRichText"/>); such a value shows the explanatory tooltip
 	/// and stays full-fidelity in the classic view.
 	/// Menus: a row whose layout binds a slice menu (`menu=`, e.g. the Lexeme Form's
-	/// mnuDataTree-LexemeForm with Swap/Convert commands) surfaces it on RIGHT-CLICK only (the
-	/// label/value right-click paths) -- text rows draw NO gear. The gear is reserved for the
-	/// "configure the supporting list" jump on chooser/vector rows; it never opens a menu.
+	/// mnuDataTree-LexemeForm with Swap/Convert commands) surfaces it from the label cell: its
+	/// right-click and its "..." field-options button. A row binding an in-string menu
+	/// (`contextMenu=`) surfaces THAT one here, from the value box. Text rows draw
+	/// NO gear; the gear is reserved for the "configure the supporting list" jump on
+	/// chooser/vector rows and never opens a menu.
 	/// Rich-text operations (character style, per-run writing-system retag, insert/edit external link,
 	/// delete embedded object) are NOT always-visible inline controls: like the legacy detail slice, which
 	/// shows only the abbreviation + value with such operations reached off-row, they are offered as items
@@ -713,6 +715,13 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 					currentRich, !valueIsReadOnly);
 
 				var rowPanel = CreateRowPanel(abbrev, valueContent, showWritingSystemAbbreviation);
+				// The whole row opens the in-string menu. The box's tunnelling handler wins
+				// inside the value.
+				if (hasBridge)
+				{
+					WireInStringContextMenu(rowPanel, field, menuRequested,
+						Avalonia.Interactivity.RoutingStrategies.Bubble);
+				}
 				Children.Add(rowPanel);
 		}
 
@@ -796,30 +805,36 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			var hasBridge = menuRequested != null && !string.IsNullOrEmpty(field.ContextMenuId);
 			if (hasBridge)
 			{
-				EventHandler<PointerPressedEventArgs> menuPressed = (s2, e2) =>
-				{
-					if (!e2.GetCurrentPoint(box).Properties.IsRightButtonPressed)
-						return;
-					var screen = box.PointToScreen(e2.GetPosition(box));
-					menuRequested(new DetailMenuRequest(field, DetailMenuKind.ContextMenu, screen.X, screen.Y));
-					e2.Handled = true;
-				};
-				EventHandler<ContextRequestedEventArgs> swallowContext = (s2, e2) => e2.Handled = true;
-				box.AddHandler(InputElement.PointerPressedEvent, menuPressed,
-					Avalonia.Interactivity.RoutingStrategies.Tunnel);
-				// 15.2: exactly ONE menu -- drop the TextBox flyout (Cut/Copy/Paste,
-				// which opens from ContextRequested on right-button RELEASE) so only the
-				// bridged menu shows; swallow the request so nothing else opens.
+				// 15.2: exactly ONE menu -- drop the TextBox flyout (Cut/Copy/Paste) so
+				// only the bridged menu shows. Tunnelling puts this handler ahead of
+				// anything the box or the whole-row handler would open.
 				box.ContextFlyout = null;
-				box.AddHandler(Control.ContextRequestedEvent, swallowContext,
+				WireInStringContextMenu(box, field, menuRequested,
 					Avalonia.Interactivity.RoutingStrategies.Tunnel);
-				_teardown.Add(() =>
-				{
-					box.RemoveHandler(InputElement.PointerPressedEvent, menuPressed);
-					box.RemoveHandler(Control.ContextRequestedEvent, swallowContext);
-				});
 			}
 			return hasBridge;
+		}
+
+		/// <summary>
+		/// Raises the row's in-string menu request.
+		/// </summary>
+		/// <param name="surface">The region the request is answered on -- the value box or the
+		/// whole row panel; also the anchor a keyboard-raised menu drops from.</param>
+		/// <param name="field">The row supplying the <c>contextMenu=</c> binding.</param>
+		/// <param name="menuRequested">The host bridge that shows the menu.</param>
+		/// <param name="routes">Tunnel puts this ahead of an inner surface's own handler; the
+		/// value box needs it so one right-click raises exactly one request.</param>
+		private void WireInStringContextMenu(Control surface, DetailField field,
+			Action<DetailMenuRequest> menuRequested, Avalonia.Interactivity.RoutingStrategies routes)
+		{
+			EventHandler<ContextRequestedEventArgs> handler = (s, e) =>
+			{
+				menuRequested(DetailMenuRequest.FromContextRequested(surface, e, field,
+					DetailMenuKind.ContextMenu));
+				e.Handled = true;
+			};
+			surface.AddHandler(Control.ContextRequestedEvent, handler, routes);
+			_teardown.Add(() => surface.RemoveHandler(Control.ContextRequestedEvent, handler));
 		}
 
 		private void WireWritingSystemKeyboard(TextBox box, DetailWsValue value,
@@ -932,7 +947,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			return null;
 		}
 
-		/// <summary>Text rows have no hover-revealed affordances (the slice menu is right-click only).</summary>
+		/// <summary>Text rows have no hover-revealed affordances of their own.</summary>
 		public IReadOnlyList<Control> HoverAffordances => Array.Empty<Control>();
 
 		/// <summary>

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailMenuTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailMenuTests.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -99,11 +100,11 @@ namespace FwAvaloniaTests
 	}
 
 	/// <summary>
-	/// Right-click on the Avalonia detail view raises a <see cref="DetailMenuRequest"/>
-	/// through the host bridge with the legacy menu binding and screen coordinates: labels/headers
-	/// raise the slice menu (or hotlinks when only those exist), value boxes with a `contextMenu=`
-	/// binding raise the in-string context menu, and unbound rows raise nothing (they keep the
-	/// local Copy flyout).
+	/// How a detail row's menus are opened, and which menu each input maps to. Every
+	/// row's LABEL cell answers right-click and the keyboard menu key with the slice menu; the
+	/// "..." field-options button raises the row's own menu or hotlinks. A row's VALUE box
+	/// answers the same inputs with the in-string `contextMenu=` menu; an unbound value
+	/// box raises nothing and keeps its local Copy flyout.
 	/// </summary>
 	[TestFixture]
 	public class DetailMenuRequestTests
@@ -121,7 +122,7 @@ namespace FwAvaloniaTests
 				menuId: menuId, contextMenuId: contextMenuId, hotlinksId: hotlinksId,
 				objectHvo: 1234);
 
-		private static (DataTree view, List<DetailMenuRequest> requests) Show(
+		private static (Window window, DataTree view, List<DetailMenuRequest> requests) Show(
 			params DetailField[] fields)
 		{
 			var requests = new List<DetailMenuRequest>();
@@ -131,19 +132,40 @@ namespace FwAvaloniaTests
 			var window = new Window { Content = view, Width = 480, Height = 300 };
 			window.Show();
 			Dispatcher.UIThread.RunJobs();
-			return (view, requests);
+			return (window, view, requests);
 		}
 
-		private static void RightClick(Control control)
+		// Right-click through the real headless input pipeline: the right-button RELEASE
+		// becomes ContextRequested. A null TranslatePoint fails loud so negative tests
+		// cannot pass against a detached target.
+		private static void RightClick(Window window, Control control)
 		{
-			var root = (Visual)control.GetVisualRoot();
-			var position = control.TranslatePoint(new Point(2, 2), root) ?? new Point(0, 0);
-			control.RaiseEvent(new PointerPressedEventArgs(control,
-				new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true),
-				root, position, 0,
-				new PointerPointProperties(RawInputModifiers.RightMouseButton,
-					PointerUpdateKind.RightButtonPressed),
-				KeyModifiers.None));
+			Click(window, control, MouseButton.Right);
+		}
+
+		private static void LeftClick(Window window, Control control)
+		{
+			Click(window, control, MouseButton.Left);
+		}
+
+		private static void Click(Window window, Control control, MouseButton button)
+		{
+			var point = control.TranslatePoint(new Point(2, 2), window);
+			Assert.That(point, Is.Not.Null, "the click target must be attached and laid out");
+			window.MouseDown(point.Value, button);
+			window.MouseUp(point.Value, button);
+			Dispatcher.UIThread.RunJobs();
+		}
+
+		// Control.OnKeyUp raises ContextRequested for the platform's OpenContextMenu
+		// hotkeys. Headless lists Apps and Win32 adds Shift+F10, so Apps covers both;
+		// the RELEASE is the half that fires.
+		private static void PressContextMenuKey(Window window)
+		{
+#pragma warning disable 618 // the Key-based overload avoids the headless physical-key map
+			window.KeyPress(Key.Apps, RawInputModifiers.None);
+			window.KeyRelease(Key.Apps, RawInputModifiers.None);
+#pragma warning restore 618
 			Dispatcher.UIThread.RunJobs();
 		}
 
@@ -167,9 +189,8 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void FieldMenuButton_OnLabelRow_RaisesTheSliceMenuRequest_WithTheLegacyMenuId()
 		{
-			var (view, requests) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+			var (_, view, requests) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
 
-			// The "..." field-options button (which replaced right-click) opens the slice menu.
 			ClickKebab(Find<Button>(view, "Gloss.FieldMenu"));
 
 			Assert.That(requests, Has.Count.EqualTo(1));
@@ -179,25 +200,78 @@ namespace FwAvaloniaTests
 				"the request carries the bound object so command routing can target it");
 		}
 
+		// Right-click and the drop-down icon open the same menu.
 		[AvaloniaTest]
-		public void RightClick_OnLabel_NoLongerRaisesAnyRequest()
+		public void RightClick_OnLabel_RaisesTheSliceMenuRequest()
 		{
-			var (view, requests) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+			var (window, view, requests) = Show(
+				Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
 
-			// The label does not open the menu; the "..." field-options button does.
-			RightClick(Find<TextBlock>(view, "Gloss.Label"));
+			RightClick(window, Find<TextBlock>(view, "Gloss.Label"));
 
-			Assert.That(requests, Is.Empty, "the slice menu now opens only from the field-options button");
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
+			Assert.That(requests[0].Field.MenuId, Is.EqualTo("mnuDataTree-Help"));
+		}
+
+		// The empty gutter beside the label is part of the same cell, so it opens the same
+		// menu rather than being a dead strip.
+		[AvaloniaTest]
+		public void RightClick_OnTheLabelGutter_RaisesTheSameSliceMenuRequest()
+		{
+			var (window, view, requests) = Show(
+				Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+
+			var labelCell = (Control)Find<TextBlock>(view, "Gloss.Label").GetVisualParent();
+			RightClick(window, labelCell);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
+		}
+
+		[AvaloniaTest]
+		public void ContextMenuKey_OnTheFocusedLabelCell_RaisesTheSliceMenuRequest()
+		{
+			var (window, view, requests) = Show(
+				Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+
+			// Tab focus reaches the row through its field-options button; the request is
+			// answered by the label cell that contains it.
+			var kebab = Find<Button>(view, "Gloss.FieldMenu");
+			kebab.Focus();
+			Dispatcher.UIThread.RunJobs();
+			Assert.That(kebab.IsFocused, Is.True, "precondition: the row's affordance has focus");
+
+			PressContextMenuKey(window);
+
+			Assert.That(requests, Has.Count.EqualTo(1),
+				"the keyboard menu key opens the same menu right-click does");
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
+		}
+
+		// A header's right-click ignores hotlinks= and opens the slice menu (the shared
+		// object group); the hotlinks stay on the kebab and the inline strip.
+		[AvaloniaTest]
+		public void RightClick_OnASectionHeader_RaisesTheSliceMenuRequest()
+		{
+			var (window, view, requests) = Show(
+				Field("Senses", DetailFieldKind.Header, hotlinksId: "mnuDataTree-Sense-Hotlinks",
+					collapsible: true));
+
+			RightClick(window, Find<Button>(view, "Senses"));
+
+			Assert.That(requests, Has.Count.EqualTo(1),
+				"a header row answers right-click like any other row");
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
 		}
 
 		[AvaloniaTest]
 		public void RightClick_OnValueBox_WithContextMenuBinding_RaisesTheContextMenuRequest()
 		{
-			var (view, requests) = Show(Field("CitationForm", DetailFieldKind.Text,
+			var (window, view, requests) = Show(Field("CitationForm", DetailFieldKind.Text,
 				menuId: "mnuDataTree-Help", contextMenuId: "mnuDataTree-CitationFormContext"));
 
-			var box = view.GetVisualDescendants().OfType<TextBox>().First();
-			RightClick(box);
+			RightClick(window, view.GetVisualDescendants().OfType<TextBox>().First());
 
 			Assert.That(requests, Has.Count.EqualTo(1));
 			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ContextMenu),
@@ -205,10 +279,180 @@ namespace FwAvaloniaTests
 			Assert.That(requests[0].Field.ContextMenuId, Is.EqualTo("mnuDataTree-CitationFormContext"));
 		}
 
+		// The whole value row takes the right-click, including the per-writing-system
+		// abbreviation gutter, which shows the same menu the value text does.
+		[AvaloniaTest]
+		public void RightClick_OnTheWritingSystemAbbreviation_RaisesTheSameContextMenuRequest()
+		{
+			var (window, view, requests) = Show(Field("LexemeForm", DetailFieldKind.Text,
+				menuId: "mnuDataTree-LexemeForm", contextMenuId: "mnuDataTree-LexemeFormContext"));
+
+			var abbrev = view.GetVisualDescendants().OfType<TextBlock>()
+				.First(t => t.Text == "en");
+			RightClick(window, abbrev);
+
+			Assert.That(requests, Has.Count.EqualTo(1),
+				"the abbreviation gutter is part of the value row, not a dead strip");
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ContextMenu));
+			Assert.That(requests[0].Field.ContextMenuId, Is.EqualTo("mnuDataTree-LexemeFormContext"));
+		}
+
+		// One right-click must never raise two requests: the value box tunnels ahead of the
+		// row handler.
+		[AvaloniaTest]
+		public void RightClick_InTheValue_RaisesExactlyOneRequest_NotAlsoTheRowHandler()
+		{
+			var (window, view, requests) = Show(Field("LexemeForm", DetailFieldKind.Text,
+				menuId: "mnuDataTree-LexemeForm", contextMenuId: "mnuDataTree-LexemeFormContext"));
+
+			RightClick(window, view.GetVisualDescendants().OfType<TextBox>().First());
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+		}
+
+		[AvaloniaTest]
+		public void ContextMenuKey_InTheValueBox_RaisesTheContextMenuRequest()
+		{
+			var (window, view, requests) = Show(Field("CitationForm", DetailFieldKind.Text,
+				menuId: "mnuDataTree-Help", contextMenuId: "mnuDataTree-CitationFormContext"));
+
+			var box = view.GetVisualDescendants().OfType<TextBox>().First();
+			box.Focus();
+			Dispatcher.UIThread.RunJobs();
+
+			PressContextMenuKey(window);
+
+			Assert.That(requests, Has.Count.EqualTo(1),
+				"the keyboard menu key works inside the value");
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ContextMenu));
+		}
+
+		// A keyboard-opened menu anchors to the field rather than to the last mouse
+		// position; a right-click still opens at the pointer.
+		[AvaloniaTest]
+		public void RightClick_OpensAtThePointer_AnchoredAtTheControlItCameFrom()
+		{
+			var (window, view, requests) = Show(Field("CitationForm", DetailFieldKind.Text,
+				contextMenuId: "mnuDataTree-CitationFormContext"));
+
+			var box = view.GetVisualDescendants().OfType<TextBox>().First();
+			RightClick(window, box);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].OpenAtPointer, Is.True, "right-click opens at the pointer");
+			Assert.That(requests[0].AnchorControl, Is.SameAs(box));
+		}
+
+		[AvaloniaTest]
+		public void ContextMenuKey_InTheValueBox_AnchorsToTheEditField_NotThePointer()
+		{
+			var (window, view, requests) = Show(Field("CitationForm", DetailFieldKind.Text,
+				contextMenuId: "mnuDataTree-CitationFormContext"));
+
+			var box = view.GetVisualDescendants().OfType<TextBox>().First();
+			box.Focus();
+			Dispatcher.UIThread.RunJobs();
+
+			PressContextMenuKey(window);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].OpenAtPointer, Is.False,
+				"a keyboard-opened menu carries no pointer position");
+			Assert.That(requests[0].AnchorControl, Is.SameAs(box),
+				"the menu anchors to the edit field the user is on");
+		}
+
+		[AvaloniaTest]
+		public void ContextMenuKey_OnTheLabelCell_AnchorsToThatCell()
+		{
+			var (window, view, requests) = Show(
+				Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+
+			var kebab = Find<Button>(view, "Gloss.FieldMenu");
+			kebab.Focus();
+			Dispatcher.UIThread.RunJobs();
+
+			PressContextMenuKey(window);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].OpenAtPointer, Is.False);
+			Assert.That(requests[0].AnchorControl, Is.Not.Null,
+				"the label cell is the anchor for a keyboard-opened menu on the row");
+		}
+
+		// The field-options button opens on mouse click AND on Enter/Space, and Button.Click
+		// carries no pointer either way, so it always drops from the icon, not the mouse.
+		[AvaloniaTest]
+		public void FieldMenuButton_AlwaysAnchorsToTheButton()
+		{
+			var (_, view, requests) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+
+			var kebab = Find<Button>(view, "Gloss.FieldMenu");
+			ClickKebab(kebab);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].OpenAtPointer, Is.False);
+			Assert.That(requests[0].AnchorControl, Is.SameAs(kebab));
+		}
+
+		// The flyout-level half of the same contract: anchored placement drops the menu from the
+		// target's bottom-left, pointer placement leaves the framework default alone.
+		[AvaloniaTest]
+		public void DetailMenuFlyout_AnchoredPlacement_DropsFromTheTargetsBottomLeft()
+		{
+			var items = new List<DetailMenuItem> { new DetailMenuItem("Show in Concordance") };
+			var target = new Button { Content = "field" };
+			var window = new Window { Content = target, Width = 300, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			var anchored = DetailMenuFlyout.Show(items, target, atPointer: false);
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(anchored, Is.Not.Null);
+			Assert.That(anchored.Placement, Is.EqualTo(PlacementMode.BottomEdgeAlignedLeft),
+				"a keyboard-invoked menu drops from the field, not from the pointer");
+		}
+
+		[AvaloniaTest]
+		public void DetailMenuFlyout_PointerPlacement_LeavesTheDefault()
+		{
+			var items = new List<DetailMenuItem> { new DetailMenuItem("Show in Concordance") };
+			var target = new Button { Content = "field" };
+			var window = new Window { Content = target, Width = 300, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			var atPointer = DetailMenuFlyout.Show(items, target, atPointer: true);
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(atPointer, Is.Not.Null);
+			Assert.That(atPointer.Placement, Is.Not.EqualTo(PlacementMode.BottomEdgeAlignedLeft),
+				"a mouse-invoked menu still opens at the pointer");
+		}
+
+		// The two menus are DISTINCT: the label opens the slice menu, the value opens the
+		// in-string menu. Neither input may produce the other's menu.
+		[AvaloniaTest]
+		public void LabelAndValue_RaiseTheirOwnDistinctMenus()
+		{
+			var (window, view, requests) = Show(Field("LexemeForm", DetailFieldKind.Text,
+				menuId: "mnuDataTree-LexemeForm", contextMenuId: "mnuDataTree-LexemeFormContext"));
+
+			RightClick(window, Find<TextBlock>(view, "LexemeForm.Label"));
+			RightClick(window, view.GetVisualDescendants().OfType<TextBox>().First());
+
+			Assert.That(requests.Select(r => r.Kind), Is.EqualTo(new[]
+			{
+				DetailMenuKind.SliceMenu,
+				DetailMenuKind.ContextMenu
+			}));
+		}
+
 		[AvaloniaTest]
 		public void FieldMenuButton_OnHotlinksOnlyHeader_RaisesTheHotlinksRequest()
 		{
-			var (view, requests) = Show(Field("Senses", DetailFieldKind.Header,
+			var (_, view, requests) = Show(Field("Senses", DetailFieldKind.Header,
 				hotlinksId: "mnuDataTree-Sense-Hotlinks", collapsible: true));
 
 			// The header's "..." button raises the hotlinks request; the collapsible toggle (id
@@ -228,7 +472,7 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void HotlinksStrip_AppearsForHotlinkHeader_IsAlwaysVisible_AndKeepsTheKebab()
 		{
-			var (view, _) = Show(Field("Senses", DetailFieldKind.Header,
+			var (_, view, _) = Show(Field("Senses", DetailFieldKind.Header,
 				hotlinksId: "mnuDataTree-Sense-Hotlinks", collapsible: true));
 
 			var strip = FindOrNull<Button>(view, "Senses.Hotlinks");
@@ -250,7 +494,7 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void HotlinksStrip_Activating_RaisesTheSameHotlinksRequest_AsTheKebab()
 		{
-			var (view, requests) = Show(Field("Senses", DetailFieldKind.Header,
+			var (_, view, requests) = Show(Field("Senses", DetailFieldKind.Header,
 				hotlinksId: "mnuDataTree-Sense-Hotlinks", collapsible: true));
 
 			// Activating the strip arrives as Button.Click (mouse OR keyboard), the same path the kebab uses.
@@ -265,7 +509,7 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void HotlinksStrip_IsAbsent_ForHeaderWithoutHotlinks()
 		{
-			var (view, _) = Show(Field("Notes", DetailFieldKind.Header, menuId: "mnuDataTree-Object"));
+			var (_, view, _) = Show(Field("Notes", DetailFieldKind.Header, menuId: "mnuDataTree-Object"));
 
 			Assert.That(FindOrNull<Button>(view, "Notes.Hotlinks"), Is.Null,
 				"a header carrying only a slice menu (no hotlinks) gets no inline command strip");
@@ -277,27 +521,33 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void BridgedValueBox_DropsTheThemeFlyout_UnboundKeepsCopy()
 		{
-			var (boundView, _) = Show(Field("CitationForm", DetailFieldKind.Text,
+			var (_, boundView, _) = Show(Field("CitationForm", DetailFieldKind.Text,
 				contextMenuId: "mnuDataTree-CitationFormContext"));
 			var boundBox = boundView.GetVisualDescendants().OfType<TextBox>().First();
 			Assert.That(boundBox.ContextFlyout, Is.Null,
 				"a bridged box must not raise a second (built-in) menu");
 
-			var (plainView, _) = Show(Field("Comment", DetailFieldKind.Text));
+			var (_, plainView, _) = Show(Field("Comment", DetailFieldKind.Text));
 			var plainBox = plainView.GetVisualDescendants().OfType<TextBox>().First();
 			Assert.That(plainBox.ContextFlyout, Is.Not.Null, "unbound rows keep the local Copy flyout");
 		}
 
 		[AvaloniaTest]
-		public void RightClick_OnUnboundRow_RaisesNoRequest()
+		public void RightClick_OnUnboundRow_LabelRaisesTheSliceMenu_ValueRaisesNothing()
 		{
-			var (view, requests) = Show(Field("Comment", DetailFieldKind.Text));
+			var (window, view, requests) = Show(Field("Comment", DetailFieldKind.Text));
 
-			RightClick(Find<TextBlock>(view, "Comment.Label"));
-			RightClick(view.GetVisualDescendants().OfType<TextBox>().First());
+			// A label right-click opens the shared object menu (Field Visibility / Move
+			// Field / Help) even when the row binds no menu=.
+			RightClick(window, Find<TextBlock>(view, "Comment.Label"));
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
 
-			Assert.That(requests, Is.Empty,
-				"rows without a legacy menu binding keep local behavior (Copy flyout) only");
+			// The value box of a row without a contextMenu= binding keeps its local
+			// Copy flyout only.
+			RightClick(window, view.GetVisualDescendants().OfType<TextBox>().First());
+			Assert.That(requests, Has.Count.EqualTo(1),
+				"an unbound value box raises no host menu request");
 			Assert.That(FindOrNull<Button>(view, "Comment.FieldMenu"), Is.Null,
 				"a row with no menu/hotlinks binding gets no field-options button");
 		}
@@ -305,7 +555,7 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void FieldMenuButton_IsHiddenAtRest_RevealedOnHover_AndKeyboardAddressable()
 		{
-			var (view, _) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+			var (_, view, _) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
 
 			var kebab = Find<Button>(view, "Gloss.FieldMenu");
 			// Accessibility: a localized name so a screen reader announces the affordance.
@@ -396,18 +646,10 @@ namespace FwAvaloniaTests
 		[AvaloniaTest]
 		public void LeftClick_OnBoundLabel_RaisesNoRequest()
 		{
-			var (view, requests) = Show(Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
+			var (window, view, requests) = Show(
+				Field("Gloss", DetailFieldKind.Text, menuId: "mnuDataTree-Help"));
 
-			var label = Find<TextBlock>(view, "Gloss.Label");
-			var root = (Visual)label.GetVisualRoot();
-			var position = label.TranslatePoint(new Point(2, 2), root) ?? new Point(0, 0);
-			label.RaiseEvent(new PointerPressedEventArgs(label,
-				new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true),
-				root, position, 0,
-				new PointerPointProperties(RawInputModifiers.LeftMouseButton,
-					PointerUpdateKind.LeftButtonPressed),
-				KeyModifiers.None));
-			Dispatcher.UIThread.RunJobs();
+			LeftClick(window, Find<TextBlock>(view, "Gloss.Label"));
 
 			Assert.That(requests, Is.Empty, "only the right button opens the slice menu, like legacy");
 		}

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -389,17 +389,6 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 
-		/// <summary>
-		/// Shows the SAME xCore-defined context menu the legacy slice shows, over the
-		/// Avalonia detail view -- the menu ids come from the layout (imported into the typed IR), the menu
-		/// is materialized from the window configuration and dispatched through the mediator,
-		/// exactly
-		/// the legacy `DTMenuHandler.MakeSliceContextMenu` recipe (menu + mnuDataTree-Object; in-string
-		/// menus add mnuDataTree-MultiStringSlice). Command targeting uses the approved baseline
-		/// adapter "command-menu-routing": the legacy DataTree + DTMenuHandler are initialized lazily and
-		/// kept HIDDEN purely as the command-target colleague chain, with CurrentSlice pointed at the
-		/// slice bound to the clicked row's object -- never shown, never active.
-		/// </summary>
 		/// <summary>The shared per-object menu group (Field Visibility / Move Field / Help).</summary>
 		internal const string ObjectMenuId = "mnuDataTree-Object";
 
@@ -410,25 +399,34 @@ namespace SIL.FieldWorks.XWorks
 		internal const string MultiStringSliceMenuId = "mnuDataTree-MultiStringSlice";
 
 		/// <summary>
-		/// Composes the ordered menu-id list for an in-string right-click, mirroring the legacy
-		/// <c>DTMenuHandler.MakeSliceContextMenu</c> recipe: the field's own context menu, then
-		/// <see cref="MultiStringSliceMenuId"/> only for a multistring row, then
-		/// <see cref="ObjectMenuId"/> only when NEITHER shared group is already present. Both
-		/// mnuDataTree-MultiStringSlice and mnuDataTree-Object independently define Field Visibility /
-		/// Move Field / Help, so adding both would show that group twice; this guard adds exactly one.
-		/// Empty ids are dropped. Kept internal-static so the composition is unit-testable without a
-		/// live window.
+		/// Composes the ordered menu-id list for a row's SLICE menu (label right-click and the
+		/// field-options button): the row's own <c>menu=</c> binding, then exactly ONE shared
+		/// trailing group. Both shared menus define Field Visibility / Move Field / Help, so
+		/// adding both would show that group twice. Section hotlinks never join this menu; they
+		/// stay on their own affordance. Internal-static so the composition is unit-testable
+		/// without a live window.
 		/// </summary>
-		internal static IReadOnlyList<string> ComposeContextMenuIds(string fieldContextMenuId,
+		internal static IReadOnlyList<string> ComposeSliceMenuIds(string fieldMenuId,
 			bool isMultiStringRow)
+		{
+			var menus = new List<string>();
+			if (!string.IsNullOrEmpty(fieldMenuId))
+				menus.Add(fieldMenuId);
+			// Exactly one shared group, whichever route put it there: a row whose own binding IS
+			// one of the two already carries it.
+			if (menus.TrueForAll(id => id != MultiStringSliceMenuId && id != ObjectMenuId))
+				menus.Add(isMultiStringRow ? MultiStringSliceMenuId : ObjectMenuId);
+			return menus;
+		}
+
+		/// <summary>
+		/// Composes the menu-id list for an IN-STRING right-click (inside a row's value).
+		/// </summary>
+		internal static IReadOnlyList<string> ComposeInStringMenuIds(string fieldContextMenuId)
 		{
 			var menus = new List<string>();
 			if (!string.IsNullOrEmpty(fieldContextMenuId))
 				menus.Add(fieldContextMenuId);
-			if (isMultiStringRow)
-				menus.Add(MultiStringSliceMenuId);
-			if (menus.TrueForAll(id => id != MultiStringSliceMenuId && id != ObjectMenuId))
-				menus.Add(ObjectMenuId);
 			return menus;
 		}
 
@@ -452,17 +450,14 @@ namespace SIL.FieldWorks.XWorks
 				switch (request.Kind)
 				{
 					case DetailMenuKind.ContextMenu:
-						ids.AddRange(ComposeContextMenuIds(request.Field.ContextMenuId,
-							request.Field.IsMultiStringRow));
+						ids.AddRange(ComposeInStringMenuIds(request.Field.ContextMenuId));
 						break;
 					case DetailMenuKind.Hotlinks:
 						ids.Add(request.Field.HotlinksId);
 						break;
 					default:
-						ids.Add(request.Field.MenuId);
-						if (!string.IsNullOrEmpty(request.Field.HotlinksId))
-							ids.Add(request.Field.HotlinksId); // section link commands stay reachable
-						ids.Add(ObjectMenuId);
+						ids.AddRange(ComposeSliceMenuIds(request.Field.MenuId,
+							request.Field.IsMultiStringRow));
 						break;
 				}
 
@@ -481,7 +476,10 @@ namespace SIL.FieldWorks.XWorks
 					var items = XCoreMenuBridge.CreateMenuItems(window, idArray, interceptor);
 					if (items.Count > 0)
 					{
-						m_avaloniaEntryForm.ShowContextMenu(items);
+						// A keyboard-opened menu anchors under the row it came from; a
+						// right-click opens it at the pointer.
+						m_avaloniaEntryForm.ShowContextMenu(items, request.AnchorControl,
+							request.OpenAtPointer);
 						return;
 					}
 				}
@@ -491,13 +489,27 @@ namespace SIL.FieldWorks.XWorks
 						nativeMenuError);
 				}
 
-				window.ShowContextMenu(idArray,
-					new System.Drawing.Point(request.ScreenX, request.ScreenY), null, null);
+				window.ShowContextMenu(idArray, AdapterMenuScreenPoint(request), null, null);
 			}
 			catch (Exception e)
 			{
 				Logger.WriteError("Detail context menu failed.", e);
 			}
+		}
+
+		// The adapter fallback needs a raw screen point: cursor position for a right-click,
+		// the anchor's bottom-left otherwise. Both corners are mapped since
+		// RTL flow mirrors X in PointToScreen.
+		private static System.Drawing.Point AdapterMenuScreenPoint(DetailMenuRequest request)
+		{
+			var anchor = request.AnchorControl;
+			if (request.OpenAtPointer || anchor == null)
+				return System.Windows.Forms.Cursor.Position;
+			var left = Avalonia.VisualExtensions.PointToScreen(anchor,
+				new Avalonia.Point(0, anchor.Bounds.Height));
+			var right = Avalonia.VisualExtensions.PointToScreen(anchor,
+				new Avalonia.Point(anchor.Bounds.Width, anchor.Bounds.Height));
+			return new System.Drawing.Point(Math.Min(left.X, right.X), left.Y);
 		}
 
 		// The per-(class, layout) override file lives in this project's

--- a/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
+++ b/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
@@ -66,6 +66,15 @@ namespace SIL.FieldWorks.XWorks
 					var children = Convert(submenu, interceptor);
 					if (children.Count == 0)
 						continue;
+
+					// An inline choice list is a population rule, not a level of menu, and
+					// reports itself invisible: splice its items rather than nesting them.
+					if (submenu.IsInlineChoiceList)
+					{
+						items.AddRange(children);
+						continue;
+					}
+
 					var display = submenu.GetDisplayProperties();
 					if (!display.Visible)
 						continue;

--- a/Src/xWorks/xWorksTests/Avalonia/Composer/DetailEditContextEditingTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Composer/DetailEditContextEditingTests.cs
@@ -512,6 +512,44 @@ namespace SIL.FieldWorks.XWorks
 				"the in-string context menu binding survives alongside");
 		}
 
+		// The two inputs show different menus: the label merges the multistring group, which
+		// is where Writing Systems lives, and the value area shows the contextMenu binding alone.
+		[Test]
+		public void Compose_LexemeFormRow_FeedsTheTwoMenus_WithWritingSystemsOnTheSliceMenuOnly()
+		{
+			var composed = DetailComposer.Compose(m_entry, Cache);
+			var lexemeForm = composed.Model.Fields.Single(f => f.Field == "Form"
+				&& f.Kind == DetailFieldKind.Text && f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+
+			Assert.That(lexemeForm.IsMultiStringRow, Is.True,
+				"editor=\"multistring\" is what the menu merge keys on");
+
+			var sliceMenuIds = RecordEditView.ComposeSliceMenuIds(lexemeForm.MenuId,
+				lexemeForm.IsMultiStringRow);
+			Assert.That(sliceMenuIds, Is.EqualTo(new[]
+			{
+				"mnuDataTree-LexemeForm",
+				RecordEditView.MultiStringSliceMenuId
+			}), "the label menu is the row's own menu plus the multistring group");
+
+			var inStringMenuIds = RecordEditView.ComposeInStringMenuIds(lexemeForm.ContextMenuId);
+			Assert.That(inStringMenuIds, Is.EqualTo(new[] { "mnuDataTree-LexemeFormContext" }),
+				"the value menu is the contextMenu binding alone");
+
+			// Only mnuDataTree-MultiStringSlice defines the Writing Systems submenu, so it must
+			// reach the label menu and must NOT reach the value menu.
+			var commonInclude = System.IO.Path.Combine(
+				SIL.FieldWorks.Common.FwUtils.FwDirectoryFinder.GetCodeSubDirectory(
+					@"Language Explorer\Configuration"),
+				"CommonDataTreeInclude.xml");
+			var multiStringGroup = System.Xml.Linq.XDocument.Load(commonInclude).Descendants("menu")
+				.First(m => (string)m.Attribute("id") == RecordEditView.MultiStringSliceMenuId);
+			Assert.That(multiStringGroup.Elements("menu")
+					.Select(m => (string)m.Attribute("id")),
+				Does.Contain("DataTree-WritingSystemsMenu"),
+				"the multistring group is the one that carries Writing Systems");
+		}
+
 		[Test]
 		public void Compose_RichTextReplacement_PreservesStringTableLabels_AndFwAvaloniaMessageLane()
 		{

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailContextMenuCompositionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailContextMenuCompositionTests.cs
@@ -8,71 +8,107 @@ using NUnit.Framework;
 namespace SIL.FieldWorks.XWorks
 {
 	/// <summary>
-	/// Locks the in-string right-click menu-id composition (<see cref="RecordEditView.ComposeContextMenuIds"/>)
-	/// against the legacy <c>DTMenuHandler.MakeSliceContextMenu</c> recipe. Both
-	/// mnuDataTree-MultiStringSlice and mnuDataTree-Object independently define the shared
-	/// Field Visibility / Move Field / Help group, so composing BOTH source menus makes that group
-	/// appear twice on a bridged row. These tests prove the composition adds at most one of the two.
+	/// Locks the two menu-id compositions, which stay separate. A row's slice menu
+	/// (<see cref="RecordEditView.ComposeSliceMenuIds"/>) is the row's own menu plus exactly one
+	/// shared trailing group; its in-string menu
+	/// (<see cref="RecordEditView.ComposeInStringMenuIds"/>) is the contextMenu binding alone.
+	/// The shared group belongs only to the former.
 	/// </summary>
 	[TestFixture]
 	public class DetailContextMenuCompositionTests
 	{
-		[Test]
-		public void MultiStringRow_AddsMultiStringSliceButNotObject()
-		{
-			var ids = RecordEditView.ComposeContextMenuIds("mnuDataTree-CitationFormContext",
-				isMultiStringRow: true);
+		// The Lexeme Form row's bindings (MorphologyParts.xml, MoForm-Detail-AsLexemeForm).
+		private const string LexemeFormMenu = "mnuDataTree-LexemeForm";
+		private const string LexemeFormContextMenu = "mnuDataTree-LexemeFormContext";
 
-			// The multistring slice group carries the Writing Systems submenu plus the shared
-			// Field Visibility / Move Field / Help leaves, so mnuDataTree-Object must NOT also be added
-			// (that would double the shared group).
-			Assert.That(ids, Is.EqualTo(new[]
-			{
-				"mnuDataTree-CitationFormContext",
-				RecordEditView.MultiStringSliceMenuId
-			}));
+		[Test]
+		public void SliceMenu_ForAMultiStringRow_AddsTheMultiStringGroup_NotTheObjectGroup()
+		{
+			var ids = RecordEditView.ComposeSliceMenuIds(LexemeFormMenu, isMultiStringRow: true);
+
+			// Only mnuDataTree-MultiStringSlice carries the Writing Systems submenu; composing
+			// mnuDataTree-Object here would drop Writing Systems off the slice menu.
+			Assert.That(ids, Is.EqualTo(new[] { LexemeFormMenu, RecordEditView.MultiStringSliceMenuId }));
 			Assert.That(ids, Has.No.Member(RecordEditView.ObjectMenuId),
-				"A multistring row must not add mnuDataTree-Object on top of mnuDataTree-MultiStringSlice: "
-				+ "both define Field Visibility / Move Field / Help, so the group would appear twice.");
+				"both shared menus define Field Visibility / Move Field / Help, so adding both doubles it");
 		}
 
 		[Test]
-		public void SingleStringRow_AddsObjectButNotMultiStringSlice()
+		public void SliceMenu_ForASingleStringRow_AddsTheObjectGroup()
 		{
-			var ids = RecordEditView.ComposeContextMenuIds("mnuDataTree-CitationFormContext",
-				isMultiStringRow: false);
+			var ids = RecordEditView.ComposeSliceMenuIds("mnuDataTree-Help", isMultiStringRow: false);
 
-			Assert.That(ids, Is.EqualTo(new[]
-			{
-				"mnuDataTree-CitationFormContext",
-				RecordEditView.ObjectMenuId
-			}));
+			Assert.That(ids, Is.EqualTo(new[] { "mnuDataTree-Help", RecordEditView.ObjectMenuId }));
 			Assert.That(ids, Has.No.Member(RecordEditView.MultiStringSliceMenuId));
 		}
 
 		[Test]
-		public void SharedSliceGroupSourceMenus_AreNeverBothPresent()
+		public void SliceMenu_ForAnUnboundRow_IsTheSharedObjectGroupAlone()
 		{
-			// The defect: a bridged multistring row composing BOTH shared source menus. Whatever the
-			// row kind, the two menus that carry the shared group must never both appear.
-			foreach (var isMultiString in new[] { true, false })
+			// A row with no menu= binding still composes mnuDataTree-Object, so Field
+			// Visibility / Move Field / Help stay reachable on every row.
+			Assert.That(RecordEditView.ComposeSliceMenuIds(null, isMultiStringRow: false),
+				Is.EqualTo(new[] { RecordEditView.ObjectMenuId }));
+			Assert.That(RecordEditView.ComposeSliceMenuIds(string.Empty, isMultiStringRow: false),
+				Is.EqualTo(new[] { RecordEditView.ObjectMenuId }));
+		}
+
+		// Every binding a row can carry, including a row bound directly to one of the two shared
+		// menus, which already supplies the group its own way.
+		[Test]
+		public void SliceMenu_NeverCarriesBothSharedGroupSources()
+		{
+			var bindings = new[]
 			{
-				var ids = RecordEditView.ComposeContextMenuIds("mnuDataTree-CitationFormContext",
-					isMultiString);
-				var sharedGroupSources = ids.Count(id =>
-					id == RecordEditView.MultiStringSliceMenuId || id == RecordEditView.ObjectMenuId);
-				Assert.That(sharedGroupSources, Is.EqualTo(1),
-					$"Exactly one shared-group source menu must be present (isMultiStringRow={isMultiString}); "
-					+ "adding both doubles the Field Visibility / Move Field / Help group.");
+				LexemeFormMenu, null, string.Empty,
+				RecordEditView.ObjectMenuId, RecordEditView.MultiStringSliceMenuId
+			};
+			foreach (var binding in bindings)
+			{
+				foreach (var isMultiString in new[] { true, false })
+				{
+					var ids = RecordEditView.ComposeSliceMenuIds(binding, isMultiString);
+					var sharedGroupSources = ids.Count(id =>
+						id == RecordEditView.MultiStringSliceMenuId || id == RecordEditView.ObjectMenuId);
+					Assert.That(sharedGroupSources, Is.EqualTo(1),
+						$"exactly one shared-group source must be present (menu={binding ?? "<null>"}, "
+						+ $"isMultiStringRow={isMultiString})");
+				}
 			}
 		}
 
 		[Test]
-		public void EmptyFieldContextMenuId_IsDropped()
+		public void SliceMenu_WithAnExplicitObjectBinding_DoesNotRepeatIt()
 		{
-			var ids = RecordEditView.ComposeContextMenuIds(null, isMultiStringRow: false);
+			// Even on a multistring row: the row's own binding already carries the shared group,
+			// so the multistring group must not be appended on top of it.
+			Assert.That(RecordEditView.ComposeSliceMenuIds(RecordEditView.ObjectMenuId,
+					isMultiStringRow: false),
+				Is.EqualTo(new[] { RecordEditView.ObjectMenuId }));
+			Assert.That(RecordEditView.ComposeSliceMenuIds(RecordEditView.ObjectMenuId,
+					isMultiStringRow: true),
+				Is.EqualTo(new[] { RecordEditView.ObjectMenuId }));
+		}
 
-			Assert.That(ids, Is.EqualTo(new[] { RecordEditView.ObjectMenuId }));
+		[Test]
+		public void InStringMenu_IsTheContextBindingAlone_EvenOnAMultiStringRow()
+		{
+			var ids = RecordEditView.ComposeInStringMenuIds(LexemeFormContextMenu);
+
+			// A single menu id, so the Lexeme Form value area shows exactly its two
+			// Concordance commands -- no shared group.
+			Assert.That(ids, Is.EqualTo(new[] { LexemeFormContextMenu }));
+			Assert.That(ids, Has.No.Member(RecordEditView.MultiStringSliceMenuId));
+			Assert.That(ids, Has.No.Member(RecordEditView.ObjectMenuId));
+		}
+
+		[Test]
+		public void InStringMenu_IsEmpty_WhenTheRowHasNoContextBinding()
+		{
+			// An unbound value box keeps its own local menu; it must not fall back to the
+			// slice menu.
+			Assert.That(RecordEditView.ComposeInStringMenuIds(null), Is.Empty);
+			Assert.That(RecordEditView.ComposeInStringMenuIds(string.Empty), Is.Empty);
 		}
 	}
 }

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -331,6 +331,38 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(jump.Execute, Is.Not.Null, "and it carries a mediator-dispatch action");
 		}
 
+		// The writing-system entries come from an inline list group: they need the Form slice
+		// targeted and the group spliced into its parent.
+		[Test]
+		public void LexemeFormSliceMenu_WritingSystemsSubmenu_ListsTheProjectWritingSystems()
+		{
+			EnsureAdapter(m_entry.LexemeFormOA.Hvo, "Form");
+			var items = BuildItems(new[] { "mnuDataTree-LexemeForm", "mnuDataTree-MultiStringSlice" });
+
+			var writingSystems = FindItem(items, "Writing Systems");
+			Assert.That(writingSystems, Is.Not.Null,
+				"the multistring group contributes the Writing Systems submenu");
+
+			var labels = writingSystems.Children.Where(c => !c.IsSeparator).Select(c => c.Label).ToList();
+			Assert.That(labels, Does.Contain("Show all right now"));
+			Assert.That(labels, Does.Contain("Configure..."));
+
+			// Both commands are handled by the slice, so they enable only once it is
+			// reachable through the colleague chain.
+			Assert.That(FindItem(items, "Show all right now").IsEnabled, Is.True);
+			Assert.That(FindItem(items, "Configure...").IsEnabled, Is.True);
+
+			// The inline list splices the slice's own writing systems between the two commands.
+			var spliced = labels.Where(l => l != "Show all right now" && l != "Configure...").ToList();
+			Assert.That(spliced, Is.Not.Empty,
+				"the inline list group must contribute the slice's writing systems, not be nested away");
+
+			var vernacular = Cache.LangProject.CurrentVernacularWritingSystems
+				.Select(ws => ws.DisplayLabel).ToList();
+			Assert.That(spliced.Intersect(vernacular), Is.Not.Empty,
+				"the spliced entries are the project's vernacular writing systems (the Lexeme Form's ws set)");
+		}
+
 		// -----------------------------------------------------------------
 		// Helpers -- production-path command drivers
 		// -----------------------------------------------------------------


### PR DESCRIPTION
The Avalonia detail view now answers a right-click and the keyboard menu key on every row, showing the two menus its layout defines and keeping them distinct:

- A row's label cell, and a section header, answer right-click with the slice menu. The "..." field-options button still opens the row's own menu.
- A row's value box answers the same inputs with the in-string contextMenu= menu, including a right-click on the writing-system abbreviation gutter.
- ComposeSliceMenuIds and ComposeInStringMenuIds keep the two compositions apart: the slice menu is the row's menu= plus exactly one shared trailing group (the object group alone when a row binds no menu=), while the value menu is the contextMenu= binding alone. Section hotlinks stay on their own affordance.
- XCoreMenuBridge splices inline choice lists, so the Writing Systems entries appear instead of being dropped as an invisible submenu.
- A menu opened without a pointer position anchors under the field it came from rather than at the last pointer position; a right-click still opens at the pointer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1094)
<!-- Reviewable:end -->

