### PR TITLE
LT-22691: Add the SetVisibleWritingSystems override operation

### DIFF
--- a/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideApplierTests.cs
@@ -25,6 +25,12 @@ namespace FwAvaloniaTests
 				EditorClassification.GroupingNone, null, ViewVisibility.Always, ViewExpansion.Expanded,
 				false, null, children);
 
+		private static ViewNode WsFieldNode(string id, string[] visibleWritingSystems)
+			=> new ViewNode(id, ViewNodeKind.Field, "A", null, "Form", "multistring",
+				EditorClassification.Known, "all vernacular", ViewVisibility.Always,
+				ViewExpansion.NotApplicable, false, null, null,
+				visibleWritingSystems: visibleWritingSystems);
+
 		private static ViewDefinitionModel Model(params ViewNode[] roots)
 			=> new ViewDefinitionModel("LexEntry", "detail", "jtview", roots, null);
 
@@ -70,6 +76,45 @@ namespace FwAvaloniaTests
 			Assert.That(rebuilt.ToggleValue, Is.True, "a toggle value survives the rebuild");
 			Assert.That(rebuilt.EnumStringList?.Ids, Is.EqualTo(options.Ids),
 				"an enum option list survives the rebuild");
+		}
+
+		// The writing-system subset a user picks for one field, recorded against its stable id.
+		[Test]
+		public void Apply_SetVisibleWritingSystems_RestrictsThatFieldOnly()
+		{
+			var shipped = Model(GroupNode("g", "Group",
+				WsFieldNode("g/a", new[] { "fr", "seh", "aka" }),
+				FieldNode("g/b", "B")));
+			var patch = new ViewDefinitionOverride("LexEntry", "detail", "jtview",
+				new[]
+				{
+					new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems, "g/a",
+						writingSystems: new[] { "fr" })
+				}, null);
+
+			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
+
+			Assert.That(applied.Roots[0].Children[0].VisibleWritingSystems, Is.EqualTo(new[] { "fr" }),
+				"the patched field is restricted to the chosen writing systems");
+			Assert.That(applied.Roots[0].Children[1].VisibleWritingSystems, Is.Null,
+				"a field the patch does not name is untouched");
+		}
+
+		[Test]
+		public void Apply_SetVisibleWritingSystems_PreservesTheChosenOrder()
+		{
+			var shipped = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "fr", "seh" })));
+			var patch = new ViewDefinitionOverride("LexEntry", "detail", "jtview",
+				new[]
+				{
+					new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems, "g/a",
+						writingSystems: new[] { "seh", "fr" })
+				}, null);
+
+			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
+
+			Assert.That(applied.Roots[0].Children[0].VisibleWritingSystems,
+				Is.EqualTo(new[] { "seh", "fr" }), "display order is the user's order, not the shipped one");
 		}
 
 		[Test]
@@ -170,6 +215,62 @@ namespace FwAvaloniaTests
 			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
 
 			Assert.That(applied.ToSnapshot(), Is.EqualTo(customized.ToSnapshot()));
