### PR TITLE
LT-22654: Require Webonary credentials before enabling Submit

### DIFF
--- a/Src/xWorks/UploadToWebonaryController.cs
+++ b/Src/xWorks/UploadToWebonaryController.cs
@@ -432,7 +432,8 @@ namespace SIL.FieldWorks.XWorks
 				return false;
 			}
 
-            // For username and password, allow whitespace (it may be a valid value), but not empty string.
+            // For username and password, allow whitespace (it may be a valid value),
+            // but not empty string.
 			if (string.IsNullOrEmpty(model.UserName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoUsername, WebonaryStatusCondition.Error);

--- a/Src/xWorks/UploadToWebonaryController.cs
+++ b/Src/xWorks/UploadToWebonaryController.cs
@@ -432,13 +432,14 @@ namespace SIL.FieldWorks.XWorks
 				return false;
 			}
 
-			if (string.IsNullOrWhiteSpace(model.UserName))
+            // For username and password, allow whitespace (it may be a valid value), but not empty string.
+			if (string.IsNullOrEmpty(model.UserName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoUsername, WebonaryStatusCondition.Error);
 				return false;
 			}
 
-			if (string.IsNullOrWhiteSpace(model.Password))
+			if (string.IsNullOrEmpty(model.Password))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoPassword, WebonaryStatusCondition.Error);
 				return false;

--- a/Src/xWorks/UploadToWebonaryController.cs
+++ b/Src/xWorks/UploadToWebonaryController.cs
@@ -417,38 +417,53 @@ namespace SIL.FieldWorks.XWorks
 			//TODO: Copy the user selected other files into the temp directory and normalize filenames to NFC
 		}
 
-		public void UploadToWebonary(UploadToWebonaryModel model, IUploadToWebonaryView view)
+		/// <summary>
+		/// Reports the first absent upload setting to the view, and answers whether
+		/// every setting an upload needs is present.
+		/// </summary>
+		private static bool HasRequiredUploadSettings(UploadToWebonaryModel model, IUploadToWebonaryView view)
 		{
-			TrackingHelper.TrackExport("lexicon", "webonary", ImportExportStep.Launched);
-			view.UpdateStatus(xWorksStrings.ksUploadingToWebonary, WebonaryStatusCondition.None);
-
 			if (string.IsNullOrEmpty(model.SiteName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoSiteName, WebonaryStatusCondition.Error);
-				return;
+				return false;
 			}
 
-			if(string.IsNullOrEmpty(model.UserName))
+			if (string.IsNullOrEmpty(model.UserName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoUsername, WebonaryStatusCondition.Error);
-				return;
+				return false;
 			}
 
 			if (string.IsNullOrEmpty(model.Password))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoPassword, WebonaryStatusCondition.Error);
-				return;
+				return false;
 			}
 
-			if(string.IsNullOrEmpty(model.SelectedPublication))
+			if (string.IsNullOrEmpty(model.SelectedPublication))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoPublication, WebonaryStatusCondition.Error);
-				return;
+				return false;
 			}
 
