### PR TITLE
Repoint nine skill references that resolved from nowhere

### DIFF
--- a/.claude/skills/fieldworks-winapp/navigation/winforms-avalonia-parity.md
+++ b/.claude/skills/fieldworks-winapp/navigation/winforms-avalonia-parity.md
@@ -17,7 +17,7 @@ a dialog, a browse table. The WinForms side needs the live app (this skill); the
 - A project with the relevant data (e.g. Words ▸ Analyses parity needs **parsed wordform analyses** — a
   bare project shows an empty interlinear). Restore per `project-loading.md`.
 - Evidence folders and parity-bundle naming: see `screenshot-evidence.md` (canonical parity
-  layout defined in the migration skill's `references/parity-evidence.md` §6).
+  layout defined in the migration skill's `.claude/skills/fieldworks-winforms-to-avalonia-migration/references/parity-evidence.md` §6).
 
 ## The two captures
 

--- a/.claude/skills/fieldworks-winapp/references/research.md
+++ b/.claude/skills/fieldworks-winapp/references/research.md
@@ -51,7 +51,7 @@ sequence, cues, and safety notes to perform that route.
 
 - One reusable navigation destination or workflow per `navigation/*.md` file.
 - Shared safety and triggering rules stay in `SKILL.md`.
-- Skill maintenance rules stay in `references/how-to-update.md`.
+- Skill maintenance rules stay in `how-to-update.md`.
 - Research rationale stays in this file so future edits can revisit the design
   without bloating the active route instructions.
 

--- a/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/architecture-patterns.md
+++ b/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/architecture-patterns.md
@@ -367,7 +367,7 @@ delta in the region manifest).
 > intentionally diverge. The visual-parity evidence type therefore checks
 > density/layout, not pixel-for-pixel appearance. The density tokens and
 > per-view border/font rules that this parity is measured against live in
-> `fieldworks-avalonia-ui/references/style-system.md`, even where styling
+> `.claude/skills/fieldworks-avalonia-ui/references/style-system.md`, even where styling
 > intentionally diverges.
 
 **Canonical code.** `Src/Common/FwAvalonia/FwAvaloniaDensity.cs`;

--- a/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/control-exemplar-map.md
+++ b/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/control-exemplar-map.md
@@ -80,7 +80,7 @@ headless tests), and then PROMOTES it:
    citations.
 2. Add a numbered subsection to dialog-conversion.md (the §2c/§2d shape:
    what the legacy behavior was, the shared design, the test names).
-3. Record any surprise in `references/lessons-learned.md` per its update
+3. Record any surprise in `lessons-learned.md` per its update
    protocol.
 
 Until a gap's exemplar exists, conversions that need it stay on the Legacy