+		}
+
+		// VisibleWritingSystems is outside ToSnapshot(), so these round trips assert it directly.
+		[Test]
+		public void RoundTrip_DiffThenApply_ReproducesCustomized_WritingSystemRestriction()
+		{
+			var shipped = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "fr", "seh" })));
+			var customized = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "seh" })));
+
+			var patch = ViewDefinitionOverrideDiffer.Diff(shipped, customized);
+			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
+
+			Assert.That(applied.Roots[0].Children[0].VisibleWritingSystems,
+				Is.EqualTo(new[] { "seh" }), "the differ captures the restriction and apply replays it");
+		}
+
+		[Test]
+		public void RoundTrip_DiffThenApply_ClearedRestrictionComesBackNull()
+		{
+			var shipped = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "fr", "seh" })));
+			var customized = Model(GroupNode("g", "Group", WsFieldNode("g/a", null)));
+
+			var patch = ViewDefinitionOverrideDiffer.Diff(shipped, customized);
+			var applied = ViewDefinitionOverrideApplier.Apply(shipped, patch);
+
+			Assert.That(applied.Roots[0].Children[0].VisibleWritingSystems, Is.Null,
+				"clearing normalizes to null, the model's own \"unrestricted\"");
+		}
+
+		[Test]
+		public void Diff_CaseOnlyWritingSystemDifference_EmitsNoOp()
+		{
+			var shipped = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "fr-FR" })));
+			var customized = Model(GroupNode("g", "Group", WsFieldNode("g/a", new[] { "fr-fr" })));
+
+			var patch = ViewDefinitionOverrideDiffer.Diff(shipped, customized);
+
+			Assert.That(patch.Operations, Is.Empty,
+				"the composer matches tags case-insensitively, so these render identically");
+		}
+
+		[Test]
+		public void Diff_AddedNodeWithWsRestriction_ReportsDiagnostic()
+		{
+			var shipped = Model(GroupNode("g", "Group", FieldNode("g/a", "A")));
+			var customized = Model(GroupNode("g", "Group", FieldNode("g/a", "A"),
+				WsFieldNode("g/new", new[] { "fr" })));
+
+			var patch = ViewDefinitionOverrideDiffer.Diff(shipped, customized);
+
+			Assert.That(patch.Operations.Single(o =>
+					o.Kind == ViewOverrideOperationKind.AddNode).StableId,
+				Is.EqualTo("g/new"), "the added node itself is still representable");
+			Assert.That(patch.Diagnostics.Any(
+					d => d.Code == "override-added-ws-restriction-dropped"), Is.True,
+				"the dropped restriction is reported, never silent");
 		}
 	}
 }

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideJsonSerializerTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideJsonSerializerTests.cs
@@ -25,6 +25,8 @@ namespace FwAvaloniaTests
 				new ViewOverrideOperation(ViewOverrideOperationKind.SetLabel, "b", label: "Headword"),
 				new ViewOverrideOperation(ViewOverrideOperationKind.ReorderChildren, "g",
 					childOrder: new[] { "g/b", "g/a" }),
+				new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems, "w",
+					writingSystems: new[] { "seh", "fr" }),
 				new ViewOverrideOperation(ViewOverrideOperationKind.HideNode, "c")
 			};
 			var diags = new List<ViewDiagnostic>
@@ -47,7 +49,7 @@ namespace FwAvaloniaTests
 			Assert.That(restored.LayoutName, Is.EqualTo("detail"));
 			Assert.That(restored.LayoutType, Is.EqualTo("jtview"));
 
-			Assert.That(restored.Operations.Count, Is.EqualTo(4));
+			Assert.That(restored.Operations.Count, Is.EqualTo(5));
 
 			var vis = restored.Operations.Single(o => o.Kind == ViewOverrideOperationKind.SetVisibility);
 			Assert.That(vis.StableId, Is.EqualTo("a"));
@@ -63,6 +65,12 @@ namespace FwAvaloniaTests
 
 			var hide = restored.Operations.Single(o => o.Kind == ViewOverrideOperationKind.HideNode);
 			Assert.That(hide.StableId, Is.EqualTo("c"));
+
+			var writingSystems = restored.Operations
+				.Single(o => o.Kind == ViewOverrideOperationKind.SetVisibleWritingSystems);
+			Assert.That(writingSystems.StableId, Is.EqualTo("w"));
+			Assert.That(writingSystems.WritingSystems, Is.EqualTo(new[] { "seh", "fr" }),
+				"the chosen writing systems round-trip in display order");
 
 			Assert.That(restored.Diagnostics.Count, Is.EqualTo(1));
 			Assert.That(restored.Diagnostics[0].Code, Is.EqualTo("override-added-node"));
@@ -97,6 +105,28 @@ namespace FwAvaloniaTests
 			const string json = "{ \"formatVersion\": 99, \"class\": \"LexEntry\", \"operations\": [] }";
 			Assert.That(() => ViewDefinitionOverrideJsonSerializer.Deserialize(json),
 				Throws.TypeOf<InvalidDataException>());
