### PR TITLE
LT-22691: Add the transient Show-all writing-system reveal

### DIFF
--- a/Src/xWorks/Avalonia/Composer/DetailComposer.cs
+++ b/Src/xWorks/Avalonia/Composer/DetailComposer.cs
@@ -115,8 +115,10 @@ namespace SIL.FieldWorks.XWorks
 
 		public static ComposedDetail Compose(ILexEntry entry, LcmCache cache, bool showHiddenFields = false,
 			SlicePluginRegistry plugins = null,
-			ViewDefinitionOverrideResolver overrides = null)
-			=> Compose((ICmObject)entry, cache, "Normal", showHiddenFields, plugins, overrides);
+			ViewDefinitionOverrideResolver overrides = null,
+			ISet<string> showAllWritingSystemsFields = null)
+			=> Compose((ICmObject)entry, cache, "Normal", showHiddenFields, plugins, overrides,
+				showAllWritingSystemsFields: showAllWritingSystemsFields);
 
 		/// <summary>
 		/// Compose the structured detail view for ANY record root + starting layout -- the
@@ -127,10 +129,14 @@ namespace SIL.FieldWorks.XWorks
 		/// object and the starting layout instead of hardcoding LexEntry/"Normal", so wiring a new tool onto
 		/// the Avalonia side needs only its registration + (when its layout uses one) a layoutChoiceField.
 		/// </summary>
+		/// <param name="showAllWritingSystemsFields">Template StableIds of parts under a
+		/// transient "Show all right now" reveal: every row of those parts composes with its
+		/// full writing-system set, ignoring per-field visibility restrictions.</param>
 		public static ComposedDetail Compose(ICmObject obj, LcmCache cache, string layoutName = "Normal",
 			bool showHiddenFields = false, SlicePluginRegistry plugins = null,
 			ViewDefinitionOverrideResolver overrides = null,
-			string layoutChoiceField = null)
+			string layoutChoiceField = null,
+			ISet<string> showAllWritingSystemsFields = null)
 		{
 			if (obj == null) throw new ArgumentNullException(nameof(obj));
 			if (cache == null) throw new ArgumentNullException(nameof(cache));
@@ -150,7 +156,8 @@ namespace SIL.FieldWorks.XWorks
 			// bridges the gap (plugin factories run at render time, not compose).
 			IDetailEditContext composedContext = null;
 			var state = new ComposeState(cache, showHiddenFields,
-				plugins ?? SlicePluginRegistry.Default, () => composedContext, overrides);
+				plugins ?? SlicePluginRegistry.Default, () => composedContext, overrides,
+				showAllWritingSystemsFields);
 			state.EnterModel(root);
 			foreach (var node in root.Roots)
 				state.Walk(node, obj, 0);
@@ -294,6 +301,9 @@ namespace SIL.FieldWorks.XWorks
 			// receive (resolved when the factory runs, after Compose has built the context).
 			private readonly SlicePluginRegistry _plugins;
 			private readonly Func<IDetailEditContext> _editContextAccessor;
+			// Parts under the host's transient "Show all right now" reveal (template StableIds);
+			// every row of those parts composes with its full writing-system set.
+			private readonly ISet<string> _showAllWsFields;
 			// Per-compose memos -- the morph-type option list is identical for every
 			// IMoForm, and an item layout's menu/hotlinks binding is identical per (class, layout).
 			private List<DetailChoiceOption> _morphTypeOptions;
@@ -327,13 +337,15 @@ namespace SIL.FieldWorks.XWorks
 
 			public ComposeState(LcmCache cache, bool showHiddenFields,
 				SlicePluginRegistry plugins, Func<IDetailEditContext> editContextAccessor,
-				ViewDefinitionOverrideResolver overrides = null)
+				ViewDefinitionOverrideResolver overrides = null,
+				ISet<string> showAllWritingSystemsFields = null)
 			{
 				_cache = cache;
 				_showHidden = showHiddenFields;
 				_plugins = plugins;
 				_editContextAccessor = editContextAccessor;
 				_overrides = overrides;
+				_showAllWsFields = showAllWritingSystemsFields;
 				_sda = cache.DomainDataByFlid;
 				_mdc = (IFwMetaDataCacheManaged)cache.DomainDataByFlid.MetaDataCache;
 			}
@@ -1057,9 +1069,9 @@ namespace SIL.FieldWorks.XWorks
 				RegisterTextRowEditHandler(stableId, hvo, flid, type, systems);
 			}
 
