### PR TITLE
LT-22691: Copy writing-system menu choices into the view override

### DIFF
--- a/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
+++ b/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using SIL.FieldWorks.Common.FwAvalonia.Detail;
+using XCore;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// The commands the Avalonia detail view retargets away from mediator dispatch, as ordered
+	/// entries keyed by command HelpId. <see cref="TryBuild"/> is the interceptor shape
+	/// <see cref="XCoreMenuBridge"/> consumes: the first matching entry builds the replacement
+	/// item; null leaves the command on its normal dispatch.
+	/// </summary>
+	internal sealed class OverrideCommandRegistry
+	{
+		private readonly List<KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>> _entries
+			= new List<KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>>();
+
+		public void Add(string helpId, Func<ChoiceBase, DetailMenuItem> build)
+			=> _entries.Add(new KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>(helpId, build));
+
+		public DetailMenuItem TryBuild(ChoiceBase choice)
+		{
+			foreach (var entry in _entries)
+			{
+				if (string.Equals(choice.HelpId, entry.Key, StringComparison.Ordinal))
+					return entry.Value(choice);
+			}
+
+			return null;
+		}
+	}
+}

--- a/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
+++ b/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
@@ -11,23 +11,27 @@ namespace SIL.FieldWorks.XWorks
 {
 	/// <summary>
 	/// The commands the Avalonia detail view retargets away from mediator dispatch, as ordered
-	/// entries keyed by command HelpId. <see cref="TryBuild"/> is the interceptor shape
-	/// <see cref="XCoreMenuBridge"/> consumes: the first matching entry builds the replacement
-	/// item; null leaves the command on its normal dispatch.
+	/// (matcher, builder) entries. <see cref="TryBuild"/> builds the replacement item from the
+	/// first matching entry; null leaves the command on its normal dispatch.
 	/// </summary>
 	internal sealed class OverrideCommandRegistry
 	{
-		private readonly List<KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>> _entries
-			= new List<KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>>();
+		private readonly List<KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>> _entries
+			= new List<KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>>();
 
 		public void Add(string helpId, Func<ChoiceBase, DetailMenuItem> build)
-			=> _entries.Add(new KeyValuePair<string, Func<ChoiceBase, DetailMenuItem>>(helpId, build));
+			=> Add(c => string.Equals(c.HelpId, helpId, StringComparison.Ordinal), build);
+
+		/// <summary>Registers by matcher, for items that carry no command id.</summary>
+		public void Add(Func<ChoiceBase, bool> matches, Func<ChoiceBase, DetailMenuItem> build)
+			=> _entries.Add(
+				new KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>(matches, build));
 
 		public DetailMenuItem TryBuild(ChoiceBase choice)
 		{
 			foreach (var entry in _entries)
 			{
-				if (string.Equals(choice.HelpId, entry.Key, StringComparison.Ordinal))
+				if (entry.Key(choice))
 					return entry.Value(choice);
 			}
 

--- a/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
+++ b/Src/xWorks/Avalonia/Hosting/OverrideCommandRegistry.cs
@@ -16,23 +16,26 @@ namespace SIL.FieldWorks.XWorks
 	/// </summary>
 	internal sealed class OverrideCommandRegistry
 	{
-		private readonly List<KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>> _entries
-			= new List<KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>>();
+		private readonly List<KeyValuePair<Func<ChoiceBase, bool>,
+			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem>>> _entries
+			= new List<KeyValuePair<Func<ChoiceBase, bool>,
+				Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem>>>();
 
-		public void Add(string helpId, Func<ChoiceBase, DetailMenuItem> build)
+		public void Add(string helpId, Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> build)
 			=> Add(c => string.Equals(c.HelpId, helpId, StringComparison.Ordinal), build);
 
 		/// <summary>Registers by matcher, for items that carry no command id.</summary>
-		public void Add(Func<ChoiceBase, bool> matches, Func<ChoiceBase, DetailMenuItem> build)
-			=> _entries.Add(
-				new KeyValuePair<Func<ChoiceBase, bool>, Func<ChoiceBase, DetailMenuItem>>(matches, build));
+		public void Add(Func<ChoiceBase, bool> matches,
+			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> build)
+			=> _entries.Add(new KeyValuePair<Func<ChoiceBase, bool>,
+				Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem>>(matches, build));
 
-		public DetailMenuItem TryBuild(ChoiceBase choice)
+		public DetailMenuItem TryBuild(ChoiceBase choice, UIItemDisplayProperties display)
 		{
 			foreach (var entry in _entries)
 			{
 				if (entry.Key(choice))
-					return entry.Value(choice);
+					return entry.Value(choice, display);
 			}
 
 			return null;

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -602,24 +602,17 @@ namespace SIL.FieldWorks.XWorks
 			if (location == null)
 				return null; // unknown/stale target: leave commands on the legacy path rather than guess.
 
-			return choice =>
-			{
-				switch (choice.HelpId)
-				{
-					case "CmdAlwaysVisible":
-						return VisibilityItem(choice, field, templateId, location, ViewVisibility.Always);
-					case "CmdIfData":
-						return VisibilityItem(choice, field, templateId, location, ViewVisibility.IfData);
-					case "CmdNormallyHidden":
-						return VisibilityItem(choice, field, templateId, location, ViewVisibility.Never);
-					case "CmdDataTree-MoveFieldUp":
-						return MoveItem(choice, field, location, up: true);
-					case "CmdDataTree-MoveFieldDown":
-						return MoveItem(choice, field, location, up: false);
-					default:
-						return null; // not a field command: keep its normal mediator dispatch.
-				}
-			};
+			// An unregistered command falls through TryBuild as null: normal mediator dispatch.
+			var registry = new OverrideCommandRegistry();
+			registry.Add("CmdAlwaysVisible",
+				c => VisibilityItem(c, field, templateId, location, ViewVisibility.Always));
+			registry.Add("CmdIfData",
+				c => VisibilityItem(c, field, templateId, location, ViewVisibility.IfData));
+			registry.Add("CmdNormallyHidden",
+				c => VisibilityItem(c, field, templateId, location, ViewVisibility.Never));
+			registry.Add("CmdDataTree-MoveFieldUp", c => MoveItem(c, field, location, up: true));
+			registry.Add("CmdDataTree-MoveFieldDown", c => MoveItem(c, field, location, up: false));
+			return registry.TryBuild;
 		}
 
 		// A Field Visibility menu item: checked when it is the field's current visibility, executes the

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -570,7 +570,8 @@ namespace SIL.FieldWorks.XWorks
 		/// rows; that keeps the legacy behavior intact when the override layer cannot be
 		/// addressed.
 		/// </summary>
-		private Func<ChoiceBase, DetailMenuItem> BuildOverrideCommandInterceptor(DetailField field)
+		private Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> BuildOverrideCommandInterceptor(
+			DetailField field)
 		{
 			if (field == null || string.IsNullOrEmpty(field.ClassName) || string.IsNullOrEmpty(field.LayoutName)
 				|| ViewOverrideStore == null)
@@ -582,7 +583,7 @@ namespace SIL.FieldWorks.XWorks
 			// into the override. They need no located template node, so they stay registered
 			// even when locating fails.
 			var registry = new OverrideCommandRegistry();
-			registry.Add(IsWritingSystemVisibilityChoice, c => WritingSystemItem(c, field));
+			registry.Add(IsWritingSystemVisibilityChoice, (c, d) => WritingSystemItem(c, d, field));
 
 			var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
 			// Locate the clicked node in the field's OWN compiled model (with any current override
@@ -610,14 +611,15 @@ namespace SIL.FieldWorks.XWorks
 			if (location != null)
 			{
 				registry.Add("CmdAlwaysVisible",
-					c => VisibilityItem(c, field, templateId, location, ViewVisibility.Always));
+					(c, d) => VisibilityItem(d, field, templateId, location, ViewVisibility.Always));
 				registry.Add("CmdIfData",
-					c => VisibilityItem(c, field, templateId, location, ViewVisibility.IfData));
+					(c, d) => VisibilityItem(d, field, templateId, location, ViewVisibility.IfData));
 				registry.Add("CmdNormallyHidden",
-					c => VisibilityItem(c, field, templateId, location, ViewVisibility.Never));
-				registry.Add("CmdDataTree-MoveFieldUp", c => MoveItem(c, field, location, up: true));
+					(c, d) => VisibilityItem(d, field, templateId, location, ViewVisibility.Never));
+				registry.Add("CmdDataTree-MoveFieldUp",
+					(c, d) => MoveItem(d, field, location, up: true));
 				registry.Add("CmdDataTree-MoveFieldDown",
-					c => MoveItem(c, field, location, up: false));
+					(c, d) => MoveItem(d, field, location, up: false));
 			}
 
 			return registry.TryBuild;
@@ -626,20 +628,20 @@ namespace SIL.FieldWorks.XWorks
 		// A Field Visibility menu item: checked when it is the field's current visibility, executes the
 		// SetVisibility override mutation (idempotent -- re-choosing the current value is a
 		// harmless write).
-		private DetailMenuItem VisibilityItem(ChoiceBase choice, DetailField field,
+		private DetailMenuItem VisibilityItem(UIItemDisplayProperties display, DetailField field,
 			string templateId, ViewNodeLocation location, ViewVisibility target)
 		{
-			var label = XCoreMenuBridge.StripAccelerator(choice.GetDisplayProperties().Text);
+			var label = XCoreMenuBridge.StripAccelerator(display.Text);
 			var isChecked = location.Visibility == target;
 			return new DetailMenuItem(label, isEnabled: true, isChecked: isChecked, children: null,
 				execute: () => ApplyFieldVisibility(field, templateId, target));
 		}
 
 		// A Move Field item: disabled at the first sibling (up) / last sibling (down) / when alone.
-		private DetailMenuItem MoveItem(ChoiceBase choice, DetailField field,
+		private DetailMenuItem MoveItem(UIItemDisplayProperties display, DetailField field,
 			ViewNodeLocation location, bool up)
 		{
-			var label = XCoreMenuBridge.StripAccelerator(choice.GetDisplayProperties().Text);
+			var label = XCoreMenuBridge.StripAccelerator(display.Text);
 			var canMove = up ? location.CanMoveUp : location.CanMoveDown;
 			return new DetailMenuItem(label, isEnabled: canMove, isChecked: false, children: null,
 				execute: canMove ? (Action)(() => ApplyMoveField(field, location, up)) : null);
@@ -670,23 +672,21 @@ namespace SIL.FieldWorks.XWorks
 		/// Configure dialog, while the Avalonia detail view composes from its own override
 		/// store.
 		/// </summary>
-		private DetailMenuItem WritingSystemItem(ChoiceBase choice, DetailField field)
+		private DetailMenuItem WritingSystemItem(ChoiceBase choice, UIItemDisplayProperties display,
+			DetailField field)
 		{
-			var display = choice.GetDisplayProperties();
 			var isListToggle = choice is ListPropertyChoice;
-			// No execute when disabled: clicking the last checked toggle would EMPTY the set.
-			var execute = display.Enabled
-				? (Action)(() =>
+			// The bridge strips execute from disabled items, so the last checked toggle
+			// (disabled) can never be invoked to EMPTY the set.
+			return new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), display.Enabled,
+				display.Checked, children: null, execute: () =>
 				{
 					// Snapshot first, so a dialog that changes nothing (e.g. Cancel) copies
 					// nothing.
 					var before = isListToggle ? null : CurrentSliceSelectedWritingSystems();
 					choice.OnClick(null, EventArgs.Empty);
 					CopyWritingSystemSelectionToOverride(field, isListToggle, before);
-				})
-				: null;
-			return new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), display.Enabled,
-				display.Checked, children: null, execute: execute);
+				});
 		}
 
 		// Copies the click's selection into the row's override and recomposes. A toggle

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -563,12 +563,12 @@ namespace SIL.FieldWorks.XWorks
 					+ "'; using the shipped definition.", error));
 
 		/// <summary>