+		}
+
+		[Test]
+		public void Deserialize_NullWritingSystemEntry_Throws()
+		{
+			const string json = "{ \"formatVersion\": 1, \"class\": \"LexEntry\", \"name\": \"detail\","
+				+ " \"type\": \"jtview\", \"operations\": [ { \"op\": \"setVisibleWritingSystems\","
+				+ " \"id\": \"w\", \"writingSystems\": [ \"seh\", null ] } ] }";
+			Assert.That(() => ViewDefinitionOverrideJsonSerializer.Deserialize(json),
+				Throws.TypeOf<InvalidDataException>(),
+				"a null entry must fail the load, not flow into the node model");
+		}
+
+		[Test]
+		public void Deserialize_NullChildOrderEntry_Throws()
+		{
+			const string json = "{ \"formatVersion\": 1, \"class\": \"LexEntry\", \"name\": \"detail\","
+				+ " \"type\": \"jtview\", \"operations\": [ { \"op\": \"reorderChildren\","
+				+ " \"id\": \"g\", \"childOrder\": [ \"g/a\", null ] } ] }";
+			Assert.That(() => ViewDefinitionOverrideJsonSerializer.Deserialize(json),
+				Throws.TypeOf<InvalidDataException>(),
+				"a null entry must fail the load, not surface at compose time");
 		}
 
 		[Test]

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
@@ -30,6 +30,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			var setLabel = new Dictionary<string, string>(StringComparer.Ordinal);
 			var hide = new HashSet<string>(StringComparer.Ordinal);
 			var reorder = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+			var setWritingSystems = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
 			var addByParent = new Dictionary<string, List<ViewOverrideOperation>>(StringComparer.Ordinal);
 			var duplicateByParent = new Dictionary<string, List<ViewOverrideOperation>>(StringComparer.Ordinal);
 
@@ -49,6 +50,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 					case ViewOverrideOperationKind.ReorderChildren:
 						reorder[op.StableId] = op.ChildOrder;
 						break;
+					case ViewOverrideOperationKind.SetVisibleWritingSystems:
+						// An empty op clears the restriction; null is the model's "unrestricted".
+						setWritingSystems[op.StableId] =
+							op.WritingSystems.Count > 0 ? op.WritingSystems : null;
+						break;
 					case ViewOverrideOperationKind.AddNode:
 						AppendByParent(addByParent, op);
 						break;
@@ -64,7 +70,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			var diagnostics = new List<ViewDiagnostic>(shipped.Diagnostics);
 			var baseById = FlattenBase(shipped.Roots);
 			var context = new ApplyContext(
-				setVisibility, setLabel, hide, reorder, addByParent, duplicateByParent, baseById, diagnostics);
+				setVisibility, setLabel, hide, reorder, setWritingSystems, addByParent, duplicateByParent,
+				baseById, diagnostics);
 
 			var newRoots = context.RebuildChildren(RootParentKey, shipped.Roots);
 
@@ -81,6 +88,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			private readonly Dictionary<string, string> _setLabel;
 			private readonly HashSet<string> _hide;
 			private readonly Dictionary<string, IReadOnlyList<string>> _reorder;
+			private readonly Dictionary<string, IReadOnlyList<string>> _setWritingSystems;
 			private readonly Dictionary<string, List<ViewOverrideOperation>> _addByParent;
 			private readonly Dictionary<string, List<ViewOverrideOperation>> _duplicateByParent;
 			private readonly Dictionary<string, ViewNode> _baseById;
@@ -92,6 +100,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				Dictionary<string, string> setLabel,
 				HashSet<string> hide,
 				Dictionary<string, IReadOnlyList<string>> reorder,
+				Dictionary<string, IReadOnlyList<string>> setWritingSystems,
 				Dictionary<string, List<ViewOverrideOperation>> addByParent,
 				Dictionary<string, List<ViewOverrideOperation>> duplicateByParent,
 				Dictionary<string, ViewNode> baseById,
@@ -101,6 +110,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				_setLabel = setLabel;
 				_hide = hide;
 				_reorder = reorder;
+				_setWritingSystems = setWritingSystems;
 				_addByParent = addByParent;
 				_duplicateByParent = duplicateByParent;
 				_baseById = baseById;
@@ -154,7 +164,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				var visibility = _setVisibility.TryGetValue(node.StableId, out var v) ? v : node.Visibility;
 				var label = _setLabel.TryGetValue(node.StableId, out var l) ? l : node.Label;
 				var children = RebuildChildren(node.StableId, node.Children);
-				return CloneWith(node, visibility, label, children);
+				var writingSystems = _setWritingSystems.TryGetValue(node.StableId, out var w)
+					? w
+					: node.VisibleWritingSystems;
+				return CloneWith(node, visibility, label, children, writingSystems);
 			}
 
 			private ViewNode CreateAddedNode(ViewOverrideOperation addOp)