-			// The writing systems of a text row: the layout set restricted by the field's per-field
-			// visibleWritingSystems override, then collapsed to a single derived row ws for a
-			// single-alternative (String/Unicode) property. Split out of WalkTextField unchanged.
+			// A text row's writing systems: the layout set, restricted by visibleWritingSystems
+			// unless the row's part is under the Show-all reveal, then collapsed to one ws for
+			// String/Unicode props.
 			private IReadOnlyList<CoreWritingSystemDefinition> ResolveTextRowWritingSystems(int hvo, int flid,
 				CellarPropertyType type, ViewNode node)
 			{
@@ -1069,7 +1081,8 @@ namespace SIL.FieldWorks.XWorks
 				// field's valid writing systems. An empty intersection keeps the full set rather than hiding
 				// the field entirely (defensive -- a stale override must never blank a real
 				// field).
-				systems = ApplyVisibleWritingSystems(systems, node.VisibleWritingSystems);
+				if (_showAllWsFields == null || !_showAllWsFields.Contains(node.StableId))
+					systems = ApplyVisibleWritingSystems(systems, node.VisibleWritingSystems);
 				if ((type == CellarPropertyType.String || type == CellarPropertyType.Unicode)
 					&& systems.Count > 0)
 				{

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2003-2017 SIL International
+﻿// Copyright (c) 2003-2017 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -73,6 +73,13 @@ namespace SIL.FieldWorks.XWorks
 		// projects/windows for the app lifetime.
 		private readonly Dictionary<string, bool> m_expansionStates = new Dictionary<string, bool>();
 
+		// The transient "Show all right now" reveal: template StableIds of parts whose rows
+		// show every writing-system option. Cleared when the shown record changes; never
+		// persisted.
+		private readonly HashSet<string> m_showAllWsFields = new HashSet<string>(StringComparer.Ordinal);
+		// The record m_showAllWsFields belongs to; a different record expires the reveal.
+		private int m_showAllWsRecordHvo;
+
 		private bool ShouldUseAvaloniaLexiconEdit
 		{
 			get { return m_activeUIFramework == UIFramework.Avalonia; }
@@ -142,6 +149,10 @@ namespace SIL.FieldWorks.XWorks
 			SettleDetailEdits();
 			m_detailEditContext.Clear();
 			m_avaloniaEntryForm?.Dispose();
+			// Transient view state dies with the view: rebuilding the host must not
+			// resurrect a stale reveal.
+			m_showAllWsFields.Clear();
+			m_showAllWsRecordHvo = 0;
 			// Null the host + refresh controller after disposing them. The recreation guards
 			// (EnsureAvaloniaEntryFormInitialized / EnsureAvaloniaRefreshController) key on `== null`, so a
 			// runtime flip New->Legacy->New rebuilds a fresh entry form instead of re-showing a disposed one.
@@ -297,6 +308,12 @@ namespace SIL.FieldWorks.XWorks
 			// cancel-on-displace remains the safety net.
 			SettleDetailEdits();
 
+			// Record-navigation expiry: the transient reveal belongs to ONE record -- it
+			// survives focus changes within the record and dies when the record changes.
+			if (obj == null || obj.Hvo != m_showAllWsRecordHvo)
+				m_showAllWsFields.Clear();
+			m_showAllWsRecordHvo = obj?.Hvo ?? 0;
+
 			// Adapter hygiene: the hidden command-routing DataTree must never answer mediator
 			// commands for a PREVIOUS record -- reset it whenever the shown record changes; the
 			// next
@@ -333,14 +350,16 @@ namespace SIL.FieldWorks.XWorks
 			{
 				composed = lexEntry != null
 					? DetailComposer.Compose(lexEntry, Cache, showHidden,
-						overrides: ResolveViewOverride)
+						overrides: ResolveViewOverride,
+						showAllWritingSystemsFields: m_showAllWsFields)
 					// Non-entry roots compose against the tool's configured layout
 					// (m_layoutName, default "Normal"); a type-selected layout (m_layoutChoiceField, e.g.
 					// Notebook RnGenericRec keyed on "Type") resolves to the right variant inside Compose.
 					: DetailComposer.Compose(obj, Cache,
 						string.IsNullOrEmpty(m_layoutName) ? "Normal" : m_layoutName, showHidden,
 						overrides: ResolveViewOverride,
-						layoutChoiceField: m_layoutChoiceField);
+						layoutChoiceField: m_layoutChoiceField,
+						showAllWritingSystemsFields: m_showAllWsFields);
 				if (composed != null)
 				{
 					detail = composed.Model;
@@ -584,6 +603,10 @@ namespace SIL.FieldWorks.XWorks
 			// even when locating fails.
 			var registry = new OverrideCommandRegistry();
 			registry.Add(IsWritingSystemVisibilityChoice, (c, d) => WritingSystemItem(c, d, field));
+			// Show all right now never dispatches or persists: it only marks the row for the
+			// host's transient reveal.
+			registry.Add("CmdDataTree-WritingSystemMenu-ShowAllRightNow",
+				(c, d) => ShowAllWritingSystemsItem(d, field));
 
 			var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
 			// Locate the clicked node in the field's OWN compiled model (with any current override
@@ -601,8 +624,8 @@ namespace SIL.FieldWorks.XWorks
 			}
 			catch (Exception e)
 			{
-				Logger.WriteError("Resolving the field's override target failed; the gear-menu field "
-					+ "commands fall back to the legacy path for this row.", e);
+				Logger.WriteError("Resolving the field's override target failed; this row's "
+					+ "menu-button commands fall back to ordinary command dispatch.", e);
 				return registry.TryBuild;
 			}
 
@@ -648,11 +671,25 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		/// <summary>
+		/// The "Show all right now" item: marks the row's part for the transient reveal (every
+		/// row of the part shows every writing-system option until the user navigates to another
+		/// record) and recomposes. The reveal is view state, not a command, so the item
+		/// dispatches nothing and never writes the override.
+		/// </summary>
+		private DetailMenuItem ShowAllWritingSystemsItem(UIItemDisplayProperties display, DetailField field)
+			=> new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), isEnabled: true,
+				isChecked: false, children: null, execute: () =>
+				{
+					m_showAllWsFields.Add(ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId));
+					RefreshAvaloniaDetail();
+				});
+
+		/// <summary>
 		/// Whether this menu item makes a persistent change to which writing systems a
 		/// multi-writing-system field shows: a per-writing-system toggle (recognized by the
 		/// property its group drives -- the toggles carry no command id) or the Configure
