### PR TITLE
LT-22641: Fix crash restoring a project from another computer

### DIFF
--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 SIL International
+// Copyright (c) 2014-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -551,19 +551,16 @@ namespace SIL.FieldWorks.XWorks
 		/// Note: homograph parameters are used for sense numbers in both the dictionary and reversal. They are never used for reversal numbers.
 		/// So, homograph parameters should always be set based on the dictionary configuration and not the reversal index configuration.
 		/// </summary>
-		/// <param name="model"></param>
-		/// <param name="cache"></param>
 		public static void SetConfigureHomographParameters(PropertyTable propertyTable, LcmCache cache)
 		{
 			var cacheHc = cache.ServiceLocator.GetInstance<HomographConfiguration>();
 
 			// Load the dictionary configuration.
-			var dictionaryConfigPath = propertyTable.GetStringProperty("DictionaryPublicationLayout", string.Empty);
+			var dictionaryConfigPath = DictionaryConfigurationListener.GetCurrentConfiguration(
+				propertyTable, false, DictionaryConfigurationListener.DictConfigDirName, null, false);
 			var dictionaryModel = new DictionaryConfigurationModel(dictionaryConfigPath, cache);
-			if (dictionaryModel.HomographConfiguration == null)
-			{
-				dictionaryModel.HomographConfiguration = new DictionaryHomographConfiguration(new HomographConfiguration());
-			}
+			dictionaryModel.HomographConfiguration ??=
+				new DictionaryHomographConfiguration(new HomographConfiguration());
 
 			ConfigurableDictionaryNode dictionarySenseNode = null;
 
@@ -571,8 +568,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				// Find the "Senses" node in the dictionary configuration
 				var dictionaryMainEntry = dictionaryModel.Parts[0];
-				dictionarySenseNode = dictionaryMainEntry.Children
-					.Where(prop => prop.Label == "Senses").FirstOrDefault();
+				dictionarySenseNode = dictionaryMainEntry.Children.FirstOrDefault(prop => prop.Label == "Senses");
 			}
 
 			if (dictionarySenseNode != null)
@@ -582,7 +578,7 @@ namespace SIL.FieldWorks.XWorks
 				cacheHc.ksSenseNumberStyle = dictionarySenseOptions.NumberingStyle;
 
 				// Similarly for subsenses