@@ -286,17 +299,17 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			return map;
 		}
 
-		// Reconstruct an immutable node with overridden visibility/label/children, copying every
-		// other field. Every trailing optional constructor argument must be passed, or that
-		// field is stripped.
-		private static ViewNode CloneWith(ViewNode n, ViewVisibility visibility, string label, IReadOnlyList<ViewNode> children)
+		// Reconstruct an immutable node with the overridden fields, copying every other one.
+		// Every trailing optional constructor argument must be passed, or that field is stripped.
+		private static ViewNode CloneWith(ViewNode n, ViewVisibility visibility, string label,
+			IReadOnlyList<ViewNode> children, IReadOnlyList<string> visibleWritingSystems)
 			=> new ViewNode(
 				n.StableId, n.Kind, label, n.Abbreviation, n.Field, n.RawEditor, n.EditorClassification,
 				n.WritingSystem, visibility, n.Expansion, n.Indented, n.TargetLayout, children,
 				n.LocalizationKey, n.AutomationId, n.Routing, n.BoldEmphasis, n.FontScalePercent, n.MenuId,
 				n.ContextMenuId, n.HotlinksId, n.GhostField, n.GhostWs, n.GhostClass, n.GhostLabel,
 				n.ForVariant, n.CustomEditorClass, n.CustomEditorAssembly, n.GhostInitMethod, n.Condition,
-				n.ChooserLinks, n.EnumStringList, n.VisibleWritingSystems, n.ToggleValue);
+				n.ChooserLinks, n.EnumStringList, visibleWritingSystems, n.ToggleValue);
 
 		// Copy a (leaf) node under a new StableId; AutomationId is dropped so the duplicate gets a fresh,
 		// non-colliding identity (the renderer derives one from the new StableId by convention).

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideDiffer.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideDiffer.cs
@@ -24,6 +24,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 		/// <summary>Reorder a node's children (same child set, different order).</summary>
 		ReorderChildren,
 
+		/// <summary>
+		/// Restrict a field to a subset of its writing systems, in display order.
+		/// </summary>
+		SetVisibleWritingSystems,
+
 		/// <summary>A node present in the shipped definition that the override removed/hid.</summary>
 		HideNode,
 
@@ -53,13 +58,15 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			string field = null,
 			string editor = null,
 			string sourceStableId = null,
-			string writingSystem = null)
+			string writingSystem = null,
+			IReadOnlyList<string> writingSystems = null)
 		{
 			Kind = kind;
 			StableId = stableId ?? throw new ArgumentNullException(nameof(stableId));
 			Visibility = visibility;
 			Label = label;
 			ChildOrder = childOrder ?? (IReadOnlyList<string>)Array.Empty<string>();
+			WritingSystems = writingSystems ?? (IReadOnlyList<string>)Array.Empty<string>();
 			ParentStableId = parentStableId;
 			Index = index;
 			NodeKind = nodeKind;
@@ -82,6 +89,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 
 		/// <summary>New child order (StableIds) for <see cref="ViewOverrideOperationKind.ReorderChildren"/>.</summary>
 		public IReadOnlyList<string> ChildOrder { get; }
+
+		/// <summary>
+		/// The writing systems a field is restricted to, in display order.
+		/// </summary>
+		public IReadOnlyList<string> WritingSystems { get; }
 
 		/// <summary>For <see cref="ViewOverrideOperationKind.AddNode"/>: the parent the new node is inserted under.</summary>
 		public string ParentStableId { get; }
@@ -115,6 +127,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 					return $"setLabel {StableId} -> {Label}";
 				case ViewOverrideOperationKind.ReorderChildren:
 					return $"reorderChildren {StableId} -> [{string.Join(",", ChildOrder)}]";
+				case ViewOverrideOperationKind.SetVisibleWritingSystems:
+					return $"setVisibleWritingSystems {StableId} -> [{string.Join(",", WritingSystems)}]";
 				case ViewOverrideOperationKind.HideNode:
 					return $"hideNode {StableId}";
 				case ViewOverrideOperationKind.AddNode:
@@ -170,9 +184,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 	/// the diff keys on <see cref="ViewNode.StableId"/>
 	/// -- the identity scheme the semantic baselines already use -- instead of a second one.
 	///
-	/// Representable edits (visibility, label, child reorder, node hidden) become operations; everything
-	/// else (added nodes, changed binding/editor/kind) becomes an explicit diagnostic. Output is
-	/// deterministic: operations and diagnostics are ordered by StableId then kind.
+	/// Representable edits (visibility, label, child reorder, writing-system restriction, node
+	/// hidden) become operations; everything else (added nodes, changed binding/editor/kind)
+	/// becomes an explicit diagnostic. Output is deterministic: operations and diagnostics are
+	/// ordered by StableId then kind.
 	/// </summary>
 	public static class ViewDefinitionOverrideDiffer
 	{
@@ -239,6 +254,14 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 						stableId, label: overriddenNode.Label));
 				}
 