-		/// dialog. Show all right now is excluded: it is a transient reveal on the slice,
-		/// not a configuration change, so persisting it would wrongly pin the full set.
+		/// dialog. Show all right now is not one of these: it is the transient reveal
+		/// (<see cref="ShowAllWritingSystemsItem"/>), not a configuration change to persist.
 		/// </summary>
 		private static bool IsWritingSystemVisibilityChoice(ChoiceBase choice)
 		{
@@ -742,10 +779,16 @@ namespace SIL.FieldWorks.XWorks
 				if (selected == null || selected.Count == 0)
 					return;
 
+				var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
 				var op = new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems,
-					ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId),
-					writingSystems: selected);
-				MutateOverrideAndRefresh(field, op);
+					templateId, writingSystems: selected);
+				if (!TryMutateOverride(field, op))
+					return;
+
+				// A successful configuration write replaces any transient reveal on the part:
+				// a newly persisted display set supersedes the reveal on every row sharing it.
+				m_showAllWsFields.Remove(templateId);
+				RefreshAvaloniaDetail();
 			}
 			catch (Exception e)
 			{
@@ -782,21 +825,30 @@ namespace SIL.FieldWorks.XWorks
 		// Avalonia detail view so the change is visible immediately. The legacy DataTree/Inventory is untouched.
 		private void MutateOverrideAndRefresh(DetailField field, ViewOverrideOperation op)
 		{
+			if (TryMutateOverride(field, op))
+				RefreshAvaloniaDetail();
+		}
+
+		// Folds the op into the (class, layout) override and saves it, WITHOUT recomposing.
+		// Returns whether the save succeeded, so a failed save can leave view state untouched.
+		private bool TryMutateOverride(DetailField field, ViewOverrideOperation op)
+		{
 			try
 			{
 				var store = ViewOverrideStore;
 				if (store == null)
-					return;
+					return false;
 
 				var existing = store.TryGet(field.ClassName, field.LayoutName)
 					?? new ViewDefinitionOverride(field.ClassName, field.LayoutName, "detail", null, null);
 				var merged = ViewDefinitionOverrideEditor.MergeOperation(existing, op);
 				store.Save(merged);
-				RefreshAvaloniaDetail();
+				return true;
 			}
 			catch (Exception e)
 			{
 				Logger.WriteError("Applying the field override failed.", e);
+				return false;
 			}
 		}
 
@@ -1056,13 +1108,14 @@ namespace SIL.FieldWorks.XWorks
 			m_propertyTable.SetPropertyPersistence(key, true, PropertyTable.SettingsGroup.LocalSettings);
 		}
 
-		// Re-resolves and re-shows the detail view for the current record from current domain state
-		// (after an external edit or this view's commit/cancel).
+		// Re-shows the detail view for the current record (external edit, commit/cancel).
+		// Resolves the shown record like ShowRecord, so a showDescendantInRoot tool recomposes
+		// the root, not the subrecord.
 		private void RefreshAvaloniaDetail()
 		{
 			if (m_avaloniaEntryForm == null || !ShouldUseAvaloniaLexiconEdit)
 				return;
-			var current = Clerk?.CurrentObject;
+			var current = ResolveShownRecord(Clerk?.CurrentObject);
 			if (current == null)
 				return;
 

--- a/Src/xWorks/RecordEditView.cs
+++ b/Src/xWorks/RecordEditView.cs
@@ -360,6 +360,17 @@ namespace SIL.FieldWorks.XWorks
 			ShowRecord(new RecordNavigationInfo(Clerk, Clerk.SuppressSaveOnChangeRecord, false, false));
 		}
 
+		// The record the view shows for a clerk object: a showDescendantInRoot tool displays
+		// the subrecord's owning root, so every show/refresh path resolves through this.
+		private ICmObject ResolveShownRecord(ICmObject obj)
+		{
+			if (obj == null || !m_showDescendantInRoot)
+				return obj;
+			while (obj.Owner != Clerk.OwningObject)
+				obj = obj.Owner;
+			return obj;
+		}
+
 		/// <summary>
 		/// Shows the record on idle. This is where the record is actually shown.
 		/// </summary>
@@ -421,14 +432,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 
 				// Enhance: Maybe do something here to allow changing the templates without the starting the application.