-		/// Builds the interceptor that retargets the per-field Field Visibility and
-		/// Move Field commands to the project override layer for the Avalonia detail view. Returns null
-		/// (intercept nothing -- every command keeps its normal mediator dispatch) when the
-		/// clicked row
-		/// carries no (class, layout) context, e.g. the first-slice fallback rows; that keeps the legacy
-		/// behavior intact when the override layer cannot be addressed.
+		/// Builds the interceptor that retargets the per-field Field Visibility, Move Field, and
+		/// writing-system commands to the project override layer for the Avalonia detail view.
+		/// Returns null (intercept nothing -- every command keeps its normal mediator dispatch)
+		/// when the clicked row carries no (class, layout) context, e.g. the first-slice fallback
+		/// rows; that keeps the legacy behavior intact when the override layer cannot be
+		/// addressed.
 		/// </summary>
 		private Func<ChoiceBase, DetailMenuItem> BuildOverrideCommandInterceptor(DetailField field)
 		{
@@ -577,6 +577,12 @@ namespace SIL.FieldWorks.XWorks
 			{
 				return null;
 			}
+
+			// Writing-system items dispatch normally; the resulting selection is then copied
+			// into the override. They need no located template node, so they stay registered
+			// even when locating fails.
+			var registry = new OverrideCommandRegistry();
+			registry.Add(IsWritingSystemVisibilityChoice, c => WritingSystemItem(c, field));
 
 			var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
 			// Locate the clicked node in the field's OWN compiled model (with any current override
@@ -596,22 +602,24 @@ namespace SIL.FieldWorks.XWorks
 			{
 				Logger.WriteError("Resolving the field's override target failed; the gear-menu field "
 					+ "commands fall back to the legacy path for this row.", e);
-				return null;
+				return registry.TryBuild;
 			}
 
-			if (location == null)
-				return null; // unknown/stale target: leave commands on the legacy path rather than guess.
+			// Unknown/stale target: leave the field commands on the legacy path rather than
+			// guess.
+			if (location != null)
+			{
+				registry.Add("CmdAlwaysVisible",
+					c => VisibilityItem(c, field, templateId, location, ViewVisibility.Always));
+				registry.Add("CmdIfData",
+					c => VisibilityItem(c, field, templateId, location, ViewVisibility.IfData));
+				registry.Add("CmdNormallyHidden",
+					c => VisibilityItem(c, field, templateId, location, ViewVisibility.Never));
+				registry.Add("CmdDataTree-MoveFieldUp", c => MoveItem(c, field, location, up: true));
+				registry.Add("CmdDataTree-MoveFieldDown",
+					c => MoveItem(c, field, location, up: false));
+			}
 
-			// An unregistered command falls through TryBuild as null: normal mediator dispatch.
-			var registry = new OverrideCommandRegistry();
-			registry.Add("CmdAlwaysVisible",
-				c => VisibilityItem(c, field, templateId, location, ViewVisibility.Always));
-			registry.Add("CmdIfData",
-				c => VisibilityItem(c, field, templateId, location, ViewVisibility.IfData));
-			registry.Add("CmdNormallyHidden",
-				c => VisibilityItem(c, field, templateId, location, ViewVisibility.Never));
-			registry.Add("CmdDataTree-MoveFieldUp", c => MoveItem(c, field, location, up: true));
-			registry.Add("CmdDataTree-MoveFieldDown", c => MoveItem(c, field, location, up: false));
 			return registry.TryBuild;
 		}
 