+				if (!WritingSystemsEqual(shippedNode.VisibleWritingSystems,
+					overriddenNode.VisibleWritingSystems))
+				{
+					operations.Add(new ViewOverrideOperation(
+						ViewOverrideOperationKind.SetVisibleWritingSystems, stableId,
+						writingSystems: overriddenNode.VisibleWritingSystems));
+				}
+
 				AppendReorderIfNeeded(operations, stableId, shippedNode, overriddenNode);
 			}
 
@@ -257,6 +280,17 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 					parentStableId: place.ParentId, index: place.Index,
 					nodeKind: added.Kind, field: added.Field, editor: added.RawEditor,
 					writingSystem: added.WritingSystem));
+
+				// An AddNode op cannot carry a writing-system restriction; report the drop
+				// rather than lose it silently.
+				if (added.VisibleWritingSystems != null && added.VisibleWritingSystems.Count > 0)
+				{
+					diagnostics.Add(new ViewDiagnostic(ViewDiagnosticSeverity.Warning,
+						"override-added-ws-restriction-dropped",
+						$"added node '{stableId}' restricts its writing systems; the restriction"
+							+ " is not representable on an AddNode op",
+						stableId));
+				}
 			}
 
 			AppendReorderIfNeeded(operations, RootParentKey,
@@ -296,6 +330,12 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			operations.Add(new ViewOverrideOperation(ViewOverrideOperationKind.ReorderChildren,
 				key, childOrder: overriddenOrder));
 		}