--- a/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/lessons-learned.md
+++ b/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/lessons-learned.md
@@ -248,8 +248,8 @@ requirements it fed are synced to `openspec/specs/lexical-edit-parity-automation
   `xWorksTests` (~1400 tests share the host); the restored test base holds the
   undoable task open (no nested `NonUndoableUnitOfWorkHelper`); `OnChangeFilter`
   takes an (added, removed) delta that `RecordList` composes into its `AndFilter`.
-- Skill files changed: `references/architecture-patterns.md` (§13),
-  `references/parity-evidence.md` (§2a, §3), `references/migration-checklist.md`
+- Skill files changed: `architecture-patterns.md` (§13),
+  `parity-evidence.md` (§2a, §3), `migration-checklist.md`
   (Phase 7), `SKILL.md` (quick map + workflow step 7), this ledger.
 
 ### 2026-06 — Lexical Edit (full entry view), phases 1–2 (seed entry)

--- a/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/migration-checklist.md
+++ b/.claude/skills/fieldworks-winforms-to-avalonia-migration/references/migration-checklist.md
@@ -47,7 +47,7 @@ Use this when collapsing a large multi-view derisk branch into a landable PR (se
 ## Phase 3 — Seams
 
 - [ ] Existing seams reused from `Src/Common/FwAvalonia/Seams/`
-- [ ] Any new seam added to `references/seam-catalog.md` with purpose,
+- [ ] Any new seam added to `seam-catalog.md` with purpose,
       rules, and pivot trigger
 - [ ] No region code reaches directly into PropertyTable/mediator/LCModel
       outside a seam
@@ -125,7 +125,7 @@ Use this when collapsing a large multi-view derisk branch into a landable PR (se
 ## Phase 10 — Retrospective (updates this skill set)
 
 - [ ] New patterns/gotchas/pivots recorded per the protocol in
-      `references/lessons-learned.md`
+      `lessons-learned.md`
 - [ ] New plugins added to the canonical examples in
       architecture-patterns.md §5
 - [ ] Stale file pointers in any fieldworks-* skill fixed


### PR DESCRIPTION
Nine cross-references in the Avalonia migration and WinApp skills pointed at nothing. An agent following one — `lessons-learned.md` sending you to `references/architecture-patterns.md`, say — got a miss and carried on without the guidance it was told to read.

**Start here:** `.claude/skills/fieldworks-winforms-to-avalonia-migration/references/lessons-learned.md` — three of the nine are in that one file, and the shape is identical in all nine.

Where to look:

- **Every target exists. Only the paths were wrong.** They were written relative to the *skill root* while the citing file lives inside `references/`, so `references/architecture-patterns.md` resolved to `references/references/architecture-patterns.md`.
- **Seven become plain sibling names** — what a file inside `references/` needs to reach the file next to it.
- **Two genuinely cross skill boundaries** and become repo-root paths: `winforms-avalonia-parity.md` cites `parity-evidence.md` in the *migration* skill, and `architecture-patterns.md` cites `style-system.md` in the *Avalonia UI* skill. Those two were never fixable as siblings.
- **Nothing else changed.** No prose, no guidance, no renames, no moves. 8 insertions, 8 deletions across 6 files.

Deliberately not here: no checker is added to stop this recurring. Worth doing, but it belongs with whoever owns skill tooling rather than bolted onto a path fix.

Verification: every reference in every `.claude` markdown file was resolved from the directory it is written in — **nine dangling before, zero after**. `gitlint` clean. No `build.ps1` or `test.ps1`: markdown only, no compiled code.

Next: review and merge — independent of #1098/#1099/#1100/#1101 and touches none of their files.

---

<details>
<summary><b>The nine, and where each now points</b></summary>

| Citing file | Was | Now |
| --- | --- | --- |
| `fieldworks-winapp/navigation/winforms-avalonia-parity.md` | `references/parity-evidence.md` | `.claude/skills/fieldworks-winforms-to-avalonia-migration/references/parity-evidence.md` |
| `fieldworks-winapp/references/research.md` | `references/how-to-update.md` | `how-to-update.md` |
| `…migration/references/architecture-patterns.md` | `fieldworks-avalonia-ui/references/style-system.md` | `.claude/skills/fieldworks-avalonia-ui/references/style-system.md` |
| `…migration/references/control-exemplar-map.md` | `references/lessons-learned.md` | `lessons-learned.md` |
| `…migration/references/lessons-learned.md` | `references/architecture-patterns.md` | `architecture-patterns.md` |
| `…migration/references/lessons-learned.md` | `references/migration-checklist.md` | `migration-checklist.md` |
| `…migration/references/lessons-learned.md` | `references/parity-evidence.md` | `parity-evidence.md` |
| `…migration/references/migration-checklist.md` | `references/lessons-learned.md` | `lessons-learned.md` |
| `…migration/references/migration-checklist.md` | `references/seam-catalog.md` | `seam-catalog.md` |

</details>

<details>
<summary><b>How these were found</b></summary>

Not by reading. They surfaced while verifying that a *different* change — the skill compression in #1100 — had not broken any pointers. The check resolves every path-like `.md` reference inside `.claude` from the directory of the file that writes it, and reports the misses.

That check found one genuine regression introduced by #1099 (fixed there) and these nine, which predate all of this work. They are split into this PR precisely because they are unrelated to it: an unrelated fix riding along in a compression PR is how a reviewer loses track of what they approved.

The same check is what verifies this PR. It is currently a throwaway script rather than something in CI — see "deliberately not here" above.

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1102)
<!-- Reviewable:end -->
