### PR TITLE
Simplify ExportWordReversal

### DIFF
--- a/Src/xWorks/DictionaryExportService.cs
+++ b/Src/xWorks/DictionaryExportService.cs
@@ -1,17 +1,17 @@
-// Copyright (c) 2016 SIL International
+// Copyright (c) 2016-2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using Newtonsoft.Json.Linq;
+using SIL.Code;
+using SIL.LCModel;
+using SIL.LCModel.Utils;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using Newtonsoft.Json.Linq;
-using SIL.Code;
-using SIL.LCModel;
-using SIL.LCModel.Utils;
 using XCore;
 
 namespace SIL.FieldWorks.XWorks
@@ -133,14 +133,10 @@ namespace SIL.FieldWorks.XWorks
 			if (progress != null)
 			  progress.Maximum = entriesToSave.Length;
 
-			// ReSharper disable once ObjectCreationAsStatement
 			// (Re)loading the reversal configuration ensures its homograph settings are in the
 			// cache's HomographConfiguration singleton during export.
 			// https://github.com/sillsdev/FieldWorks/pull/939
-			// REVIEW (Hasso) 2026.08: would revConfig.Load(m_cache); suffice?
-			new DictionaryConfigurationModel(
-				DictionaryConfigurationListener.GetCurrentConfiguration(m_propertyTable,
-					"ReversalIndex"), m_cache);
+			revConfig.Load(m_cache);
 
 			string reversalFilePath = filePath.Split(new string[] { ".docx"}, StringSplitOptions.None)[0] + "-reversal-" + reversalWs + ".docx";
 			LcmWordGenerator.SavePublishedDocx(entriesToSave, revClerk, pubDecorator, int.MaxValue, revConfig, m_propertyTable,


### PR DESCRIPTION
## CI-ready checklist

- [x] Commit messages follow [`.github/commit-guidelines.md`](https://github.com/sillsdev/FieldWorks/blob/main/.github/commit-guidelines.md).
- [ ] ~~As much as possible, the change is unit tested.~~ Writing a test would require enough setup to actually export a Word document; this is done only in manual tests.
- [x] Builds pass.
- [x] I have considered all comments from an AI code reviewer (such as [Devin](https://app.devin.ai/review/sillsdev/FieldWorks/pull/1115))

## Notes for reviewers (optional)
<!-- Risks, roll-out, docs/tests touched, special validation steps, etc. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1115)
<!-- Reviewable:end -->