+
+		// Null and empty both mean "no restriction"; order matters (it is the display order).
+		// Tags compare case-insensitively, matching how the composer resolves them.
+		private static bool WritingSystemsEqual(IReadOnlyList<string> shipped, IReadOnlyList<string> overridden)
+			=> (shipped ?? Array.Empty<string>()).SequenceEqual(
+				overridden ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
 		private static int CompareOperations(ViewOverrideOperation a, ViewOverrideOperation b)
 		{

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideJsonSerializer.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideJsonSerializer.cs
@@ -26,6 +26,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				{ ViewOverrideOperationKind.SetVisibility, "setVisibility" },
 				{ ViewOverrideOperationKind.SetLabel, "setLabel" },
 				{ ViewOverrideOperationKind.ReorderChildren, "reorderChildren" },
+				{ ViewOverrideOperationKind.SetVisibleWritingSystems, "setVisibleWritingSystems" },
 				{ ViewOverrideOperationKind.HideNode, "hideNode" },
 				{ ViewOverrideOperationKind.AddNode, "addNode" },
 				{ ViewOverrideOperationKind.DuplicateNode, "duplicateNode" }
@@ -94,6 +95,9 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				case ViewOverrideOperationKind.ReorderChildren:
 					o["childOrder"] = new JArray(op.ChildOrder);
 					break;
+				case ViewOverrideOperationKind.SetVisibleWritingSystems:
+					o["writingSystems"] = new JArray(op.WritingSystems);
+					break;
 				case ViewOverrideOperationKind.HideNode:
 					break;
 				case ViewOverrideOperationKind.AddNode:
@@ -132,8 +136,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				case ViewOverrideOperationKind.SetLabel:
 					return new ViewOverrideOperation(kind, stableId, label: (string)o["label"]);
 				case ViewOverrideOperationKind.ReorderChildren:
-					var order = ((JArray)o["childOrder"] ?? new JArray()).Select(t => (string)t).ToList();
-					return new ViewOverrideOperation(kind, stableId, childOrder: order);
+					return new ViewOverrideOperation(kind, stableId,
+						childOrder: ReadStringList(o, "childOrder"));
+				case ViewOverrideOperationKind.SetVisibleWritingSystems:
+					return new ViewOverrideOperation(kind, stableId,
+						writingSystems: ReadStringList(o, "writingSystems"));
 				case ViewOverrideOperationKind.AddNode:
 					var addKindText = (string)o["nodeKind"];
 					var addKind = addKindText == null
@@ -171,6 +178,16 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			var o = (JObject)token;
 			var severity = ParseEnum<ViewDiagnosticSeverity>((string)o["severity"], "severity");
 			return new ViewDiagnostic(severity, (string)o["code"], (string)o["message"], (string)o["path"]);
+		}
+
+		// Reads a string-array field. To prevent a null/empty entry from flowing
+		// into the node model, fail the load with InvalidDataException.
+		private static List<string> ReadStringList(JObject o, string field)
+		{
+			var list = ((JArray)o[field] ?? new JArray()).Select(t => (string)t).ToList();
+			if (list.Any(string.IsNullOrEmpty))
+				throw new InvalidDataException($"Null or empty {field} entry in override patch.");
+			return list;
 		}
 
 		// Parses an enum value from committed JSON, turning a null/garbage token into a controlled


### PR DESCRIPTION
A project view override can now store a per-field writing-system restriction. The differ captures a changed `VisibleWritingSystems` set as a new `SetVisibleWritingSystems` operation, the JSON wire format round-trips it, and the applier writes it onto the rebuilt node.

**Nothing writes this operation at runtime yet.** The RecordEditView mirror that records the user's Writing Systems menu choice ships separately: the mirror is the piece a native command layer would delete, while this storage layer survives either answer to the open adapter-direction question — which is why it lands alone. The review question here is narrower than the diff suggests: does the new operation round-trip losslessly, and does a bad patch file fail safely?

Where to look:

- **Round trip**: `Diff` → `Apply` reproduces a restriction and clears one — `RoundTrip_DiffThenApply_ReproducesCustomized_WritingSystemRestriction` / `_ClearedRestrictionComesBackNull`.
- **Empty clears to null**, the model's own "unrestricted"; normalized once at op bucketing in the applier.
- **Tags compare case-insensitively**, matching how `DetailComposer.ApplyVisibleWritingSystems` resolves them — `Diff_CaseOnlyWritingSystemDifference_EmitsNoOp`.
- **Bad patch files fail at load, not compose**: a shared `ReadStringList` guard now covers both string-list lanes (`writingSystems` and the previously unguarded `childOrder`) — `Deserialize_NullChildOrderEntry_Throws`.
- **Added nodes**: a restriction on a customer-added node is not representable on an AddNode op; the differ reports `override-added-ws-restriction-dropped` instead of losing it silently.

Deliberately not here:

- The RecordEditView mirror (next PR in the series; held for the adapter-direction answer on #1079).
- Carrying the restriction on AddNode ops (deferred until the migrator gets a production caller).
- Per-op skip for unknown op kinds — `formatVersion` stays 1 (see the deferred accordion).
- Set-ops targeting patch-created node ids remain silent no-ops (pre-existing, all op kinds).

Based directly on `main` (originally stacked on #1096, since merged; the branch was rebased and the diff is unchanged). Verified: `build.ps1 -CommentHygiene` clean; 76/76 targeted FwAvaloniaTests green. Manual testing deferred to the mirror PR, when a UI write path exists.

---

<details>
<summary><b>Reading this a year from now</b> — start here</summary>

This PR is the storage half of LT-22691's "commit 4", split so the part that survives the adapter-direction decision (this) is not held hostage by the part that decision could delete (the RecordEditView mirror). The working review record was produced in-session and lives in this description; the `.review/` folder is gitignored by design, so this is the only durable copy.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

- **Null and empty both mean "no restriction", and null is canonical on the node.** The wire format still writes an explicit empty array for a clear-op (so the op is visible in the file), but the applier normalizes to null at op bucketing — one enforcement site, and `ViewNode.VisibleWritingSystems` never holds an empty list on any path. Today's composer treats both alike; the normalization exists so no future consumer ever sees the ambiguous state.
- **`OrdinalIgnoreCase` for tag comparison.** `DetailComposer.ApplyVisibleWritingSystems` resolves tags case-insensitively, so an `Ordinal` differ would emit operations for layouts that render identically — a render-identical project would carry a persistent non-empty override file, defeating empty-patch cleanup. StableId comparisons elsewhere in the differ deliberately stay `Ordinal`; the two comparers are correct for different domains, which is why the two list-compare sites were not unified.
- **Validation at load, shared between lanes.** The `childOrder` lane read the same JSON shape as the new `writingSystems` lane but let a null entry through to crash at compose time — where a broad catch degrades the layout to the first-slice fallback persistently. Both lanes now read through one validating helper that fails the load with `InvalidDataException`, which the store quarantines cleanly (logged, shipped definition used).
- **Diagnostic, not silent drop, for added-node restrictions.** An AddNode op cannot carry the restriction yet; emitting `override-added-ws-restriction-dropped` keeps the differ's "unrepresentable edits become diagnostics" contract truthful without growing the AddNode wire shape while nothing exercises it.

</details>

<details>
<summary><b>Deferred, and what would unblock it</b></summary>

- **Carrying `visibleWritingSystems` on AddNode ops** (so an added node's restriction survives Diff→Apply): unblocked when `ViewDefinitionOverrideMigrator` gets a production caller — today the drop is reported as a diagnostic and no product path produces the input.
- **Per-op graceful skip for unknown op kinds**: one new-kind op in a patch file makes a pre-change build's reader throw, and the store treats the whole file as "no override" — every customization for that layout silently gone on that build. Exposure is version rollback and backup/restore only (`.viewoverride.json` does not travel through Send/Receive), and bumping `formatVersion` would be strictly worse (old readers would reject every new file). Skipping unknown ops with a diagnostic is the remedy; it changes forward-compat semantics for the whole format and deserves a deliberate design call.
- **Set-ops targeting patch-created node ids** are silently ignored, and the stale-target diagnostic is suppressed because the created id lands in the seen set. Pre-existing for `setVisibility`/`setLabel` since the applier existed; only hand-authored patches can produce the input. Unblocked if the field menus ever operate on added/duplicated nodes.

</details>

<details>
<summary><b>Preflight review details</b></summary>

<!-- pr-preflight:summary:start -->
This branch went through an adversarial review in-session: 8 independent finder angles (line-by-line, removed-behavior, cross-file tracing, reuse, simplification, efficiency, altitude, repo conventions), 23 raw candidates deduplicated to 12, each verified by its own agent. Results: 9 CONFIRMED, 1 PLAUSIBLE, 1 REFUTED (write-path asymmetry — no producer can construct the bad input today), 1 resolved by a later fix in the same review cycle.

Fixed before this PR (each with a locking test where behavior changed):

- Differ emit side existed but compared tags `Ordinal` while the composer matches `OrdinalIgnoreCase` — fixed, `Diff_CaseOnlyWritingSystemDifference_EmitsNoOp`.
- `childOrder` JSON lane accepted null entries that crashed at compose time — fixed via shared `ReadStringList`, `Deserialize_NullChildOrderEntry_Throws`.
- Added-node restrictions were dropped silently — fixed at diagnostic depth, `Diff_AddedNodeWithWsRestriction_ReportsDiagnostic`.
- Empty→null normalization ran per rebuilt node — moved to op bucketing.
- A new comment documented caller behavior (banned by the repo commenting standard) — reworded.
- Test cleanup: duplicated `ViewNode` constructions unified behind `WsFieldNode`; a provably-dead assertion disjunct replaced with `Is.Null`.

Deferred with reasons (see the accordion above): AddNode restriction carriage, per-op unknown-kind skip, patch-created-id set-ops. Dropped: missing-`id` exception type (pre-existing for every op kind; the store catches broadly).

Validation: `.\build.ps1 -CommentHygiene` clean; `.\test.ps1 -CommentHygiene -TestProject "Src/Common/FwAvalonia/FwAvaloniaTests" -TestFilter "FullyQualifiedName~ViewDefinitionOverride"` — 76/76 passed. UTF-8 BOM state verified unchanged on all five files. Manual testing deferred to the mirror PR: nothing populates `VisibleWritingSystems` at runtime yet, so the read path is only reachable via hand-authored patch files; a six-scenario manual recipe (restriction, order, casing, clear, coexistence with the Field Visibility write path, corruption quarantine) is recorded for that PR.
<!-- pr-preflight:summary:end -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1097)
<!-- Reviewable:end -->
