### PR TITLE
LT-22657: Fix Word export guidewords

### DIFF
--- a/Src/xWorks/DictionaryConfigurationModel.cs
+++ b/Src/xWorks/DictionaryConfigurationModel.cs
@@ -128,6 +128,20 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// Checks which folder this will be saved in to determine if it is a classified dictionary
+		/// </summary>
+		internal bool IsClassified
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(FilePath))
+					return false; // easiest way to avoid a crash; assume something that may not be true!
+				var directory = Path.GetFileName(Path.GetDirectoryName(FilePath));
+				return DictionaryConfigurationListener.ClassifiedDictConfigDirName.Equals(directory);
+			}
+		}
+
+		/// <summary>
 		/// Checks if this model is Hybrid type. Not root and has Subentries
 		/// </summary>
 		internal bool IsHybrid

--- a/Src/xWorks/DictionaryConfigurationModel.cs
+++ b/Src/xWorks/DictionaryConfigurationModel.cs
@@ -128,7 +128,8 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Checks which folder this will be saved in to determine if it is a classified dictionary
+		/// Checks which folder this will be saved in to determine if it is a
+		/// classified dictionary
 		/// </summary>
 		internal bool IsClassified
 		{

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -2933,17 +2933,18 @@ namespace SIL.FieldWorks.XWorks
 		/// Get the full style names for the runs that should be used for guidewords.
 		/// For each of the guideword styles, the full style name is retrieved from the first RunStyle that begins with that guideword style name.
 		/// </summary>
-		/// <param name="type">Indicates if we are are exporting a Reversal, Classified Dictionary, or regular Configured Dictionary.</param>
-		/// <returns>A list of the full style names beginning with each guideword style.
+		/// <returns>A list of the full style names for the runs that should be used for guidewords.
 		///          Null if none are found.</returns>
 		public static List<string> GetFirstGuidewordStylesList(DocFragment frag, DictionaryConfigurationModel configuration)
 		{
-			// guidewordBaseStyles lists the base styles of the words in the document from which guidewords are drawn;
-			// it does not describe the styles applied to the guidewords themselves.
+			// guidewordBaseStyles lists the base styles of the words in the document from which
+			// guidewords are drawn; it does not describe the styles applied to the guidewords
+			// themselves.
 			List<string> guidewordBaseStyles = new List<string>();
 			var runStyles = frag.DocBody.Descendants<RunStyle>().ToList();
 			// Add any before, after, between, or language-specific tags to the style names in
-			// guideWordBaseStyles to produce the final style names from which guidewords are drawn.
+			// guideWordBaseStyles to produce the final style names from which guidewords are
+			// drawn.
 			List<string> guidewordFinalStyleNames = new List<string>();
 
 			if (configuration.IsReversal)
@@ -2952,7 +2953,8 @@ namespace SIL.FieldWorks.XWorks
 
 			else if (configuration.IsClassified)
 			{
-				// For Classified Dictionary, the Abbreviation and Name are semantic domain numbers and names respectively;
+				// For Classified Dictionary, the Abbreviation and Name are
+				// semantic domain numbers and names respectively;
 				// we combine these into the guidewords in this case.
 				guidewordBaseStyles.Add(WordStylesGenerator.Abbreviation);
 				guidewordBaseStyles.Add(WordStylesGenerator.Name);
@@ -2960,8 +2962,10 @@ namespace SIL.FieldWorks.XWorks
 
 			else
 			{
-				// Configured Dictionary entries are based on either Headword, Lexeme Form, or Citation Form.
-				// For guidewords, use whichever of these appears first in the list of dictionary configuration fields selected for display, defaulting to Headword.
+				// Configured Dictionary entries are based on either Headword, Lexeme Form,
+				// or Citation Form.
+				// For guidewords, use whichever of these appears first in the list of dictionary
+				// configuration fields selected for display, defaulting to Headword.
 				var primaryFieldOptions = new List<string> {WordStylesGenerator.HeadwordDisplayName, WordStylesGenerator.LexemeForm, WordStylesGenerator.CitationForm};
 				var firstSelectedPrimaryField = configuration.Parts[0].Children?
 					.FirstOrDefault(c => c.IsEnabled && primaryFieldOptions.Contains(c.Label));

--- a/Src/xWorks/LcmWordGenerator.cs
+++ b/Src/xWorks/LcmWordGenerator.cs
@@ -189,7 +189,7 @@ namespace SIL.FieldWorks.XWorks
 						// Get styles if firstGuidewordStyles is null or empty
 						if (firstGuidewordStyles == null || firstGuidewordStyles.Count == 0)
 						{
-							firstGuidewordStyles = GetFirstGuidewordStylesList((DocFragment)entry.Item2, configuration.Type);
+							firstGuidewordStyles = GetFirstGuidewordStylesList((DocFragment)entry.Item2, configuration);
 						}
 					}
 				}
@@ -2936,30 +2936,37 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="type">Indicates if we are are exporting a Reversal, Classified Dictionary, or regular Configured Dictionary.</param>
 		/// <returns>A list of the full style names beginning with each guideword style.
 		///          Null if none are found.</returns>
-		public static List<string> GetFirstGuidewordStylesList(DocFragment frag, DictionaryConfigurationModel.ConfigType type)
+		public static List<string> GetFirstGuidewordStylesList(DocFragment frag, DictionaryConfigurationModel configuration)
 		{
+			// guidewordBaseStyles lists the base styles of the words in the document from which guidewords are drawn;
+			// it does not describe the styles applied to the guidewords themselves.
 			List<string> guidewordBaseStyles = new List<string>();
 			var runStyles = frag.DocBody.Descendants<RunStyle>().ToList();
+			// Add any before, after, between, or language-specific tags to the style names in
+			// guideWordBaseStyles to produce the final style names from which guidewords are drawn.
 			List<string> guidewordFinalStyleNames = new List<string>();
 
-			switch (type)
+			if (configuration.IsReversal)
+				// For Reversals, guidewords are pulled from Reversal Forms.
+				guidewordBaseStyles.Add(WordStylesGenerator.ReversalFormDisplayName);
+
+			else if (configuration.IsClassified)
 			{
-				case DictionaryConfigurationModel.ConfigType.Reversal:
-					guidewordBaseStyles.Add(WordStylesGenerator.ReversalFormDisplayName);
-					break;
-				// Lexeme type means this is a Classified Dictionary;
-				// the Abbreviation and Name are semantic domain numbers and names respectively,
-				// which we want to combine into the guidewords in this case.
-				case DictionaryConfigurationModel.ConfigType.Lexeme:
-					guidewordBaseStyles.Add(WordStylesGenerator.Abbreviation);
-					guidewordBaseStyles.Add(WordStylesGenerator.Name);
-					break;
-				// Root type is the default Configured Dictionary;
-				// use headwords as the guidewords.
-				case DictionaryConfigurationModel.ConfigType.Root:
-				default:
-					guidewordBaseStyles.Add(WordStylesGenerator.HeadwordDisplayName);
-					break;
+				// For Classified Dictionary, the Abbreviation and Name are semantic domain numbers and names respectively;
+				// we combine these into the guidewords in this case.
+				guidewordBaseStyles.Add(WordStylesGenerator.Abbreviation);
+				guidewordBaseStyles.Add(WordStylesGenerator.Name);
+			}
+
+			else
+			{
+				// Configured Dictionary entries are based on either Headword, Lexeme Form, or Citation Form.
+				// For guidewords, use whichever of these appears first in the list of dictionary configuration fields selected for display, defaulting to Headword.
+				var primaryFieldOptions = new List<string> {WordStylesGenerator.HeadwordDisplayName, WordStylesGenerator.LexemeForm, WordStylesGenerator.CitationForm};
+				var firstSelectedPrimaryField = configuration.Parts[0].Children?
+					.FirstOrDefault(c => c.IsEnabled && primaryFieldOptions.Contains(c.Label));
+				var selectedPrimaryFieldName = firstSelectedPrimaryField?.Label ?? WordStylesGenerator.HeadwordDisplayName;
+				guidewordBaseStyles.Add(selectedPrimaryFieldName);
 			}
 
 			// Include beforeafterbetween only if there is more than one guideword base style

--- a/Src/xWorks/WordStylesGenerator.cs
+++ b/Src/xWorks/WordStylesGenerator.cs
@@ -36,6 +36,8 @@ namespace SIL.FieldWorks.XWorks
 		internal const string WritingSystemStyleName = "Writing System Abbreviation";
 		internal const string WritingSystemDisplayName = "Writing System Abbreviation";
 		internal const string HeadwordDisplayName = "Headword";
+		internal const string LexemeForm = "Lexeme Form";
+		internal const string CitationForm = "Citation Form";
 		internal const string ReversalFormDisplayName = "Reversal Form";
 		internal const string StyleSeparator = "-";
 		internal const string LangTagPre = "[lang=";

--- a/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
@@ -1598,6 +1598,109 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		[Test]
+		public void GetGuidewordStyleForConfiguredDictionary_LexemeForm()
+		{
+			var wsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "en" });
+			var lexemeFormWsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "fr" });
+			var lexemeFormNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "LexemeFormOA",
+				DictionaryNodeOptions = lexemeFormWsOpts,
+				Style = "Dictionary-LexemeForm",
+				Label = WordStylesGenerator.LexemeForm
+			};
+			var glossNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "Gloss",
+				DictionaryNodeOptions = wsOpts,
+				Style = DictionaryGlossStyleName
+			};
+			var sensesNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "Senses",
+				DictionaryNodeOptions = ConfiguredXHTMLGeneratorTests.GetSenseNodeOptions(),
+				Children = new List<ConfigurableDictionaryNode> { glossNode },
+				Style = DictionaryNormal
+			};
+			// Lexeme Form is selected as the field to draw guidewords from
+			// when it is the first enabled child of the main entry node
+			// from the list {Headword, Lexeme Form, Citation Form}.
+			var mainEntryNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "LexEntry",
+				Children = new List<ConfigurableDictionaryNode> { lexemeFormNode, sensesNode },
+				Style = MainEntryParagraphStyleName,
+				Label = MainEntryParagraphDisplayName
+			};
+			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
+			var entry = ConfiguredXHTMLGeneratorTests.CreateInterestingLexEntry(Cache);
+			ConfiguredXHTMLGeneratorTests.AddLexemeFormToEntry(entry, "LexemeFormTest", Cache);
+			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0) as DocFragment;
+
+			var configuration = new DictionaryConfigurationModel
+			{
+				Parts = new List<ConfigurableDictionaryNode> { mainEntryNode }
+			};
+
+			//SUT
+			List<string> firstLexemeFormStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, configuration);
+
+			Assert.That(firstLexemeFormStyles.Count == 1, Is.True);
+			Assert.That(firstLexemeFormStyles[0] == "Lexeme Form[lang=fr]", Is.True);
+		}
+
+		[Test]
+		public void GetGuidewordStyleForConfiguredDictionary_CitationForm()
+		{
+			var wsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "en" });
+			var citationFormWsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "fr" });
+			var citationFormNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "CitationForm",
+				DictionaryNodeOptions = citationFormWsOpts,
+				Style = "Dictionary-CitationForm",
+				Label = WordStylesGenerator.CitationForm
+			};
+			var glossNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "Gloss",
+				DictionaryNodeOptions = wsOpts,
+				Style = DictionaryGlossStyleName
+			};
+			var sensesNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "Senses",
+				DictionaryNodeOptions = ConfiguredXHTMLGeneratorTests.GetSenseNodeOptions(),
+				Children = new List<ConfigurableDictionaryNode> { glossNode },
+				Style = DictionaryNormal
+			};
+			// Citation Form is selected as the field to draw guidewords from
+			// when it is the first enabled child of the main entry node
+			// from the list {Headword, Lexeme Form, Citation Form}.
+			var mainEntryNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "LexEntry",
+				Children = new List<ConfigurableDictionaryNode> { citationFormNode, sensesNode },
+				Style = MainEntryParagraphStyleName,
+				Label = MainEntryParagraphDisplayName
+			};
+			CssGeneratorTests.PopulateFieldsForTesting(mainEntryNode);
+			var entry = ConfiguredXHTMLGeneratorTests.CreateInterestingLexEntry(Cache);
+			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0) as DocFragment;
+
+			var configuration = new DictionaryConfigurationModel
+			{
+				Parts = new List<ConfigurableDictionaryNode> { mainEntryNode }
+			};
+
+			//SUT
+			List<string> firstCitationFormStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, configuration);
+
+			Assert.That(firstCitationFormStyles.Count == 1, Is.True);
+			Assert.That(firstCitationFormStyles[0] == "Citation Form[lang=fr]", Is.True);
+		}
+
+		[Test]
 		public void GetGuidewordStyleForClassifiedDictionary()
 		{
 			var classifiedClerk = CreateClassifiedClerk();

--- a/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
+++ b/Src/xWorks/xWorksTests/LcmWordGeneratorTests.cs
@@ -1553,12 +1553,19 @@ namespace SIL.FieldWorks.XWorks
 		public void GetGuidewordStyleForConfiguredDictionary()
 		{
 			var wsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "en" });