-				ICmObject obj = Clerk.CurrentObject;
-
-				if (m_showDescendantInRoot)
-				{
-					// find the root object of the current object
-					while (obj.Owner != Clerk.OwningObject)
-						obj = obj.Owner;
-				}
+				ICmObject obj = ResolveShownRecord(Clerk.CurrentObject);
 
 				if (ShouldUseAvaloniaLexiconEdit && m_avaloniaEntryForm != null)
 				{

--- a/Src/xWorks/xWorksTests/Avalonia/Composer/FieldTypeComposerTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Composer/FieldTypeComposerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 SIL International
+﻿// Copyright (c) 2026 SIL International
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using SIL.FieldWorks.Common.FwAvalonia.Detail;
+using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
 using SIL.LCModel;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.Core.Text;
@@ -82,6 +83,130 @@ namespace SIL.FieldWorks.XWorks
 			Assert.That(DetailComposer.ApplyVisibleWritingSystems(all, new[] { "zz-not-a-ws" }),
 				Is.SameAs(all), "a stale override that matches nothing keeps the full set, never blanks the field");
 		}
+
+		// ---- Transient "Show all right now" reveal ----
+
+		// The reveal bypasses the ws restriction for EXACTLY the revealed part: Compose
+		// consults the template StableId set the host holds until record navigation.
+		[Test]
+		public void ShowAllReveal_BypassesTheWsRestriction_ForTheRevealedRowOnly()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentVernacularWritingSystems(second);
+			});
+			try
+			{
+				var form = ComposedFormRow(null, null);
+				var fullSet = form.Values.Select(v => v.WsTag).ToList();
+				Assume.That(fullSet.Count, Is.GreaterThanOrEqualTo(2),
+					"the Form row must offer at least two writing systems for a visible reveal");
+
+				var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(form.StableId);
+				var restriction = new ViewDefinitionOverride(form.ClassName, form.LayoutName, "detail",
+					new[]
+					{
+						new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems,
+							templateId, writingSystems: new[] { fullSet[0] })
+					}, null);
+				ViewDefinitionOverrideResolver resolver = (cls, layout) =>
+					cls == form.ClassName && layout == form.LayoutName ? restriction : null;
+
+				var restricted = ComposedFormRow(resolver, null);
+				Assert.That(restricted.Values.Select(v => v.WsTag), Is.EqualTo(new[] { fullSet[0] }),
+					"precondition: the override restricts the row to one writing system");
+
+				var revealedElsewhere = ComposedFormRow(resolver,
+					new HashSet<string> { "not-a-part" });
+				Assert.That(revealedElsewhere.Values.Select(v => v.WsTag),
+					Is.EqualTo(new[] { fullSet[0] }),
+					"a reveal keyed to another part leaves this row restricted");
+
+				var revealed = ComposedFormRow(resolver, new HashSet<string> { templateId });
+				Assert.That(revealed.Values.Select(v => v.WsTag), Is.EqualTo(fullSet),
+					"the revealed row composes with its full writing-system set, in layout order");
+			}
+			finally
+			{
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentVernacularWritingSystems.Remove(second));
+			}
+		}
+
+		// One reveal covers the whole part: every row sharing the template (each sense's
+		// Gloss) composes with the full set.
+		[Test]
+		public void ShowAllReveal_CoversEveryRowOfThePart()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentAnalysisWritingSystems(second);
+				var senseFactory = Cache.ServiceLocator.GetInstance<ILexSenseFactory>();
+				foreach (var gloss in new[] { "first", "second" })
+				{
+					var sense = senseFactory.Create();
+					m_entry.SensesOS.Add(sense);
+					sense.Gloss.set_String(Cache.DefaultAnalWs,
+						TsStringUtils.MakeString(gloss, Cache.DefaultAnalWs));
+				}
+			});
+			try
+			{
+				var glossRows = GlossRows(null, null);
+				Assume.That(glossRows.Count, Is.EqualTo(2), "one Gloss row per sense");
+				var fullCount = glossRows[0].Values.Count;
+				Assume.That(fullCount, Is.GreaterThanOrEqualTo(2),
+					"the Gloss row must offer at least two writing systems for a visible reveal");
+				var templateId = ViewDefinitionOverrideEditor.StripRuntimeSuffix(glossRows[0].StableId);
+				Assume.That(ViewDefinitionOverrideEditor.StripRuntimeSuffix(glossRows[1].StableId),
+					Is.EqualTo(templateId), "sibling sense rows share one template");
+
+				var restriction = new ViewDefinitionOverride(glossRows[0].ClassName,
+					glossRows[0].LayoutName, "detail", new[]
+					{
+						new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems,
+							templateId, writingSystems: new[] { glossRows[0].Values[0].WsTag })
+					}, null);
+				ViewDefinitionOverrideResolver resolver = (cls, layout) =>
+					cls == glossRows[0].ClassName && layout == glossRows[0].LayoutName
+						? restriction
+						: null;
+
+				Assert.That(GlossRows(resolver, null).Select(r => r.Values.Count),
+					Is.All.EqualTo(1), "precondition: the restriction reaches both sense rows");
+
+				Assert.That(GlossRows(resolver, new HashSet<string> { templateId })
+						.Select(r => r.Values.Count), Is.All.EqualTo(fullCount),
+					"one revealed template covers every sense's row");
+			}
+			finally
+			{
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentAnalysisWritingSystems.Remove(second));
+			}
+		}
+
+		// The composed Lexeme Form row (the MoForm's own Form field), under the given override
+		// resolver and transient reveal set.
+		private DetailField ComposedFormRow(ViewDefinitionOverrideResolver overrides,
+			ISet<string> showAllWritingSystemsFields)
+			=> DetailComposer.Compose(m_entry, Cache, overrides: overrides,
+					showAllWritingSystemsFields: showAllWritingSystemsFields)
+				.Model.Fields.Single(f => f.Field == "Form" && f.Kind == DetailFieldKind.Text
+					&& f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+
+		// Every composed Gloss text row (one per sense), under the given override resolver and
+		// reveal set.
+		private List<DetailField> GlossRows(ViewDefinitionOverrideResolver overrides,
+			ISet<string> showAllWritingSystemsFields)
+			=> DetailComposer.Compose(m_entry, Cache, overrides: overrides,
+					showAllWritingSystemsFields: showAllWritingSystemsFields)
+				.Model.Fields.Where(f => f.Field == "Gloss" && f.Kind == DetailFieldKind.Text)
+				.ToList();
 
 		[Test]
 		public void ShowHidden_RevealsNeverFields_HideOmitsThem()

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -450,8 +450,7 @@ namespace SIL.FieldWorks.XWorks
 					});
 				TestContext.WriteLine("compose asked for: " + string.Join(", ", asked));
 
