### PR TITLE
Cleanup comments

### DIFF
--- a/Src/Common/FwAvalonia/Detail/DetailModel.cs
+++ b/Src/Common/FwAvalonia/Detail/DetailModel.cs
@@ -1608,7 +1608,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// the entry's own fields carry "LexEntry"; a row from a descended object (a sense, an
 		/// allomorph)
 		/// carries that object's layout class. Paired with <see cref="LayoutName"/> it keys the per-project
-		/// <c>ViewDefinitionOverride</c> store so the per-field gear-menu commands (Field
+		/// <c>ViewDefinitionOverride</c> store so the per-field menu-button commands (Field
 		/// Visibility / Move
 		/// Field) target the right layout. Set by the composer at compose time (null on rows built outside
 		/// the full-entry composer, e.g. the first-slice fallback).

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailOverrideRenderingTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailOverrideRenderingTests.cs
@@ -16,10 +16,10 @@ using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
 namespace FwAvaloniaTests
 {
 	/// <summary>
-	/// advanced-entry-view (view layer): the per-field gear-menu commands work by changing the composed
-	/// model the detail view renders -- hiding a Never row, showing a non-empty IfData row, and
-	/// reordering
-	/// siblings. These headless tests prove the <see cref="DataTree"/> renders EXACTLY the
+	/// advanced-entry-view (view layer): the per-field menu-button commands work by
+	/// changing the composed model the detail view renders -- hiding a Never row, showing
+	/// a non-empty IfData row, and reordering siblings. These headless tests prove the
+	/// <see cref="DataTree"/> renders EXACTLY the
 	/// rows the (patched) model carries, in model order. The composer's filtering/reorder semantics are
 	/// covered in xWorksTests; here we prove the visible detail view follows the model so the round trip is
 	/// closed at the rendering edge.

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideEditorTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/ViewDefinitionOverrideEditorTests.cs
@@ -9,7 +9,7 @@ using SIL.FieldWorks.Common.FwAvalonia.ViewDefinition;
 namespace FwAvaloniaTests
 {
 	/// <summary>
-	/// advanced-entry-view: the pure "where does the per-field gear-menu command land" logic --
+	/// advanced-entry-view: the pure "where does the per-field menu-button command land" logic --
 	/// strip the
 	/// runtime hvo suffix, locate a node's parent + sibling order + visibility in a compiled definition,
 	/// compute the moved sibling order, and fold one operation into an existing override (idempotently).

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideEditor.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideEditor.cs
@@ -9,9 +9,9 @@ using System.Linq;
 namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 {
 	/// <summary>
-	/// The runtime "where the per-field gear-menu command lands" helper for the Avalonia detail view
-	/// (advanced-entry-view). Two pure jobs over the immutable IR + override model, both unit-testable
-	/// without any XCore/Inventory/LCModel dependency:
+	/// The runtime "where the per-field menu-button command lands" helper for the
+	/// Avalonia detail view (advanced-entry-view). Two pure jobs over the immutable IR +
+	/// override model, both unit-testable without any XCore/Inventory/LCModel dependency:
 	///
 	/// <list type="number">
 	/// <item><see cref="LocateTarget"/> -- given a compiled <see cref="ViewDefinitionModel"/> and
@@ -174,7 +174,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 	/// <summary>
 	/// Where a node sits in a compiled definition: its current visibility, its parent's StableId (null
 	/// at the root), the parent's ordered child StableIds, and the node's index among them. The address
-	/// the gear-menu commands turn into a <see cref="ViewOverrideOperation"/>.
+	/// the menu-button commands turn into a <see cref="ViewOverrideOperation"/>.
 	/// </summary>
 	public sealed class ViewNodeLocation
 	{

--- a/Src/xWorks/Avalonia/Composer/DetailComposer.cs
+++ b/Src/xWorks/Avalonia/Composer/DetailComposer.cs
@@ -284,8 +284,8 @@ namespace SIL.FieldWorks.XWorks
 			// The per-project override resolver, threaded into every CompileForObject
 			// so a descended object's layout gets its own patch applied; plus the (class, layout) of the
 			// model currently being walked, captured onto each emitted field so the host's per-field
-			// gear-menu commands target the right override file. A stack so the entry context restores
-			// after a nested object's walk returns.
+			// menu-button commands target the right override file. A stack so the entry
+			// context restores after a nested object's walk returns.
 			private readonly ViewDefinitionOverrideResolver _overrides;
 			private readonly Stack<(string ClassName, string LayoutName)> _modelContext
 				= new Stack<(string, string)>();
@@ -3020,8 +3020,8 @@ namespace SIL.FieldWorks.XWorks
 				if (compiled != null && compiled.Roots.Count > 0)
 				{
 					// Rows from the descended model are stamped with ITS (class,
-					// layout), so the gear-menu commands on a sense/allomorph row target that layout's
-					// override file, not the entry's.
+					// layout), so the menu-button commands on a sense/allomorph row target
+					// that layout's override file, not the entry's.
 					EnterModel(compiled);
 					foreach (var child in compiled.Roots)
 						Walk(child, target, depth + 1);

--- a/Src/xWorks/xWorksTests/Avalonia/Composer/DetailComposerOverrideTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Composer/DetailComposerOverrideTests.cs
@@ -14,9 +14,9 @@ using SIL.LCModel.Infrastructure;
 namespace SIL.FieldWorks.XWorks
 {
 	/// <summary>
-	/// advanced-entry-view: end-to-end coverage that the per-field gear-menu commands actually change
-	/// what the Avalonia detail view composes, BY GOING THROUGH the override layer the menu
-	/// writes -- not the
+	/// advanced-entry-view: end-to-end coverage that the per-field menu-button commands
+	/// actually change what the Avalonia detail view composes, BY GOING THROUGH the
+	/// override layer the menu writes -- not the
 	/// legacy Inventory store. Visibility overrides hide/show rows under the same showHidden semantics
 	/// legacy slices use; reorder overrides move sibling rows; both survive a recompose; and applying an
 	/// override never poisons the process-wide compiled-model cache (a compose without the patch is


### PR DESCRIPTION
Eight comments across six files described the detail row's field menu as a "gear menu". There is no gear anywhere: it is a blue down-arrow in the legacy view and a three-dot button in Avalonia. They now say "menu-button", the term already used in LT-17670 and LT-19150 — which also stops the wrong word being copied into new comments.

Comments only. No executable code changed, so the build is the gate here; it validates the `<see cref>` references in the doc comments, and there is nothing for tests to exercise.

The diff is a little larger than eight word swaps. "menu-button" is two characters longer than "gear-menu", which pushed five lines past the width limit and tripped the comment-hygiene auto-rewrap, stranding single words ("composed", "view", "restores", "layout's", "change") on their own lines. Those blocks are hand-rewrapped so the prose reads normally and stays under the limit.

One further occurrence, the log message in `RecordEditView.Avalonia.cs`, is deliberately absent: it is already fixed in #1119, and touching it here would conflict.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1120)
<!-- Reviewable:end -->