+			var headwordWsOpts = ConfiguredXHTMLGeneratorTests.GetWsOptionsForLanguages(new[] { "fr" });
+			var headwordNode = new ConfigurableDictionaryNode
+			{
+				FieldDescription = "MLHeadWord",
+				DictionaryNodeOptions = headwordWsOpts,
+				Style = "Dictionary-Headword",
+				Label = WordStylesGenerator.HeadwordDisplayName
+			};
 			var glossNode = new ConfigurableDictionaryNode
 			{
 				FieldDescription = "Gloss",
 				DictionaryNodeOptions = wsOpts,
-				Style = "Dictionary-Headword",
-				Label = WordStylesGenerator.HeadwordDisplayName
+				Style = DictionaryGlossStyleName
 			};
 			var sensesNode = new ConfigurableDictionaryNode
 			{
@@ -1570,7 +1577,7 @@ namespace SIL.FieldWorks.XWorks
 			var mainEntryNode = new ConfigurableDictionaryNode
 			{
 				FieldDescription = "LexEntry",
-				Children = new List<ConfigurableDictionaryNode> { sensesNode },
+				Children = new List<ConfigurableDictionaryNode> { headwordNode, sensesNode },
 				Style = MainEntryParagraphStyleName,
 				Label = MainEntryParagraphDisplayName
 			};
@@ -1578,11 +1585,16 @@ namespace SIL.FieldWorks.XWorks
 			var entry = ConfiguredXHTMLGeneratorTests.CreateInterestingLexEntry(Cache);
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(entry, mainEntryNode, null, DefaultSettings, 0) as DocFragment;
 
+			var configuration = new DictionaryConfigurationModel
+			{
+				Parts = new List<ConfigurableDictionaryNode> { mainEntryNode }
+			};
+
 			//SUT
-			List<string> firstHeadwordStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, DictionaryConfigurationModel.ConfigType.Root);
+			List<string> firstHeadwordStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, configuration);
 
 			Assert.That(firstHeadwordStyles.Count == 1, Is.True);
