### PR TITLE
LT-22691: Preserve trailing ViewNode fields when applying an override

### DIFF
--- a/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
@@ -41,6 +41,37 @@ namespace FwAvaloniaTests
 			Assert.That(applied.ToSnapshot(), Is.EqualTo(shipped.ToSnapshot()));
 		}
 
+		// Every node is rebuilt on apply, so a clone that omits a field strips it tree-wide once
+		// any override exists. These three fields are outside ToSnapshot(), so the empty-patch
+		// test misses it.
+		[Test]
+		public void Apply_PreservesNodeFieldsNoOperationTouches()
+		{
+			var writingSystems = new[] { "fr", "seh" };
+			var options = new ViewStringList(new[] { "IsElsewhereForm", "IsAbstractForm" }, "AllomorphStatus");
+			var shipped = Model(GroupNode("g", "Group",
+				new ViewNode("g/a", ViewNodeKind.Field, "A", null, "F", "multistring",
+					EditorClassification.Known, "vern", ViewVisibility.Always,
+					ViewExpansion.NotApplicable, false, null, null,
+					enumStringList: options, visibleWritingSystems: writingSystems, toggleValue: true)));
+			var patch = new ViewDefinitionOverride("LexEntry", "detail", "jtview",
+				new[]
+				{
+					new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibility, "g/a",
+						visibility: ViewVisibility.Never)
+				}, null);
+
+			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
+
+			var rebuilt = applied.Roots[0].Children[0];
+			Assert.That(rebuilt.Visibility, Is.EqualTo(ViewVisibility.Never), "the operation still applies");
+			Assert.That(rebuilt.VisibleWritingSystems, Is.EqualTo(writingSystems),
+				"a per-field writing-system subset survives the rebuild");
+			Assert.That(rebuilt.ToggleValue, Is.True, "a toggle value survives the rebuild");
+			Assert.That(rebuilt.EnumStringList?.Ids, Is.EqualTo(options.Ids),
+				"an enum option list survives the rebuild");
+		}
+
 		[Test]
 		public void Apply_AddNode_InsertsAtParentIndex()
 		{

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
@@ -42,8 +42,8 @@ namespace FwAvaloniaTests
 		}
 
 		// Every node is rebuilt on apply, so a clone that omits a field strips it tree-wide once
-		// any override exists. These three fields are outside ToSnapshot(), so the empty-patch
-		// test misses it.
+		// any override exists. These three fields are outside ToSnapshot() and aren't covered by
+		// the EmptyPatch test.
 		[Test]
 		public void Apply_PreservesNodeFieldsNoOperationTouches()
 		{

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
@@ -286,7 +286,9 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			return map;
 		}
 
-		// Reconstruct an immutable node with overridden visibility/label/children, copying every other field.
+		// Reconstruct an immutable node with overridden visibility/label/children, copying every
+		// other field. Every trailing optional constructor argument must be passed, or that
+		// field is stripped.
 		private static ViewNode CloneWith(ViewNode n, ViewVisibility visibility, string label, IReadOnlyList<ViewNode> children)
 			=> new ViewNode(
 				n.StableId, n.Kind, label, n.Abbreviation, n.Field, n.RawEditor, n.EditorClassification,
@@ -294,7 +296,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				n.LocalizationKey, n.AutomationId, n.Routing, n.BoldEmphasis, n.FontScalePercent, n.MenuId,
 				n.ContextMenuId, n.HotlinksId, n.GhostField, n.GhostWs, n.GhostClass, n.GhostLabel,
 				n.ForVariant, n.CustomEditorClass, n.CustomEditorAssembly, n.GhostInitMethod, n.Condition,
-				n.ChooserLinks);
+				n.ChooserLinks, n.EnumStringList, n.VisibleWritingSystems, n.ToggleValue);
 
 		// Copy a (leaf) node under a new StableId; AutomationId is dropped so the duplicate gets a fresh,
 		// non-colliding identity (the renderer derives one from the new StableId by convention).
@@ -305,6 +307,6 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				n.LocalizationKey, null, n.Routing, n.BoldEmphasis, n.FontScalePercent, n.MenuId,
 				n.ContextMenuId, n.HotlinksId, n.GhostField, n.GhostWs, n.GhostClass, n.GhostLabel,
 				n.ForVariant, n.CustomEditorClass, n.CustomEditorAssembly, n.GhostInitMethod, n.Condition,
-				n.ChooserLinks);
+				n.ChooserLinks, n.EnumStringList, n.VisibleWritingSystems, n.ToggleValue);
 	}
 }


### PR DESCRIPTION
ViewDefinitionOverrideApplier rebuilds every node when it applies a patch, but its CloneWith and CloneWithId helpers stopped short of the ViewNode constructor's last three optional parameters. Omitting them let the defaults win, so EnumStringList, VisibleWritingSystems and ToggleValue were stripped from the whole tree as soon as a project carried any override -- a single SetVisibility operation was enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1096)
<!-- Reviewable:end -->