-			if(string.IsNullOrEmpty(model.SelectedConfiguration))
+			if (string.IsNullOrEmpty(model.SelectedConfiguration))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoConfiguration, WebonaryStatusCondition.Error);
+				return false;
+			}
+
+			return true;
+		}
+
+		public void UploadToWebonary(UploadToWebonaryModel model, IUploadToWebonaryView view)
+		{
+			TrackingHelper.TrackExport("lexicon", "webonary", ImportExportStep.Launched);
+			view.UpdateStatus(xWorksStrings.ksUploadingToWebonary, WebonaryStatusCondition.None);
+
+			if (!HasRequiredUploadSettings(model, view))
+			{
+				view.UploadCompleted();
 				return;
 			}
 

--- a/Src/xWorks/UploadToWebonaryController.cs
+++ b/Src/xWorks/UploadToWebonaryController.cs
@@ -142,11 +142,14 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
-		/// Converts siteName to lowercase and removes https://www.webonary.org, if present. LT-21224, LT-21387
+		/// Converts siteName to lowercase, strips surrounding whitespace, and removes
+		/// https://www.webonary.org, if present. LT-21224, LT-21387
 		/// </summary>
 		internal static string NormalizeSiteName(string siteName)
 		{
-			siteName = siteName.ToLowerInvariant();
+			if (string.IsNullOrWhiteSpace(siteName))
+				return string.Empty;
+			siteName = siteName.Trim().ToLowerInvariant();
 			// trim a leading [http[s]://]webonary.org/
 			const string domainSlash = WebonaryOrg + "/";
 			var domainIndex = siteName.IndexOf(domainSlash, StringComparison.InvariantCulture);
@@ -423,19 +426,19 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		private static bool HasRequiredUploadSettings(UploadToWebonaryModel model, IUploadToWebonaryView view)
 		{
-			if (string.IsNullOrEmpty(model.SiteName))
+			if (string.IsNullOrWhiteSpace(model.SiteName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoSiteName, WebonaryStatusCondition.Error);
 				return false;
 			}
 
-			if (string.IsNullOrEmpty(model.UserName))
+			if (string.IsNullOrWhiteSpace(model.UserName))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoUsername, WebonaryStatusCondition.Error);
 				return false;
 			}
 
-			if (string.IsNullOrEmpty(model.Password))
+			if (string.IsNullOrWhiteSpace(model.Password))
 			{
 				view.UpdateStatus(xWorksStrings.ksErrorNoPassword, WebonaryStatusCondition.Error);
 				return false;

--- a/Src/xWorks/UploadToWebonaryDlg.Designer.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.Designer.cs
@@ -117,12 +117,14 @@ namespace SIL.FieldWorks.XWorks
 			resources.ApplyResources(this.webonaryPasswordTextbox, "webonaryPasswordTextbox");
 			this.webonaryPasswordTextbox.Name = "webonaryPasswordTextbox";
 			this.toolTip.SetToolTip(this.webonaryPasswordTextbox, resources.GetString("webonaryPasswordTextbox.ToolTip"));
+			this.webonaryPasswordTextbox.TextChanged += new System.EventHandler(this.credentialsBox_TextChanged);
 			// 
 			// webonaryUsernameTextbox
 			// 
 			resources.ApplyResources(this.webonaryUsernameTextbox, "webonaryUsernameTextbox");
 			this.webonaryUsernameTextbox.Name = "webonaryUsernameTextbox";
 			this.toolTip.SetToolTip(this.webonaryUsernameTextbox, resources.GetString("webonaryUsernameTextbox.ToolTip"));
+			this.webonaryUsernameTextbox.TextChanged += new System.EventHandler(this.credentialsBox_TextChanged);
 			// 
 			// webonarySiteNameTextbox
 			// 

--- a/Src/xWorks/UploadToWebonaryDlg.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.cs
@@ -9,10 +9,8 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using Gecko.WebIDL;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.IO;
-using SIL.LCModel.Core.Phonology;
 using SIL.Windows.Forms;
 using SIL.PlatformUtilities;
 using PropertyTable = XCore.PropertyTable;
@@ -102,6 +100,23 @@ namespace SIL.FieldWorks.XWorks
 		{
 			// ReSharper disable once LocalizableElement -- this is the *world-wide* web, not a LAN.
 			webonarySiteURLLabel.Text = $"https://www.{UploadToWebonaryController.Server}/{webonarySiteNameTextbox.Text}";
+			UpdateSubmitButtonEnabledState();
+		}
+
+		private void credentialsBox_TextChanged(object sender, EventArgs e)
+		{
+			UpdateSubmitButtonEnabledState();
+		}
+
+		/// <summary>
+		/// Enables Submit only while a site name, a user name, and a password are all
+		/// present.
+		/// </summary>
+		private void UpdateSubmitButtonEnabledState()
+		{
+			publishButton.Enabled = !string.IsNullOrWhiteSpace(webonarySiteNameTextbox.Text)
+				&& !string.IsNullOrWhiteSpace(webonaryUsernameTextbox.Text)
+				&& !string.IsNullOrWhiteSpace(webonaryPasswordTextbox.Text);
 		}
 
 		private void UpdateEntriesToBePublishedLabel()
@@ -201,6 +216,8 @@ namespace SIL.FieldWorks.XWorks
 
 		public void UploadCompleted()
 		{
+			// Let pending log writes finish so the report covers the whole upload.
+			Model.Log.WaitForLogEntries();
 			m_progress.Value = m_progress.Maximum;
 			m_progress.Style = ProgressBarStyle.Continuous;
 			reportButton.Enabled = true;
@@ -246,6 +263,7 @@ namespace SIL.FieldWorks.XWorks
 				UpdateEntriesToBePublishedLabel();
 				reportButton.Enabled = Model.CanViewReport;
 			}
+			UpdateSubmitButtonEnabledState();
 		}
 
 		private void SaveToModel()

--- a/Src/xWorks/UploadToWebonaryDlg.cs
+++ b/Src/xWorks/UploadToWebonaryDlg.cs
@@ -110,13 +110,14 @@ namespace SIL.FieldWorks.XWorks
 
 		/// <summary>
 		/// Enables Submit only while a site name, a user name, and a password are all
-		/// present.
+		/// present. Whitespace is not valid for site name, but may be valid for
+		/// user name and password.
 		/// </summary>
 		private void UpdateSubmitButtonEnabledState()
 		{
 			publishButton.Enabled = !string.IsNullOrWhiteSpace(webonarySiteNameTextbox.Text)
-				&& !string.IsNullOrWhiteSpace(webonaryUsernameTextbox.Text)
-				&& !string.IsNullOrWhiteSpace(webonaryPasswordTextbox.Text);
+				&& !string.IsNullOrEmpty(webonaryUsernameTextbox.Text)
+				&& !string.IsNullOrEmpty(webonaryPasswordTextbox.Text);
 		}
 
 		private void UpdateEntriesToBePublishedLabel()

--- a/Src/xWorks/WebonaryUploadLog.cs
+++ b/Src/xWorks/WebonaryUploadLog.cs
@@ -75,9 +75,18 @@ namespace SIL.FieldWorks.XWorks
 			return logTask;
 		}
 