-			Assert.That(firstHeadwordStyles[0] == "Headword[lang=en]", Is.True);
+			Assert.That(firstHeadwordStyles[0] == "Headword[lang=fr]", Is.True);
 		}
 
 		[Test]
@@ -1620,11 +1632,18 @@ namespace SIL.FieldWorks.XWorks
 			var domain = CreateSemanticDomain(Cache);
 			var result = ConfiguredLcmGenerator.GenerateContentForEntry(domain, mainEntryNode, null, DefaultSettings, 0) as DocFragment;
 
-			//SUT
-			List<string> firstGuidewordStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, DictionaryConfigurationModel.ConfigType.Lexeme);
+			var configuration = new DictionaryConfigurationModel
+			{
+				FilePath = Path.Combine("Classified Dictionary", "ClassifiedDictionary" + DictionaryConfigurationModel.FileExtension),
+				Parts = new List<ConfigurableDictionaryNode> { mainEntryNode }
+			};
 
-			// For Classified Dictionary, the guidewords should consist of the following three pieces:
-			// semantic domain number (abbreviation), after content associated with the semantic domain number, semantic domain name.
+			//SUT
+			List<string> firstGuidewordStyles = LcmWordGenerator.GetFirstGuidewordStylesList(result, configuration);
+
+			// For Classified Dictionary, guidewords consist of the following 3 pieces:
+			// semantic domain number (abbreviation),
+			// after content associated with the semantic domain number, semantic domain name.
 			Assert.That(firstGuidewordStyles.Count, Is.EqualTo(3));
 			Assert.That(firstGuidewordStyles[0], Is.EqualTo(WordStylesGenerator.Abbreviation+"[lang=en]"));
 			Assert.That(firstGuidewordStyles[1], Is.EqualTo(WordStylesGenerator.Abbreviation+WordStylesGenerator.BeforeAfterBetween+"[lang=en]"));


### PR DESCRIPTION
## Quick Summary
- Add IsClassified property to DictionaryConfigurationModel, modeled after the IsReversal property. Use this instead of Lexeme type to determine whether we are exporting a Classified Dictionary, since Configured Dictionary can also be a Lexeme type.
- For guidewords in a Configured Dictionary export, use the first selected field in Dictionary Configuration of type Headword, Lexeme Form, or Citation Form.
- Fixes #LT-22657.

## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->

## CI-ready checklist

- [x] Commit messages follow [`.github/commit-guidelines.md`](https://github.com/sillsdev/FieldWorks/blob/main/.github/commit-guidelines.md).
- [x] Builds & tests pass locally (or I've run the CI-style build via `build.ps1`, `test.ps1`, or MSBuild).
- [x] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate (no nested AGENTS.md under Src/xWorks; Src/AGENTS.md unaffected).
- [x] I have considered all comments from an AI code reviewer (such as [Devin]https://app.devin.ai/review/sillsdev/FieldWorks/pull/####)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1110)
<!-- Reviewable:end -->