-				var row = recomposed.Model.Fields.Single(f => f.Field == "Form"
-					&& f.Kind == DetailFieldKind.Text && f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+				var row = FindLexemeFormRow(recomposed.Model);
 				Assert.That(row.Label, Is.EqualTo("OverrideMarker"),
 					"an override keyed by the row's own (class, layout) must reach the composed row");
 			}
@@ -462,14 +461,215 @@ namespace SIL.FieldWorks.XWorks
 		}
 
 		// -----------------------------------------------------------------
+		// "Show all right now": the transient writing-system reveal
+		// -----------------------------------------------------------------
+
+		// The intercepted item must reveal WITHOUT persisting: the row composes with the full
+		// set while the stored override keeps the restriction.
+		[Test]
+		public void ShowAllRightNow_RevealsTheFullSet_WithoutWritingTheOverride()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentVernacularWritingSystems(second);
+			});
+			var field = LexemeFormField();
+			try
+			{
+				var fullSet = field.Values.Select(v => v.WsTag).ToList();
+				Assume.That(fullSet, Is.EqualTo(new List<string> { "fr", "es" }),
+					"precondition: the unrestricted Lexeme Form row shows both vernaculars");
+				GetOverrideStore().Save(new ViewDefinitionOverride(field.ClassName, field.LayoutName,
+					"detail", new[]
+					{
+						new ViewOverrideOperation(ViewOverrideOperationKind.SetVisibleWritingSystems,
+							ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId),
+							writingSystems: new[] { "fr" })
+					}, null));
+				Assert.That(ComposedFormWsTags(RevealedFields()), Is.EqualTo(new[] { "fr" }),
+					"precondition: the override restricts the composed row");
+
+				InvokeShowAllRightNow(field);
+
+				Assert.That(RevealedFields(), Does.Contain(TemplateId(field)),
+					"the click marks the row's part in the host's transient reveal set");
+				Assert.That(ComposedFormWsTags(RevealedFields()), Is.EqualTo(fullSet),
+					"the revealed row composes with the full writing-system set");
+				Assert.That(StoredWritingSystems(field), Is.EqualTo(new[] { "fr" }),
+					"the stored override keeps the restriction -- the reveal is never persisted");
+			}
+			finally
+			{
+				DeleteOverrideFor(field);
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentVernacularWritingSystems.Remove(second));
+			}
+		}
+
+		// The reveal survives everything within the record and expires only when the shown
+		// record changes.
+		[Test]
+		public void TransientReveal_ExpiresOnRecordNavigation()
+		{
+			var field = LexemeFormField();
+			InvokeShowAllRightNow(field);
+			Assert.That(RevealedFields(), Does.Contain(TemplateId(field)), "precondition: revealed");
+
+			ILexEntry other = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				var stemMorphType = GetMorphTypeOrCreateOne("stem");
+				var noun = GetGrammaticalCategoryOrCreateOne("noun", Cache.LangProject.PartsOfSpeechOA);
+				other = AddLexeme(m_createdObjects, "other-entry", stemMorphType, "other gloss", noun);
+			});
+			m_view.Clerk.JumpToRecord(other.Hvo);
+			DrainMediatorAndIdleQueues();
+
+			Assert.That(RevealedFields(), Is.Empty,
+				"showing a different record expires every transient reveal");
+		}
+
+		// A configuration write replaces the reveal: after a toggle, the row shows the newly
+		// stored set, not the stale full set.
+		[Test]
+		public void WritingSystemToggle_ReplacesTheTransientReveal()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentVernacularWritingSystems(second);
+			});
+			var field = LexemeFormField();
+			try
+			{
+				InvokeShowAllRightNow(field);
+				Assert.That(RevealedFields(), Does.Contain(TemplateId(field)), "precondition: revealed");
+
+				var toggle = BuildWritingSystemsSubmenu(field).Children
+					.First(c => !c.IsSeparator && c.IsChecked && c.Execute != null);
+				var toggledLabel = toggle.Label;
+				toggle.Execute();
+				DrainMediatorAndIdleQueues();
+
+				Assert.That(RevealedFields(), Does.Not.Contain(TemplateId(field)),
+					"persisting a new display set replaces the transient reveal");
+
+				// Re-check the toggled writing system: the toggle persists the visible set into
+				// the part-ref Inventory, which is shared across this fixture's tests.
+				var reAdd = BuildWritingSystemsSubmenu(field).Children
+					.Single(c => !c.IsSeparator && c.Label == toggledLabel);
+				reAdd.Execute();
+				DrainMediatorAndIdleQueues();
+			}
+			finally
+			{
+				DeleteOverrideFor(field);
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentVernacularWritingSystems.Remove(second));
+			}
+		}
+
+		// Drives the intercepted "Show all right now" item for a row the way
+		// OnDetailMenuRequested would: target the adapter, materialize the submenu, invoke,
+		// drain.
+		private void InvokeShowAllRightNow(DetailField field)
+		{
+			EnsureAdapter(field.ObjectHvo, field.Field);
+			var showAll = FindItem(BuildWritingSystemsSubmenu(field).Children, "Show all right now");
+			Assert.That(showAll, Is.Not.Null, "the intercepted reveal item must materialize");
+			Assert.That(showAll.IsEnabled, Is.True);
+			Assert.That(showAll.Execute, Is.Not.Null);
+			showAll.Execute();
+			DrainMediatorAndIdleQueues();
+		}
+
+		// The reveal set is keyed by the part's template id, not the runtime row id.
+		private static string TemplateId(DetailField field)
+			=> ViewDefinitionOverrideEditor.StripRuntimeSuffix(field.StableId);
+
+		// A failed override save must leave the reveal alone: ending it without recomposing
+		// would collapse the row at the next unrelated refresh, with nothing to explain it.
+		[Test]
+		public void TransientReveal_SurvivesAFailedOverrideSave()
+		{
+			CoreWritingSystemDefinition second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				Cache.ServiceLocator.WritingSystemManager.GetOrSet("es", out second);
+				Cache.ServiceLocator.WritingSystems.AddToCurrentVernacularWritingSystems(second);
+			});
+			var field = LexemeFormField();
+			// A file where the store expects its directory: Save's CreateDirectory throws.
+			var blocker = Path.Combine(Path.GetTempPath(), "fw-reveal-" + Guid.NewGuid().ToString("N"));
+			File.WriteAllText(blocker, "not a directory");
+			var storeField = typeof(RecordEditView).GetField("m_viewOverrideStore",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.That(storeField, Is.Not.Null, "the override store field must exist");
+			var original = storeField.GetValue(m_view);
+			string toggledLabel = null;
+			try
+			{
+				InvokeShowAllRightNow(field);
+				Assert.That(RevealedFields(), Does.Contain(TemplateId(field)), "precondition: revealed");
+
+				storeField.SetValue(m_view, new ViewDefinitionOverrideStore(blocker));
+				var toggle = BuildWritingSystemsSubmenu(field).Children
+					.First(c => !c.IsSeparator && c.IsChecked && c.Execute != null);
+				toggledLabel = toggle.Label;
+				toggle.Execute();
+				DrainMediatorAndIdleQueues();
+
+				Assert.That(RevealedFields(), Does.Contain(TemplateId(field)),
+					"a save that failed must leave the transient reveal in place");
+			}
+			finally
+			{
+				storeField.SetValue(m_view, original);
+				File.Delete(blocker);
+				// The toggle persists into the part-ref inventory this fixture shares; re-check
+				// it or later tests see no visible writing system.
+				if (toggledLabel != null)
+				{
+					BuildWritingSystemsSubmenu(field).Children
+						.Single(c => !c.IsSeparator && c.Label == toggledLabel).Execute();
+					DrainMediatorAndIdleQueues();
+				}
+				DeleteOverrideFor(field);
+				NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+					Cache.ServiceLocator.WritingSystems.CurrentVernacularWritingSystems.Remove(second));
+			}
+		}
+
+		// The host's transient reveal set, read through the same seam the production compose
+		// uses.
+		private HashSet<string> RevealedFields()
+			=> (HashSet<string>)GetField(m_view, "m_showAllWsFields");
+
+		// The Lexeme Form row's composed writing-system tags under the CURRENT stored override
+		// and the given reveal set -- the same Compose call ShowAvaloniaEntry makes.
+		private IReadOnlyList<string> ComposedFormWsTags(HashSet<string> reveal)
+			=> FindLexemeFormRow(DetailComposer.Compose(m_entry, Cache,
+					overrides: (cls, layout) => GetOverrideStore().TryGet(cls, layout),
+					showAllWritingSystemsFields: reveal).Model)
+				.Values.Select(v => v.WsTag).ToList();
+
+		// -----------------------------------------------------------------
 		// Helpers -- production-path command drivers
 		// -----------------------------------------------------------------
 
 		// The composed Lexeme Form row, as the production host resolves it before raising a
 		// menu request.
 		private DetailField LexemeFormField()