@@ -636,6 +644,119 @@ namespace SIL.FieldWorks.XWorks
 			return new DetailMenuItem(label, isEnabled: canMove, isChecked: false, children: null,
 				execute: canMove ? (Action)(() => ApplyMoveField(field, location, up)) : null);
 		}
+
+		/// <summary>
+		/// Whether this menu item makes a persistent change to which writing systems a
+		/// multi-writing-system field shows: a per-writing-system toggle (recognized by the
+		/// property its group drives -- the toggles carry no command id) or the Configure
+		/// dialog. Show all right now is excluded: it is a transient reveal on the slice,
+		/// not a configuration change, so persisting it would wrongly pin the full set.
+		/// </summary>
+		private static bool IsWritingSystemVisibilityChoice(ChoiceBase choice)
+		{
+			if (choice is ListPropertyChoice list)
+			{
+				return string.Equals(list.ParentProperty,
+					PropertyConstants.CurrentContextMenuSelectedWsIds, StringComparison.Ordinal);
+			}
+
+			return string.Equals(choice.HelpId, "CmdDataTree-WritingSystemMenu-Configure",
+				StringComparison.Ordinal);
+		}
+
+		/// <summary>
+		/// A writing-system item that dispatches normally and then copies the resulting
+		/// selection into the override: the hidden adapter slice owns the picker and the
+		/// Configure dialog, while the Avalonia detail view composes from its own override
+		/// store.
+		/// </summary>
+		private DetailMenuItem WritingSystemItem(ChoiceBase choice, DetailField field)
+		{
+			var display = choice.GetDisplayProperties();
+			var isListToggle = choice is ListPropertyChoice;
+			// No execute when disabled: clicking the last checked toggle would EMPTY the set.
+			var execute = display.Enabled
+				? (Action)(() =>
+				{
+					// Snapshot first, so a dialog that changes nothing (e.g. Cancel) copies
+					// nothing.
+					var before = isListToggle ? null : CurrentSliceSelectedWritingSystems();
+					choice.OnClick(null, EventArgs.Empty);
+					CopyWritingSystemSelectionToOverride(field, isListToggle, before);
+				})
+				: null;
+			return new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), display.Enabled,
+				display.Checked, children: null, execute: execute);
+		}
+
+		// Copies the click's selection into the row's override and recomposes. A toggle
+		// updates its property BEFORE the slice: read the property, in option order;
+		// Configure reads the slice.
+		private void CopyWritingSystemSelectionToOverride(DetailField field, bool fromListToggle,
+			IReadOnlyList<string> sliceSetBeforeClick)
+		{
+			try
+			{
+				var slice = m_dataEntryForm?.CurrentSlice as MultiStringSlice;
+				if (slice == null)
+				{
+					// The command dispatched, but the result is unreadable: say so, or the
+					// symptom is "the menu did nothing" with no trail.
+					Logger.WriteEvent("Writing-system selection was not copied: the adapter "
+						+ "slice is unreadable; the view override was not updated.");
+					return;
+				}
+
+				// A stale adapter target would store another row's set under this row's id.
+				if (slice.Object == null || slice.Object.Hvo != field.ObjectHvo)
+				{
+					Logger.WriteEvent("Writing-system selection was not copied: the adapter "
+						+ "slice is not the clicked row's; the view override was not updated.");
+					return;
+				}
+
+				List<string> selected;
+				if (fromListToggle)
+				{
+					var ids = m_propertyTable.GetStringProperty(
+						PropertyConstants.CurrentContextMenuSelectedWsIds, null);
+					// Canonicalize: option order, junk tokens dropped -- the stored order is the
+					// render order.
+					selected = string.IsNullOrEmpty(ids)
+						? null
+						: StringSliceUtils.GetVisibleWritingSystems(ids,
+							slice.WritingSystemOptionsForDisplay).Select(ws => ws.Id).ToList();
+				}
+				else
+				{
+					selected = slice.WritingSystemsSelectedForDisplay?.Select(ws => ws.Id).ToList();
+					if (selected != null && sliceSetBeforeClick != null
+						&& selected.SequenceEqual(sliceSetBeforeClick, StringComparer.Ordinal))
+					{
+						return; // the dialog changed nothing (e.g. Cancel): no override write.
+					}
+				}
+
+				// The menu disables the last checked toggle, so an empty set only means "nothing
+				// to copy" -- and an empty op would CLEAR the restriction, so bail instead.
+				if (selected == null || selected.Count == 0)
+					return;
+
+				var op = new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems,
+					ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId),
+					writingSystems: selected);
+				MutateOverrideAndRefresh(field, op);
+			}
+			catch (Exception e)
+			{
+				Logger.WriteError("Copying the writing-system selection into the view override failed.", e);
+			}
+		}
+
+		// The adapter slice's current selection, or null when it cannot be read.
+		private IReadOnlyList<string> CurrentSliceSelectedWritingSystems()
+			=> (m_dataEntryForm?.CurrentSlice as MultiStringSlice)
+				?.WritingSystemsSelectedForDisplay?.Select(ws => ws.Id).ToList();
 
 		// Writes a SetVisibility op for the field's template id into the project override and recomposes.
 		private void ApplyFieldVisibility(DetailField field, string templateId, ViewVisibility target)