-				var dictionarySubSenseNode = dictionarySenseNode.Children.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
+				var dictionarySubSenseNode = dictionarySenseNode.Children.FirstOrDefault(prop => prop.Label == "Subsenses");
 				if (dictionarySubSenseNode != null)
 				{
 					var dictionarySubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSenseNode.DictionaryNodeOptions;
@@ -590,7 +586,9 @@ namespace SIL.FieldWorks.XWorks
 					cacheHc.ksParentSenseNumberStyle = dictionarySubSenseOptions.ParentSenseNumberingStyle;
 
 					// And for subsubsenses
-					var dictionarySubSubSenseNode = dictionarySubSenseNode.ReferencedOrDirectChildren.Where(prop => prop.Label == "Subsenses").FirstOrDefault();
+					var dictionarySubSubSenseNode =
+						dictionarySubSenseNode.ReferencedOrDirectChildren.FirstOrDefault(prop =>
+							prop.Label == "Subsenses");
 					if (dictionarySubSubSenseNode != null)
 					{
 						var dictionarySubSubSenseOptions = (DictionaryNodeSenseOptions)dictionarySubSubSenseNode.DictionaryNodeOptions;

--- a/Src/xWorks/DictionaryConfigurationController.cs
+++ b/Src/xWorks/DictionaryConfigurationController.cs
@@ -553,8 +553,6 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		public static void SetConfigureHomographParameters(PropertyTable propertyTable, LcmCache cache)
 		{
-			var cacheHc = cache.ServiceLocator.GetInstance<HomographConfiguration>();
-
 			// Load the dictionary configuration.
 			var dictionaryConfigPath = DictionaryConfigurationListener.GetCurrentConfiguration(
 				propertyTable, false, DictionaryConfigurationListener.DictConfigDirName, null, false);
@@ -573,6 +571,8 @@ namespace SIL.FieldWorks.XWorks
 
 			if (dictionarySenseNode != null)
 			{
+				var cacheHc = cache.ServiceLocator.GetInstance<HomographConfiguration>();
+
 				var dictionarySenseOptions = (DictionaryNodeSenseOptions)dictionarySenseNode.DictionaryNodeOptions;
 				// Apply the dictionary sense numbering styles to the cache
 				cacheHc.ksSenseNumberStyle = dictionarySenseOptions.NumberingStyle;

--- a/Src/xWorks/DictionaryConfigurationListener.cs
+++ b/Src/xWorks/DictionaryConfigurationListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 SIL International
+// Copyright (c) 2014-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -8,16 +8,9 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
-using SIL.Extensions;
 using SIL.FieldWorks.Common.FwUtils;
 using static SIL.FieldWorks.Common.FwUtils.FwUtils;
-using SIL.FieldWorks.Common.RootSites;
-using SIL.FieldWorks.Common.Widgets;
 using SIL.LCModel;
-using SIL.LCModel.DomainImpl;
-using SIL.FieldWorks.FwCoreDlgs;
-using SIL.FieldWorks.XWorks.LexText;
-using SIL.LCModel.Core.WritingSystems;
 using XCore;
 using SIL.FieldWorks.FdoUi;
 
@@ -268,27 +261,19 @@ namespace SIL.FieldWorks.XWorks
 			return GetCurrentConfiguration(propertyTable, true, innerConfigDir, obj);
 		}
 
-		private static void SetConfigureHomographParameters(PropertyTable propertyTable, LcmCache cache)
-		{
-			DictionaryConfigurationController.SetConfigureHomographParameters(propertyTable, cache);
-		}
-
-
 		/// <summary>
 		/// Returns the path to the current Dictionary or ReversalIndex configuration file, based on client specification or the current tool
 		/// Guarantees that the path is set to an existing configuration file, which may cause a redisplay of the XHTML view if fUpdate is true.
 		/// </summary>
-		public static string GetCurrentConfiguration(PropertyTable propertyTable, bool fUpdate, string innerConfigDir = null, ICmObject obj = null)
+		public static string GetCurrentConfiguration(PropertyTable propertyTable,
+			bool fBroadcastIfChanged, string innerConfigDir = null, ICmObject obj = null,
+			bool fSetConfigureHomographParameters = true)
 		{
 			// Since this is used in the display of the title and XWorksViews sometimes tries to display the title
 			// before full initialization (if this view is the one being displayed on startup) test the propertyTable before continuing.
 			if(propertyTable == null)
 				return null;
-			if (innerConfigDir == null)
-			{
-				innerConfigDir = GetInnermostConfigurationDirectory(propertyTable, obj) ??
-								 ReversalIndexServices.RevIndexDir;
-			}
+			innerConfigDir ??= GetInnermostConfigurationDirectory(propertyTable, obj) ?? DictConfigDirName;
 			var pubLayoutPropName = GetPropNameForConfigType(innerConfigDir);
 			var currentConfig = pubLayoutPropName != null
 				? propertyTable.GetStringProperty(pubLayoutPropName, string.Empty)
@@ -296,8 +281,10 @@ namespace SIL.FieldWorks.XWorks
 			var cache = propertyTable.GetValue<LcmCache>("cache");
 			if (!string.IsNullOrEmpty(currentConfig) && File.Exists(currentConfig))
 			{
-				var dictionaryConfigDir = GetProjectConfigurationDirectory(propertyTable, DictConfigDirName);
-				SetConfigureHomographParameters(propertyTable, cache);
+				if (fSetConfigureHomographParameters)
+				{
+					DictionaryConfigurationController.SetConfigureHomographParameters(propertyTable, cache);
+				}
 				return currentConfig;
 			}
 			var defaultConfigFileName = GetDefaultConfigFileName(innerConfigDir);
@@ -307,7 +294,7 @@ namespace SIL.FieldWorks.XWorks
 			// and the value is "publishSomething", try to use the new "Something" config
 			if (currentConfig != null && currentConfig.StartsWith("publish", StringComparison.Ordinal))
 			{
-				var selectedPublication = currentConfig.Replace("publish", string.Empty);
+				var selectedPublication = currentConfig.Substring("publish".Length);
 				if (innerConfigDir == RevIndexConfigDirName)
 				{
 					var languageCode = selectedPublication.Replace("Reversal-", string.Empty);
@@ -327,7 +314,7 @@ namespace SIL.FieldWorks.XWorks
 					// check in projectConfigDir for files whose name = default analysis ws
 					if (TryMatchingReversalConfigByWritingSystem(propertyTable, projectConfigDir, cache, out currentConfig))
 					{
-						propertyTable.SetProperty(pubLayoutPropName, currentConfig, fUpdate);
+						propertyTable.SetProperty(pubLayoutPropName, currentConfig, fBroadcastIfChanged);
 						return currentConfig;
 					}
 				}
@@ -340,7 +327,7 @@ namespace SIL.FieldWorks.XWorks
 			}
 			if (File.Exists(currentConfig) && pubLayoutPropName != null)
 			{
-				propertyTable.SetProperty(pubLayoutPropName, currentConfig, fUpdate);
+				propertyTable.SetProperty(pubLayoutPropName, currentConfig, fBroadcastIfChanged);
 			}
 			else if(pubLayoutPropName != null)
 			{

--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -133,10 +133,11 @@ namespace SIL.FieldWorks.XWorks
 			if (progress != null)
 			  progress.Maximum = entriesToSave.Length;
 
-			// ReSharper disable once ObjectCreationAsStatement - The Reversal Configuration needs
-			// to be loaded per https://github.com/sillsdev/FieldWorks/pull/939
-			// REVIEW (Hasso) 2026.08: why is this needed? The revConfig is passed in, so it must
-			// have been loaded already.
+			// ReSharper disable once ObjectCreationAsStatement
+			// (Re)loading the reversal configuration ensures its homograph settings are in the
+			// cache's HomographConfiguration singleton during export.
+			// https://github.com/sillsdev/FieldWorks/pull/939
+			// REVIEW (Hasso) 2026.08: would revConfig.Load(m_cache); suffice?
 			new DictionaryConfigurationModel(
 				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable,
 					"ReversalIndex"), m_cache);

--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -133,11 +133,13 @@ namespace SIL.FieldWorks.XWorks
 			if (progress != null)
 			  progress.Maximum = entriesToSave.Length;
 
-			// ReSharper disable once ObjectCreationAsStatement - The Reversal Configuration needs to be loaded per
-			// https://github.com/sillsdev/FieldWorks/pull/939
-			// REVIEW (Hasso) 2026.08: why is this needed? The revConfig is passed in, so it must have been loaded already.
+			// ReSharper disable once ObjectCreationAsStatement - The Reversal Configuration needs
+			// to be loaded per https://github.com/sillsdev/FieldWorks/pull/939
+			// REVIEW (Hasso) 2026.08: why is this needed? The revConfig is passed in, so it must
+			// have been loaded already.
 			new DictionaryConfigurationModel(
-				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable, "ReversalIndex"), m_cache);
+				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable,
+					"ReversalIndex"), m_cache);
 
 			string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-reversal-" + reversalWs + ".docx";
 			LcmWordGenerator.SavePublishedDocx(entriesToSave, revClerk, pubDecorator, int.MaxValue, revConfig, m_propertyTable,

--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -133,7 +133,10 @@ namespace SIL.FieldWorks.XWorks
 			if (progress != null)
 			  progress.Maximum = entriesToSave.Length;
 
-			var dictConfig = new DictionaryConfigurationModel(
+			// ReSharper disable once ObjectCreationAsStatement - The Reversal Configuration needs to be loaded per
+			// https://github.com/sillsdev/FieldWorks/pull/939
+			// REVIEW (Hasso) 2026.08: why is this needed? The revConfig is passed in, so it must have been loaded already.
+			new DictionaryConfigurationModel(
 				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable, "ReversalIndex"), m_cache);
 
 			string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-reversal-" + reversalWs + ".docx";

--- a/Src/xWorks/xWorksTests/DictionaryConfigurationControllerTests.cs
+++ b/Src/xWorks/xWorksTests/DictionaryConfigurationControllerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 SIL International
+// Copyright (c) 2014-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -17,6 +17,7 @@ using SIL.LCModel.Core.KernelInterfaces;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.FieldWorks.Common.Widgets;
 using SIL.LCModel;
+using SIL.LCModel.DomainImpl;
 using SIL.LCModel.DomainServices;
 using SIL.LCModel.Infrastructure;
 using SIL.LCModel.Utils;
@@ -42,6 +43,30 @@ namespace SIL.FieldWorks.XWorks
 		public void Setup()
 		{
 			m_model = new DictionaryConfigurationModel();
+		}
+
+		[Test]
+		public void SetConfigureHomographParameters_InvalidPathInPropertyTable_UsesDefaultConfiguration()
+		{
+			var nonExistentPath = Path.Combine(Path.GetTempPath(),
+				Guid.NewGuid() + DictionaryConfigurationModel.FileExtension);
+			m_propertyTable.SetProperty("DictionaryPublicationLayout", nonExistentPath, false);
+
+			// set sense numbering styles to something other than the default to verify that
+			// values are loaded from the default configuration file.
+			var hc = Cache.ServiceLocator.GetInstance<HomographConfiguration>();
+			hc.ksSenseNumberStyle = "sense-";
+			hc.ksSubSenseNumberStyle = "numbing";
+			// not setting subsubsense numbering style because the default configuration file
+			// does not have a value for it
+
+			// SUT
+			DictionaryConfigurationController.SetConfigureHomographParameters(m_propertyTable, Cache);
+
+			Assert.That(hc, Is.Not.Null, "HomographConfiguration instance should exist");
+			Assert.That(hc.ksSenseNumberStyle, Is.EqualTo("%d"), "Sense numbering style should have been configured");
+			Assert.That(hc.ksSubSenseNumberStyle, Is.EqualTo("%d"), "Subsense numbering style should have been configured");
+			Assert.That(hc.ksSubSubSenseNumberStyle, Is.EqualTo("%d"), "Subsubsense numbering style should still be configured");
 		}
 
 		[OneTimeSetUp]


### PR DESCRIPTION
When getting the current dictionary configuration from the property table, ensure that the file exists. If the settings were restored from another computer, paths might not match, leading to a crash.

## CI-ready checklist

- [x] Commit messages follow [`.github/commit-guidelines.md`](https://github.com/sillsdev/FieldWorks/blob/main/.github/commit-guidelines.md).
- [x] As much as possible, the change is unit tested.
- [x] Builds & tests pass locally (or I've run the CI-style build via `build.ps1`, `test.ps1`, or MSBuild).
- [ ] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.
- [x] I have considered all comments from an AI code reviewer (such as [Devin](https://app.devin.ai/review/sillsdev/FieldWorks/pull/1103))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1103)
<!-- Reviewable:end -->