-			=> DetailComposer.Compose(m_entry, Cache).Model.Fields.Single(f => f.Field == "Form"
-				&& f.Kind == DetailFieldKind.Text && f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
+			=> FindLexemeFormRow(DetailComposer.Compose(m_entry, Cache).Model);
+
+		// The one locator for the Lexeme Form row (the MoForm's own Form field) in a composed
+		// model.
+		private DetailField FindLexemeFormRow(DetailModel model)
+			=> model.Fields.Single(f => f.Field == "Form" && f.Kind == DetailFieldKind.Text
+				&& f.ObjectHvo == m_entry.LexemeFormOA.Hvo);
 
 		private ViewDefinitionOverrideStore GetOverrideStore()
 		{


### PR DESCRIPTION
"Show all right now" on a detail row's Writing Systems menu did nothing. This makes it work: the click reveals every writing system the field can show, for as long as you stay on the record.

The reveal is transient by design — it is view state, not configuration. It survives clicking between fields and editing within the record, and it ends when you navigate to another record or persist a new selection through the writing-system toggles or the Configure dialog. Nothing is written to `.viewoverride.json`, so a peek can never silently pin a field's writing systems.

One reveal covers the whole part, matching what the legacy view does: revealing Gloss on sense 1 reveals it on every sense.

### Why record-scoped expiry

The legacy slice's comments say the reveal ends when the slice loses currency, and its `SetCurrentState` does call `ReloadWssToDisplayForPart` to that end — but that method only resets when `WritingSystemsSelectedForDisplay` is null, and its getter never returns null. The revert has been dead code for years. Testing the shipped behaviour confirmed it: a reveal survives moving between fields and ends only when the rows are rebuilt. This implementation matches the measured behaviour rather than the comment.

Refresh (F5) is a deliberate divergence: the reveal survives it. Legacy rebuilds its slices there, but its F5 handling is itself unreliable in this area (it can leave a block of blank space where a row was), so it is not a parity target. Clearing on every recompose would also kill the reveal whenever an in-record edit completes.

### Also in this branch

`RefreshAvaloniaDetail` now resolves the record to show through the same root walk `ShowRecord` uses. Without it, a `showDescendantInRoot` tool (Notebook) recomposed the subrecord instead of the root on every refresh — a pre-existing defect that also made the reveal clear itself the instant it was set.

The override write path clears the reveal and recomposes only after the save succeeds. `MutateOverrideAndRefresh` is split into a `TryMutateOverride` that reports success without recomposing. Previously a failed save ended the reveal invisibly, so the row collapsed at the next unrelated refresh with nothing to explain it.

### Validation

`build.ps1 -CommentHygiene` green; 23/23 targeted tests pass across the three affected fixtures with no skips (4 new tests). Manually tested in Sena 3: reveal, part scope, record-navigation expiry, replacement by a persisted selection, and confirmation that nothing reaches the override file.

<details>
<summary>Found while testing, not fixed here</summary>

**LT-22777 — writing systems holding data are hidden.** The legacy view never hides an alternative that contains data, regardless of the per-field selection or the project-level checkbox (`SkipEmptyWritingSystem`), and its option list includes active-but-unticked writing systems. The Avalonia composer has neither rule: it resolves only current writing systems and intersects them with the per-field restriction. Two consequences — restricting a field can hide data, and data in an unticked writing system is unreachable. This also bounds the feature in this PR: on a field with no restriction, "Show all right now" has nothing to add, because the composer never resolved the wider set. Filed separately because the fix is a composer-level change to the writing-system model, not to this command.

**Move Field is flaky.** Move Up/Down works sometimes and not others. A real cause was identified — a row at the top level of its own layout gets a null `ParentStableId`, which enablement ignores but `ApplyMoveField` bails on, so the item enables and silently does nothing, even though the applier already reorders roots under an empty parent key. A one-line fix and a test were written and then backed out of this branch, because intermittency means that cause is incomplete. To be investigated on its own.

**Deferred with reasons.** The reveal is left in place on the copy-bail paths (unreadable or stale adapter slice): nothing was persisted there, so keeping the view as the user left it is more honest than collapsing the row. A tidy-up of eight stale "gear-menu" comments is left for a separate commit to keep this diff on topic.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
# Code Review Summary

**Branch**: LT-22691g

**Base**: origin/main (merge-base 8f46a80fc)

**Date**: 2026-09-02

**Review model**: Claude Opus 5

**Files changed**: 5

## Overview

Makes the Avalonia detail view's "Show all right now" writing-system command work.
It was deliberately inert since the c4b menu work (#1108): the menu item existed but
nothing consulted it. The command now marks the clicked row's part in a host-held set
of template StableIds, and the composer skips that part's per-field
`visibleWritingSystems` restriction, so every row sharing the part shows its full
writing-system set until the shown record changes.

Expiry semantics were chosen against measured legacy behavior rather than the legacy
code comments: the legacy slice's documented "expires when the slice loses currency"
path is dead code (`ReloadWssToDisplayForPart` only resets when
`WritingSystemsSelectedForDisplay` is null, which its getter never returns), so legacy
reveals actually survive until the slices are rebuilt. The reveal is therefore
record-scoped, never persisted.

## Contract/API Changes

`DetailComposer.Compose` (both overloads) gains an optional trailing
`ISet<string> showAllWritingSystemsFields` parameter; all existing callers are
source-compatible. `MutateOverrideAndRefresh` is split, adding a private
`TryMutateOverride` that saves without recomposing and reports success.

## Findings

### Critical - Must address before merge

None.

### Important - Should address before merge

- [x] **Reveal was row-scoped where the legacy reveal covers the whole part**
  _(fixed during review: keyed the set on the template StableId, which is the same
  equivalence class as the legacy part-ref; added a test proving one reveal covers
  every sense's Gloss row)_
- [x] **A persist cleared only the clicked row's reveal while the override write
  applies to every row sharing the template** _(fixed during review: same template-id
  rekey)_
- [x] **`RefreshAvaloniaDetail` recomposed `Clerk.CurrentObject` without the
  `showDescendantInRoot` root walk, so the reveal self-cleared on click in Notebook**
  _(fixed during review: added `ResolveShownRecord`, shared with `ShowRecord`; this
  also fixes a pre-existing subrecord-recompose defect)_
- [x] **A failed override save cleared the reveal without recomposing, so the row
  collapsed at the next unrelated refresh** _(fixed during review: `TryMutateOverride`
  split; the reveal is cleared and the view recomposed only after a successful save)_

### Minor - Consider

- [x] **Reveal membership was computed at the call site and threaded as a positional
  bool** _(fixed during review: the check moved inside `ResolveTextRowWritingSystems`)_
- [x] **Repeated invoke-Show-all sequence and a duplicated row locator in the host
  fixture** _(fixed during review: `InvokeShowAllRightNow` and `FindLexemeFormRow`
  helpers)_
- [ ] ~~Lone `<param>` tag on an eight-parameter method breaks the comment standard's
  all-or-nothing rule~~ _(author does not accept the all-or-nothing rule; only the new
  parameter is documented)_
- [ ] ~~The reveal survives F5 / master refresh where legacy rebuilds slices~~
  _(author decision: legacy's F5 handling is itself defective here, leaving blank space
  where a removed row was, so it is not a parity target; clearing on every recompose
  would also kill the reveal when an in-record edit completes)_
- [ ] ~~Reveal state can drift on copy-bail paths (unreadable or stale adapter slice)~~
  _(nothing was persisted on those paths, so keeping the reveal leaves the view as the
  user left it; clearing it would imply a configuration change that did not happen)_

## Required Validation / Evidence

- `./build.ps1 -CommentHygiene` - green (a `-Clean` run was needed once to regenerate
  MIDL headers after PR #1065 added `IVwPattern2`; unrelated to this branch).
- `./test.ps1 -CommentHygiene -TestProject xWorksTests -TestFilter
  "FullyQualifiedName~FieldTypeComposerTests|FullyQualifiedName~DetailObjectCommandExecutionTests|FullyQualifiedName~DetailComposerOverrideTests"`
  - 23/23 passed, 0 skipped.
- Author manual testing in Sena 3 against the checklist below: reveal, part scope,
  record-navigation expiry, persistence replacement, never-persisted.
- Not run: full suite; native tests (no native change); installer validation (none).

## Positive Observations

- The composer bypass is placed where restrictions are applied, so a restriction from
  the shipped layout is honored the same way as one from the project override.
- The reveal is never written to `.viewoverride.json`, verified by a test that asserts
  the stored override still holds the restriction after a reveal.

## Interview Notes

- Expiry semantics: the author tested legacy directly and established that a reveal is
  NOT reverted by moving between fields, contradicting both the legacy doc comments and
  the initial analysis. Record-navigation expiry was chosen to match measured behavior.
- The author established that legacy always displays a writing system that holds data
  regardless of the per-field selection or the project-level checkbox
  (`SkipEmptyWritingSystem`). The Avalonia composer has no such rule and resolves only
  current writing systems. Filed as LT-22777; out of scope here.
- Move Field was found to be flaky during manual testing. A confirmed root-level cause
  was identified and a one-line fix plus test were written, then backed out at the
  author's request because the intermittency proves the cause is incomplete. To be
  investigated separately.
- Author does not understand: nothing recorded. The author reviewed the diff directly
  and drove the design decisions on expiry and scope.

## In-Review Quality Check

All fixes above were made before the commit; build and targeted tests were re-run green
after each. Comment hygiene is clean, and comments comparing behavior to legacy were
removed at the author's request so they do not rot when legacy is retired.

## Suggested Review Focus

- [ ] Template-StableId keying: is the template id the right equivalence class for
      "the same part" in every layout, not just the lexicon ones tested?
- [ ] `ResolveShownRecord` now runs on every Avalonia refresh, changing behavior for
      `showDescendantInRoot` tools (Notebook) that are not yet Avalonia-enabled.
- [ ] The reveal set lives on the host and is passed into every compose; confirm no
      other host composes these rows and would need the same wiring.

<!-- pr-preflight:summary:end -->

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1119)
<!-- Reviewable:end -->