--- a/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
+++ b/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
@@ -32,16 +32,18 @@ namespace SIL.FieldWorks.XWorks
 		/// <summary>
 		/// As <see cref="CreateMenuItems(XWindow, string[])"/>, but lets the host RETARGET specific leaf
 		/// commands for the Avalonia detail view (advanced-entry-view). For each command leaf, the
-		/// <paramref name="interceptor"/> is offered the leaf <see cref="ChoiceBase"/> (so the host can
-		/// read the localized label and command id from it); if it returns a non-null
+		/// <paramref name="interceptor"/> is offered the leaf <see cref="ChoiceBase"/> and its
+		/// already-computed display properties (so the host reads the localized label and state
+		/// without a second Display* round trip); if it returns a non-null
 		/// <see cref="DetailMenuItem"/>, that item (its label/checked/enabled/execute) is used INSTEAD of
 		/// the default xCore-dispatched item. Returning null leaves the command on its normal mediator
 		/// path. This is how the per-field Field Visibility / Move Field commands route to the project
 		/// override layer while Help and every other item keep working unchanged. The interceptor only
-		/// sees leaf commands (submenus pass through).
+		/// sees leaf commands (submenus pass through). Every leaf, default or retargeted, is
+		/// normalized so a disabled item carries no execute action.
 		/// </summary>
 		public static IReadOnlyList<DetailMenuItem> CreateMenuItems(XWindow window, string[] menuIds,
-			Func<ChoiceBase, DetailMenuItem> interceptor)
+			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> interceptor)
 		{
 			var group = window?.GetContextMenuChoiceGroup(menuIds);
 			if (group == null)
@@ -50,7 +52,8 @@ namespace SIL.FieldWorks.XWorks
 			return Convert(group, interceptor);
 		}
 
