### PR TITLE
LT-22691: Publish writing system under cursor

### DIFF
--- a/Src/Common/FwUtils/EventConstants.cs
+++ b/Src/Common/FwUtils/EventConstants.cs
@@ -55,5 +55,6 @@ namespace SIL.FieldWorks.Common.FwUtils
 		public const string ViewLiftMessages = "ViewLiftMessages";
 		public const string ViewMessages = "ViewMessages";
 		public const string WarnUserAboutFailedLiftImportIfNecessary = "WarnUserAboutFailedLiftImportIfNecessary";
+		public const string WritingSystemUnderCursorChanged = "WritingSystemUnderCursorChanged";
 	}
 }

--- a/Src/Common/SimpleRootSite/SimpleRootSite.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSite.cs
@@ -5792,6 +5792,21 @@ namespace SIL.FieldWorks.Common.RootSites
 			return g_focusRootSite.Target == this;
 		}
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Forgets which root site last had focus, so no root site reports <see
+		/// cref="WasFocused"/>.
+		/// Call when focus is known to have moved to an HWND that is not a WinForms control:
+		/// the kill-focus plumbing resolves such a window to null and leaves the stale
+		/// reference in place (see OnKillFocus), so a later "WritingSystemHvo"/"BestStyleName"
+		/// change would act on a root site the user has left.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public static void ForgetLastFocusedRootSite()
+		{
+			g_focusRootSite = new WeakReference(null);
+		}
+
 		/// -----------------------------------------------------------------------------------
 		/// <summary>
 		/// Some situations lead to invalidating very large rectangles. Something seems to go wrong

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2003-2017 SIL International
+// Copyright (c) 2003-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -381,13 +381,38 @@ namespace SIL.FieldWorks.XWorks
 			if (!m_detailEditContext.IsDeactivateHookAttached)
 				m_detailEditContext.AttachDeactivateHook(FindForm());
 			m_avaloniaEntryForm.ShowDetail(detail, editContext,
-				wsTag => WritingSystemKeyboards.Activate(Cache, wsTag),
+				OnDetailWritingSystemFocused,
 				GetPersistedExpansionState, PersistExpansionState,
 				OnDetailMenuRequested, OnDetailLinkRequested,
 				new FwTsStringClipboard(Cache.WritingSystemFactory),
 				GetPersistedLabelColumnWidth, PersistLabelColumnWidth);
 		}
 
+		/// <summary>
+		/// Called when a writing system editor gains focus. Never throws: a focus
+		/// event can race view teardown, so failures are logged instead.
+		/// </summary>
+		internal void OnDetailWritingSystemFocused(string wsTag)
+		{
+			if (IsDisposed || m_propertyTable == null)
+				return;
+			try
+			{
+				// Without this, the last-focused root site still answers WasFocused() and the
+				// property change below would make it steal focus and re-tag its selection.
+				SimpleRootSite.ForgetLastFocusedRootSite();
+				WritingSystemKeyboards.Activate(Cache, wsTag);
+				var ws = Cache.WritingSystemFactory.GetWsFromStr(wsTag);
+				if (ws <= 0)
+					return;
+				Publisher.Publish(new PublisherParameterObject(
+					EventConstants.WritingSystemUnderCursorChanged, ws, m_propertyTable.GetWindow()));
+			}
+			catch (Exception e)
+			{
+				Logger.WriteError("Writing-system focus handling failed.", e);
+			}
+		}
 
 		/// <summary>
 		/// Shows the SAME xCore-defined context menu the legacy slice shows, over the

--- a/Src/xWorks/TextListeners.cs
+++ b/Src/xWorks/TextListeners.cs
@@ -9,9 +9,11 @@ using System.Linq;
 using System.Xml;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.Core.WritingSystems;
+using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.DomainServices;
 using XCore;