+		/// <summary>
+		/// Blocks until the entries queued so far have been written.
+		/// </summary>
 		public void WaitForLogEntries()
 		{
-			Task.WaitAll(logTasks.ToArray());
+			try
+			{
+				Task.WaitAll(logTasks.ToArray());
+			}
+			catch (AggregateException)
+			{
+			}
 		}
 	}
 }

--- a/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
@@ -278,6 +278,36 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		[Test]
+		public void UploadToWebonaryCompletesTheUploadWhenRequiredInfoIsMissing()
+		{
+			// Covers the settings whose absence can be probed repeatedly. Reading an
+			// unset SelectedConfiguration mutates shared project configuration.
+			var missingSettings = new Dictionary<string, Action<UploadToWebonaryModel>>
+			{
+				{ "SiteName", m => m.SiteName = null },
+				{ "UserName", m => m.UserName = null },
+				{ "Password", m => m.Password = null },
+				{ "SelectedPublication", m => m.SelectedPublication = null }
+			};
+
+			foreach (var missingSetting in missingSettings)
+			{
+				using (var controller = SetUpController())
+				{
+					var view = SetUpView();
+					missingSetting.Value(view.Model);
+					//SUT
+					controller.UploadToWebonary(view.Model, view);
+
+					Assert.That(view.StatusConditions, Does.Contain(WebonaryStatusCondition.Error),
+						"Missing " + missingSetting.Key + " should be reported as an error.");
+					Assert.That(view.UploadCompletedCount, Is.EqualTo(1),
+						"Missing " + missingSetting.Key + " left the upload uncompleted, so the dialog would still show it running.");
+				}
+			}
+		}
+
+		[Test]
 		public void UploadToWebonaryCanCompleteWithoutError()
 		{
 			using (var controller = SetUpController())
@@ -456,8 +486,11 @@ namespace SIL.FieldWorks.XWorks
 				StatusConditions.Add(condition);
 			}
 