-		private static List<DetailMenuItem> Convert(ChoiceGroup group, Func<ChoiceBase, DetailMenuItem> interceptor)
+		private static List<DetailMenuItem> Convert(ChoiceGroup group,
+			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> interceptor)
 		{
 			var items = new List<DetailMenuItem>();
 			foreach (var member in group)
@@ -90,22 +93,30 @@ namespace SIL.FieldWorks.XWorks
 					// advanced-entry-view: offer the leaf to the host; a non-null result retargets this
 					// command to the override layer (Field Visibility / Move Field) instead of the
 					// hidden-DataTree mediator dispatch.
-					var retargeted = interceptor?.Invoke(choice);
+					var retargeted = interceptor?.Invoke(choice, display);
 					if (retargeted != null)
 					{
-						items.Add(retargeted);
+						items.Add(WithoutExecuteWhenDisabled(retargeted));
 						continue;
 					}
 
 					var captured = choice;
 					items.Add(new DetailMenuItem(StripAccelerator(display.Text), display.Enabled,
-						display.Checked, null, () => captured.OnClick(null, EventArgs.Empty)));
+						display.Checked, null,
+						display.Enabled ? (Action)(() => captured.OnClick(null, EventArgs.Empty)) : null));
 				}
 			}
 
 			TrimSeparators(items);
 			return items;
 		}
+
+		// A disabled leaf carries no execute action, so "Execute != null" means invokable for
+		// every consumer -- programmatic invokers included, not just the pointer UI.
+		private static DetailMenuItem WithoutExecuteWhenDisabled(DetailMenuItem item)
+			=> item.IsEnabled || item.Execute == null
+				? item
+				: new DetailMenuItem(item.Label, isEnabled: false, item.IsChecked, item.Children, null);
 
 		// xCore marks the accelerator with a single '_' before the mnemonic; WinForms
 		// translates it to '&'. Avalonia shows text raw, so strip only the first

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -489,7 +489,8 @@ namespace SIL.FieldWorks.XWorks
 			var build = typeof(RecordEditView).GetMethod("BuildOverrideCommandInterceptor",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			Assert.That(build, Is.Not.Null, "the override interceptor seam must exist");
-			var interceptor = (Func<ChoiceBase, DetailMenuItem>)build.Invoke(m_view, new object[] { field });
+			var interceptor = (Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem>)build.Invoke(
+				m_view, new object[] { field });
 			TestContext.WriteLine("interceptor built: " + (interceptor != null));
 			var window = m_propertyTable.GetValue<XWindow>("window");
 			return XCoreMenuBridge.CreateMenuItems(window, menuIds, interceptor);

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -13,9 +13,11 @@ using NUnit.Framework;
 using SIL.FieldWorks.Common.Controls;
 using SIL.FieldWorks.Common.FwAvalonia;
 using SIL.FieldWorks.Common.FwAvalonia.Detail;
+using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
 using SIL.FieldWorks.Common.Framework.DetailControls;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
+using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Infrastructure;
 using XCore;
 // Both namespaces above define DataTree; the adapter tests mean the legacy WinForms one.
@@ -363,9 +365,163 @@ namespace SIL.FieldWorks.XWorks
 				"the spliced entries are the project's vernacular writing systems (the Lexeme Form's ws set)");
 		}
 