+using static SIL.FieldWorks.Common.FwUtils.FwUtils;
 
 namespace SIL.FieldWorks.XWorks
 {
@@ -123,6 +125,9 @@ namespace SIL.FieldWorks.XWorks
 
 			if (disposing)
 			{
+				Subscriber.Unsubscribe(EventConstants.WritingSystemUnderCursorChanged,
+					WritingSystemUnderCursorChanged);
+
 				// Dispose managed resources here.
 				if (m_mediator !=  null)
 					m_mediator.RemoveColleague(this);
@@ -149,6 +154,21 @@ namespace SIL.FieldWorks.XWorks
 				cache.ServiceLocator.WritingSystems.DefaultAnalysisWritingSystem.Handle.ToString(),
 				true);
 			m_propertyTable.SetPropertyPersistence("WritingSystemHvo", false);
+
+			Subscriber.Subscribe(EventConstants.WritingSystemUnderCursorChanged,
+				WritingSystemUnderCursorChanged, m_propertyTable.GetWindow());
+
+		}
+
+		/// <summary>
+		/// Subscriber for the focus writing system changing.
+		/// </summary>
+		private void WritingSystemUnderCursorChanged(object argument)
+		{
+			if (!(argument is int ws))
+				return;
+			m_propertyTable.SetProperty(PropertyConstants.WritingSystemHvo,
+				ws.ToString(CultureInfo.InvariantCulture), true);
 		}
 
 		/// <summary>

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailWritingSystemStateTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailWritingSystemStateTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+using NUnit.Framework;
+using SIL.FieldWorks.Common.FwUtils;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+using XCore;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// End-to-end proof of the writing-system-under-cursor state channel on the real product
+	/// host: <see cref="RecordEditView.OnDetailWritingSystemFocused"/> (the Avalonia detail
+	/// view's editor-focus hook) publishes
+	/// <see cref="EventConstants.WritingSystemUnderCursorChanged"/> window-scoped, and the
+	/// window's <see cref="WritingSystemListHandler"/> subscriber mirrors it into the
+	/// writing-system property the toolbar combo displays.
+	/// </summary>
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class DetailWritingSystemStateTests : XWorksAppTestBase
+	{
+		private PropertyTable m_propertyTable;
+		private List<ICmObject> m_createdObjects;
+		private RecordEditView m_view;
+		// The real subscriber under test. MockFwXWindow's bare-minimum LoadUI never loads the
+		// Main.xml listeners, so the fixture creates the one this channel needs itself.
+		private WritingSystemListHandler m_wsListHandler;
+
+		protected override void Init()
+		{
+			m_application = new MockFwXApp(new MockFwManager { Cache = Cache }, null, null);
+			m_configFilePath = Path.Combine(FwDirectoryFinder.CodeDirectory, m_application.DefaultConfigurationPathname);
+		}
+
+		[SetUp]
+		public void SetUpWindow()
+		{
+			m_window = new MockFwXWindow(m_application, m_configFilePath);
+			((MockFwXWindow)m_window).Init(Cache);
+			m_propertyTable = m_window.PropTable;
+			m_propertyTable.RemoveLocalAndGlobalSettings();
+			m_window.LoadUI(m_configFilePath);
+			m_wsListHandler = new WritingSystemListHandler();
+			m_wsListHandler.Init(m_window.Mediator, m_propertyTable, null);
+			m_createdObjects = new List<ICmObject>();
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, CreateLexiconTestData);
+
+			m_propertyTable.SetProperty("UIMode", "New", true);
+			m_propertyTable.SetPropertyPersistence("UIMode", false);
+			LoadRecordEditView("lexiconEdit");
+			DrainMediatorAndIdleQueues();
+
+			m_view = m_propertyTable.GetValue<object>("currentContentControlObject", null) as RecordEditView;
+			Assert.That(m_view, Is.Not.Null, "expected the lexicon edit RecordEditView to load");
+		}
+
+		[TearDown]
+		public void TearDownWindow()
+		{
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, DestroyLexiconTestData);
+			m_createdObjects = null;
+			m_view = null;
+			// Unsubscribes from the process-wide Pub/Sub singleton; without it a disposed
+			// handler would still hear later fixtures' publishes.
+			m_wsListHandler?.Dispose();
+			m_wsListHandler = null;
+			m_propertyTable?.RemoveLocalAndGlobalSettings();
+			m_propertyTable = null;
+			if (m_window != null && !m_window.IsDisposed)
+			{
+				m_window.Dispose();
+				m_window = null;
+			}
+		}
+
+		[Test]
+		public void EditorFocus_UpdatesWritingSystemHvoProperty_ThroughPubSub()
+		{
+			var vernacular = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
+			var analysis = Cache.ServiceLocator.WritingSystems.DefaultAnalysisWritingSystem;
+			Assert.That(vernacular.Handle, Is.Not.EqualTo(analysis.Handle),
+				"precondition: distinct vernacular and analysis writing systems");
+			Assert.That(CurrentWritingSystemHvoProperty(),
+				Is.EqualTo(analysis.Handle.ToString(CultureInfo.InvariantCulture)),
+				"precondition: WritingSystemListHandler.Init seeds the default analysis ws");
+
+			m_view.OnDetailWritingSystemFocused(vernacular.Id);
+
+			Assert.That(CurrentWritingSystemHvoProperty(),
+				Is.EqualTo(vernacular.Handle.ToString(CultureInfo.InvariantCulture)),
+				"focusing a vernacular editor must update the combo property through Pub/Sub");
+
+			m_view.OnDetailWritingSystemFocused("xxx-unknown-tag");
+
+			Assert.That(CurrentWritingSystemHvoProperty(),
+				Is.EqualTo(vernacular.Handle.ToString(CultureInfo.InvariantCulture)),
+				"an unresolvable tag must publish nothing and leave the property alone");
+
+			m_view.OnDetailWritingSystemFocused(analysis.Id);
+
+			Assert.That(CurrentWritingSystemHvoProperty(),
+				Is.EqualTo(analysis.Handle.ToString(CultureInfo.InvariantCulture)),
+				"focusing an analysis editor must move the combo property back");
+		}
+
+		private string CurrentWritingSystemHvoProperty()
+		{
+			return m_propertyTable.GetStringProperty(PropertyConstants.WritingSystemHvo, null);
+		}
+
+		private void LoadRecordEditView(string toolValue)
+		{
+			var windowConfiguration = m_propertyTable.GetValue<XmlNode>("WindowConfiguration");
+			Assert.That(windowConfiguration, Is.Not.Null);
+			var controlNode = windowConfiguration.SelectSingleNode(
+				string.Format("//tool[@value='{0}']/control//control[dynamicloaderinfo/@class='SIL.FieldWorks.XWorks.RecordEditView']", toolValue));
+			Assert.That(controlNode, Is.Not.Null, "Expected the RecordEditView configuration node for tool '{0}'.", toolValue);
+
+			m_propertyTable.SetProperty("currentContentControlParameters", controlNode, true);
+			m_propertyTable.SetPropertyPersistence("currentContentControlParameters", false);
+			m_propertyTable.SetProperty("currentContentControl", toolValue, true);
+			m_propertyTable.SetPropertyPersistence("currentContentControl", false);
+		}
+
+		private void CreateLexiconTestData()
+		{
+			var stemMorphType = GetMorphTypeOrCreateOne("stem");
+			var nounPartOfSpeech = GetGrammaticalCategoryOrCreateOne("noun", Cache.LangProject.PartsOfSpeechOA);
+			AddLexeme(m_createdObjects, "ws-state-entry", stemMorphType, "ws state gloss", nounPartOfSpeech);
+		}
+
+		private void DestroyLexiconTestData()
+		{
+			if (m_createdObjects == null)
+				return;
+			foreach (var obj in m_createdObjects)
+			{
+				if (obj.IsValidObject && obj is ILexEntry)
+					obj.Delete();
+			}
+		}
+	}
+}


### PR DESCRIPTION
The detail editor focus hook now also publishes the window-scoped WritingSystemUnderCursorChanged event, so the toolbar writing-system combo tracks the cursor while the Avalonia detail view is focused.

Notes:
- This adds the first Avalonia-to-WinForms state channel rather than replacing an adapter route.
- The view publishes an event instead of writing the property itself so the relevant code stays quarantined in the one listener that already owns that combo. The view stays ignorant of its consumers, and a replacement toolbar later subscribes to the same event without touching the view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1095)
<!-- Reviewable:end -->