+			public int UploadCompletedCount;
+
 			public void UploadCompleted()
 			{
+				UploadCompletedCount++;
 			}
 
 			public void PopulatePublicationsList(IEnumerable<string> publications)

--- a/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
@@ -160,6 +160,10 @@ namespace SIL.FieldWorks.XWorks
 		[TestCase(UploadToWebonaryController.WebonaryOrg + "/thAI", "thai")]
 		[TestCase("httpS://www.Webonary.org/tPi", "tpi")]
 		[TestCase("httpS://www.Webonary.org/tPi/", "tpi")]
+		[TestCase("  English  ", "english")]
+		[TestCase("  httpS://www.Webonary.org/tPi/  ", "tpi")]
+		[TestCase(null, "")]
+		[TestCase("   ", "")]
 		public void NormalizeSiteName(string userEntered, string expected)
 		{
 			Assert.That(UploadToWebonaryController.NormalizeSiteName(userEntered), Is.EqualTo(expected));
@@ -285,8 +289,11 @@ namespace SIL.FieldWorks.XWorks
 			var missingSettings = new Dictionary<string, Action<UploadToWebonaryModel>>
 			{
 				{ "SiteName", m => m.SiteName = null },
+				{ "whitespace SiteName", m => m.SiteName = "   " },
 				{ "UserName", m => m.UserName = null },
+				{ "whitespace UserName", m => m.UserName = "   " },
 				{ "Password", m => m.Password = null },
+				{ "whitespace Password", m => m.Password = "   " },
 				{ "SelectedPublication", m => m.SelectedPublication = null }
 			};
 

--- a/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryControllerTests.cs
@@ -291,9 +291,7 @@ namespace SIL.FieldWorks.XWorks
 				{ "SiteName", m => m.SiteName = null },
 				{ "whitespace SiteName", m => m.SiteName = "   " },
 				{ "UserName", m => m.UserName = null },
-				{ "whitespace UserName", m => m.UserName = "   " },
 				{ "Password", m => m.Password = null },
-				{ "whitespace Password", m => m.Password = "   " },
 				{ "SelectedPublication", m => m.SelectedPublication = null }
 			};
 

--- a/Src/xWorks/xWorksTests/UploadToWebonaryDlgTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryDlgTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.Reflection;
+using System.Threading;
+using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// Covers Upload to Webonary dialog behavior that is independent of a project and a
+	/// controller.
+	/// </summary>
+	[TestFixture]
+	[Apartment(ApartmentState.STA)]
+	public class UploadToWebonaryDlgTests
+	{
+		[Test]
+		public void SubmitIsDisabledUntilSiteNameUserNameAndPasswordAreAllPresent()
+		{
+			using (var dlg = new UploadToWebonaryDlg())
+			{
+				var submit = GetControl<Button>(dlg, "publishButton");
+				var siteName = GetControl<TextBox>(dlg, "webonarySiteNameTextbox");
+				var userName = GetControl<TextBox>(dlg, "webonaryUsernameTextbox");
+				var password = GetControl<TextBox>(dlg, "webonaryPasswordTextbox");
+
+				Assert.That(submit.Enabled, Is.False, "Submit should be disabled while every field is empty.");
+
+				siteName.Text = "site";
+				Assert.That(submit.Enabled, Is.False, "Submit should stay disabled without a user name and a password.");
+
+				userName.Text = "user";
+				Assert.That(submit.Enabled, Is.False, "Submit should stay disabled without a password.");
+
+				password.Text = "password";
+				Assert.That(submit.Enabled, Is.True, "Submit should be enabled once all three fields are filled in.");
+
+				userName.Text = "   ";
+				Assert.That(submit.Enabled, Is.False, "Whitespace should not satisfy the user name.");
+
+				userName.Text = "user";
+				siteName.Text = string.Empty;
+				Assert.That(submit.Enabled, Is.False, "Clearing the site name should disable Submit again.");
+			}
+		}
+
+		private static T GetControl<T>(UploadToWebonaryDlg dlg, string fieldName) where T : Control
+		{
+			var field = typeof(UploadToWebonaryDlg).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.That(field, Is.Not.Null, fieldName + " is missing from the dialog.");
+			return (T)field.GetValue(dlg);
+		}
+	}
+}