+		// THE decisive copy test: unchecking one of two vernaculars must store the REDUCED
+		// set (the slice still holds the pre-click set right after OnClick), and re-checking
+		// must store the restored set.
+		[Test]
+		public void WritingSystemToggle_TwoVernaculars_StoresTheReducedThenRestoredSet()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentVernacularWritingSystems(second);
+			});
+			var field = LexemeFormField();
+			try
+			{
+				EnsureAdapter(m_entry.LexemeFormOA.Hvo, "Form");
+				var writingSystems = BuildWritingSystemsSubmenu(field);
+				var checkedEntries = writingSystems.Children
+					.Where(c => !c.IsSeparator && c.IsChecked && c.Execute != null).ToList();
+				TestContext.WriteLine("checked: " + string.Join(", ",
+					checkedEntries.Select(e => e.Label)));
+				Assert.That(checkedEntries.Count, Is.EqualTo(2),
+					"precondition: both vernacular writing systems start visible");
+				var toggled = checkedEntries[0].Label;
+
+				checkedEntries[0].Execute();
+				DrainMediatorAndIdleQueues();
+
+				var reduced = StoredWritingSystems(field);
+				TestContext.WriteLine("reduced: " + string.Join(",", reduced));
+				Assert.That(reduced, Is.EqualTo(new[] { "es" }),
+					"the stored op holds the set AFTER the uncheck, not the pre-click set");
+
+				// Re-check the same writing system on a freshly built menu: the ADD direction.
+				writingSystems = BuildWritingSystemsSubmenu(field);
+				var reAdd = writingSystems.Children.Single(c => !c.IsSeparator && c.Label == toggled);
+				Assert.That(reAdd.IsChecked, Is.False, "the unchecked toggle stays unchecked");
+				Assert.That(reAdd.Execute, Is.Not.Null, "an unchecked toggle is clickable");
+				reAdd.Execute();
+				DrainMediatorAndIdleQueues();
+
+				var restored = StoredWritingSystems(field);
+				TestContext.WriteLine("restored: " + string.Join(",", restored));
+				// Exact order matters: the property appends the re-checked writing system at the
+				// end, but the copy canonicalizes to option order so rows never reorder.
+				Assert.That(restored, Is.EqualTo(new[] { "fr", "es" }),
+					"re-checking stores the restored set in option order");
+			}
+			finally
+			{
+				DeleteOverrideFor(field);
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentVernacularWritingSystems.Remove(second));
+			}
+		}
+
+		// The Lexeme Form row is keyed by the MoForm's own descended (class, layout). Compose
+		// must resolve an override for it, or the row's customizations are written and never
+		// read.
+		[Test]
+		public void Compose_ResolvesTheOverrideForADescendedLayout()
+		{
+			var field = LexemeFormField();
+			var store = GetOverrideStore();
+			var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
+			TestContext.WriteLine(
+				$"class={field.ClassName} layout={field.LayoutName} template={templateId}");
+			try
+			{
+				store.Save(new ViewDefinitionOverride(field.ClassName, field.LayoutName, "detail",
+					new[]
+					{
+						new ViewOverrideOperation(ViewOverrideOperationKind.SetLabel, templateId,
+							label: "OverrideMarker")
+					}, null));
+
+				var asked = new List<string>();
+				var recomposed = DetailComposer.Compose(m_entry, Cache, showHiddenFields: false,
+					overrides: (cls, layout) =>
+					{
+						asked.Add(cls + "/" + layout);
+						return store.TryGet(cls, layout);
+					});
+				TestContext.WriteLine("compose asked for: " + string.Join(", ", asked));
+
+				var row = recomposed.Model.Fields.Single(f => f.Field == "Form"
+					&& f.Kind == DetailFieldKind.Text && f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+				Assert.That(row.Label, Is.EqualTo("OverrideMarker"),
+					"an override keyed by the row's own (class, layout) must reach the composed row");
+			}
+			finally
+			{
+				DeleteOverrideFor(field);
+			}
+		}
+
 		// -----------------------------------------------------------------
 		// Helpers -- production-path command drivers
 		// -----------------------------------------------------------------
+
+		// The composed Lexeme Form row, as the production host resolves it before raising a
+		// menu request.
+		private DetailField LexemeFormField()
+			=> DetailComposer.Compose(m_entry, Cache).Model.Fields.Single(f => f.Field == "Form"
+				&& f.Kind == DetailFieldKind.Text && f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+
+		private ViewDefinitionOverrideStore GetOverrideStore()
+		{
+			var storeProperty = typeof(RecordEditView).GetProperty("ViewOverrideStore",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.That(storeProperty, Is.Not.Null, "the override store seam must exist");
+			var store = (ViewDefinitionOverrideStore)storeProperty.GetValue(m_view);
+			Assert.That(store, Is.Not.Null, "the project must have a reachable override store");
+			return store;
+		}
+
+		// Materializes a menu the way OnDetailMenuRequested does, WITH the override interceptor,
+		// so the intercepted writing-system items are the ones under test.
+		private IReadOnlyList<DetailMenuItem> BuildItemsWithOverrideInterceptor(string[] menuIds,
+			DetailField field)
+		{
+			var build = typeof(RecordEditView).GetMethod("BuildOverrideCommandInterceptor",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.That(build, Is.Not.Null, "the override interceptor seam must exist");
+			var interceptor = (Func<ChoiceBase, DetailMenuItem>)build.Invoke(m_view, new object[] { field });
+			TestContext.WriteLine("interceptor built: " + (interceptor != null));
+			var window = m_propertyTable.GetValue<XWindow>("window");
+			return XCoreMenuBridge.CreateMenuItems(window, menuIds, interceptor);
+		}
+
+		private ViewDefinitionOverride ReadOverrideFor(DetailField field)
+			=> GetOverrideStore().TryGet(field.ClassName, field.LayoutName);
+
+		private DetailMenuItem BuildWritingSystemsSubmenu(DetailField field)
+		{
+			var items = BuildItemsWithOverrideInterceptor(
+				new[] { "mnuDataTree-LexemeForm", "mnuDataTree-MultiStringSlice" }, field);
+			var writingSystems = FindItem(items, "Writing Systems");
+			Assert.That(writingSystems, Is.Not.Null,
+				"precondition: the Writing Systems submenu is present");
+			return writingSystems;
+		}
+
+		// The writing systems the stored override op carries for the field's row.
+		private IReadOnlyList<string> StoredWritingSystems(DetailField field)
+		{
+			var stored = ReadOverrideFor(field);
+			Assert.That(stored, Is.Not.Null,
+				"toggling a writing system must write a project override");
+			return stored.Operations.Single(o =>
+				o.Kind == ViewOverrideOperationKind.SetVisibleWritingSystems).WritingSystems;
+		}
+
+		// Saving an empty patch deletes the file, so overrides never leak between tests.
+		private void DeleteOverrideFor(DetailField field)
+			=> GetOverrideStore().Save(new ViewDefinitionOverride(
+				field.ClassName, field.LayoutName, "detail", null, null));
 
 		// Drives a SLICE-menu command exactly as OnDetailMenuRequested(Kind=SliceMenu) does: ensure the
 		// adapter targets the object, materialize the menu (menuId + the host-appended mnuDataTree-Object)


### PR DESCRIPTION
In the new UI, changing which writing systems a multi-writing-system field shows — unchecking a toggle, re-checking one, or using the Configure dialog — now updates the Avalonia detail view immediately and persists per project. This completes the field-menu family started with Field Visibility and Move Field, and fixes the long-standing bug where unchecking a writing system left the row visible.

Builds on #1097 (the storage layer this writes into), which has merged; this branch is rebased onto main and the diff is only the new work. It also delivers two commitments from #1097's review discussion: the ordering canonicalization and the UI write path with auto-refresh.

Three commits, in reading order:

1. **Registry refactor** — the interceptor's `HelpId` switch becomes an `OverrideCommandRegistry`. Behavior-identical; the commit message carries the rationale (natively-handled commands become enumerable data, which a later per-menu-group completion check can query — a switch cannot).
2. **The selection copy** — writing-system items dispatch to the hidden adapter slice as before; the resulting selection is then copied into the project view override.
3. **Bridge leaf contract** — the interceptor receives the leaf's already-computed display properties (no second `Display*` round trip), and every leaf, default or retargeted, carries no execute action when disabled.

Where to look:

- **The timing asymmetry is the load-bearing subtlety**: toggles read the selection property (written before `OnClick` returns; the slice reacts later), Configure reads the slice (updated synchronously by the modal dialog). Reading the slice after a toggle stores the pre-click set — that was the bug. Locked by `WritingSystemToggle_TwoVernaculars_StoresTheReducedThenRestoredSet`, red under the old code.
- **Canonicalization**: the stored set is filtered to the slice's options in option order via `StringSliceUtils.GetVisibleWritingSystems`, so uncheck+recheck never reorders rows and junk tokens never restrict.
- **Cancel writes nothing**: the selection is snapshotted before dispatch; an unchanged Configure result is not copied.
- **Guards fail safe with a log trail**: unreadable adapter slice, a slice that isn't the clicked row's, and empty sets all decline to write.
- **The bridge's disabled-no-execute rule applies to every tool's menus**, not just the Lexicon.

Deliberately not here:

- **"Show all right now" is visibly inert in the Avalonia view** — deliberate: it is a transient reveal in legacy, and persisting it would pin the full set. The native transient reveal is the recorded follow-up.
- Reversal-entries rows (the plugin row neither raises this menu nor reads the restriction yet; the copy log-and-bails there).
- Mutation-command conversion and adapter end-state (the open #1079 direction question).

Verified: `build.ps1 -CommentHygiene` clean; 23/23 targeted menu fixtures; 213/213 Detail-fixture sweep after the bridge change. Manual testing is complete — the 9-scenario Sena 3 plan, including the Configure dialog lanes that cannot run headlessly.

---

<details>
<summary><b>Reading this a year from now</b> — start here</summary>

This is the write path ("4b") for the SetVisibleWritingSystems override operation whose storage layer landed as #1097 ("4a"). The split existed because a native command layer — one possible answer to the #1079 adapter-direction question — would delete this copy code while the storage survives. This PR was developed stacked on #1097's branch and rebased onto main once that merged. The working review record lives in this description; `.review/` is gitignored by design.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

- **A registry instead of the switch, honestly weighed.** The switch would have worked (the id-less toggles only need one `if`). The registry is the deliberate "middle path" from the adapter end-state analysis: natively-handled commands become enumerable data, so a later per-menu-group completion check can ask what is covered and skip building the hidden adapter for a fully covered menu. If the direction ruling ends up plain per-command peeling forever, the cost is one 45-line class.
- **"Copy", not "mirror."** This codebase already uses "mirrors legacy X" to mean *reimplements the same algorithm* (a parity claim). The operation here is one-directional, after-the-fact state copying — so the vocabulary is copy (the action) and stored (what tests assert), and "mirror" was retired from these additions to avoid two senses of one word in one file.
- **Copy-after-dispatch, not replacement.** The hidden adapter slice owns the picker, the Configure dialog, and the legacy layout-inventory record; the Avalonia view composes from its own override store. Copying the outcome keeps both sides working without reimplementing either — and it is precisely the code a native command layer would later delete, which is why it is isolated to one registry entry and three private members.
- **Show-all stays visibly inert (chosen over graying it out or reinterpreting it as a persistent clear).** Legacy's command is a temporary reveal that reverts when the slice loses currency; every cheap way to make the button "do something" persistent was rejected as data corruption or dishonest UI. Inert-and-visible makes the gap obvious until the native transient reveal is built.
- **The disabled-no-execute rule lives in the bridge, for all leaves.** Real UI already blocked disabled clicks; the rule exists for programmatic invokers (tests, future keyboard/automation), and enforcing it once in the bridge deleted a ws-specific guard and made `Execute != null` a uniform invariant.

</details>

<details>
<summary><b>Deferred, and what would unblock it</b></summary>

- **Show-all transient reveal** (the desired end state): intercept the click into host-level transient state, recompose, and have `DetailComposer.ApplyVisibleWritingSystems` consult it — it must be composer-level because the restriction can come from the shipped layout, not just the override. The open design decision is expiry (legacy expires on slice-currency loss; Avalonia analogs are field focus loss or record navigation). Roughly 100–150 lines with tests.
- **Reversal-entries rows**: three missing pieces — the plugin row raising the standard menu, the row consuming `VisibleWritingSystems`, and the copy gaining a slice-agnostic options source (a small shared interface). Belongs to reversal-slice Avalonia parity; today the copy logs and declines on that slice type.
- **Adapter end-state**: whether the registry grows group-completion checks and native mutation commands is the #1079 direction question; nothing here commits either way.

</details>

<details>
<summary><b>Preflight review details</b></summary>

<!-- pr-preflight:summary:start -->
The branch went through the 8-angle adversarial review (line-by-line, removed-behavior, cross-file tracing, reuse, simplification, efficiency, altitude, conventions): 34 raw candidates deduplicated to 10 findings, each verified against quoted source. All ten are dispositioned; the significant ones and their fixes:

- Show-all was being persisted despite being a transient reveal in legacy (`OnDataTreeWritingSystemsShowAll` never persists; `SetCurrentState(false)` reverts) — excluded from the copy.
- Configure-Cancel wrote an override pinning the current set — before/after snapshot comparison; no change, no write.
- Raw property order and tokens were stored verbatim while legacy renders in options order — canonicalized through `StringSliceUtils.GetVisibleWritingSystems`; exact-order test assertions.
- A stale adapter slice could write the wrong row's set — object-identity guard with a log entry.
- A null override-target location silently disabled the copy — the ws entry now registers before locating.
- The reversal slice drives the same menu property — both lanes require a `MultiStringSlice` and log-and-bail otherwise.
- Bridge-level issues (double `GetDisplayProperties` per intercepted item; disabled leaves carrying execute) — the leaf-contract commit.
- Plus an unreachable guard removed, a silent-bail log added, and comment-standard fixes.

Validation: `build.ps1 -CommentHygiene` clean at every step; 23/23 targeted menu fixtures; 213/213 Detail sweep after the bridge change. The author reviewed every change line-by-line, approving names individually ("copy"/"stored" vocabulary, `WritingSystemItem`, `CopyWritingSystemSelectionToOverride`). Manual testing: the 9-scenario Sena 3 plan has been executed by the author — it is the only coverage for the Configure dialog lanes, which cannot run headlessly (modal).
<!-- pr-preflight:summary:end -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1108)
<!-- Reviewable:end -->