--- a/Src/xWorks/xWorksTests/UploadToWebonaryDlgTests.cs
+++ b/Src/xWorks/xWorksTests/UploadToWebonaryDlgTests.cs
@@ -39,9 +39,13 @@ namespace SIL.FieldWorks.XWorks
 				Assert.That(submit.Enabled, Is.True, "Submit should be enabled once all three fields are filled in.");
 
 				userName.Text = "   ";
-				Assert.That(submit.Enabled, Is.False, "Whitespace should not satisfy the user name.");
+				Assert.That(submit.Enabled, Is.True,
+					"A credential is opaque, so whitespace in one still counts as filled in.");
 
 				userName.Text = "user";
+				siteName.Text = "   ";
+				Assert.That(submit.Enabled, Is.False, "Whitespace should not satisfy the site name.");
+
 				siteName.Text = string.Empty;
 				Assert.That(submit.Enabled, Is.False, "Clearing the site name should disable Submit again.");
 			}

--- a/Src/xWorks/xWorksTests/WebonaryUploadLogTests.cs
+++ b/Src/xWorks/xWorksTests/WebonaryUploadLogTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.IO;
+using NUnit.Framework;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// Covers the upload log's behavior when the log file itself cannot be written.
+	/// </summary>
+	[TestFixture]
+	public class WebonaryUploadLogTests
+	{
+		[Test]
+		public void WaitForLogEntriesDoesNotThrowWhenTheLogFileIsLocked()
+		{
+			var directory = Path.Combine(Path.GetTempPath(), "webonary-log-tests", Path.GetRandomFileName());
+			Directory.CreateDirectory(directory);
+			var logFilePath = Path.Combine(directory, "last-upload.log");
+			try
+			{
+				// An exclusive handle makes the log's append fail, faulting the write task.
+				using (File.Open(logFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+				{
+					var log = new WebonaryUploadLog(logFilePath);
+					log.AddEntry(WebonaryStatusCondition.Error, "an entry that cannot be written");
+					//SUT
+					Assert.DoesNotThrow(() => log.WaitForLogEntries());
+					Assert.DoesNotThrow(() => log.WaitForLogEntries(),
+						"A faulted write should not resurface on a later flush.");
+				}
+			}
+			finally
+			{
+				try
+				{
+					Directory.Delete(directory, true);
+				}
+				catch (IOException)
+				{
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Quick Summary
<!-- Briefly describe what changed and why. Link issues if applicable (e.g., Fixes #1234). For large, multi-faceted PRs, use at most 6 bullets or short items. If more would be needed, include: "This quick summary does not capture all meaningful changes from this PR - please review the full summary carefully." -->
In Upload to Webonary dialog, Submit stayed enabled with Site name, Username, or Password blank. Clicking Submit started an upload that the controller refused immediately, but the refusal only reached the upload log, and the progress bar was left in marquee style, so the dialog appeared to upload forever.

Gate Submit on all three fields, and complete a refused upload so the dialog stops showing one as running when a publication or configuration is missing.

## CI-ready checklist

- [x] Commit messages follow [`.github/commit-guidelines.md`](https://github.com/sillsdev/FieldWorks/blob/main/.github/commit-guidelines.md).
- [x] Builds & tests pass locally (or I've run the CI-style build via `build.ps1`, `test.ps1`, or MSBuild).
- [x] If this is core-developer AI-assisted work, I followed `Docs/workflows/ai-pr-workflow.md` and ran `pr-preflight` or the equivalent branch-readiness review before requesting review.
- [ ] For any `Src/**` folders touched, corresponding `AGENTS.md` files are updated or explicitly confirmed still accurate.
- [x] I have considered all comments from an AI code reviewer (such as [Devin]https://app.devin.ai/review/sillsdev/FieldWorks/pull/####)

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1112)
<!-- Reviewable:end -->
