### PR TITLE
Fix the writing system drop down not tracking reversal fields

### DIFF
--- a/Src/xWorks/Avalonia/Composer/DetailComposer.cs
+++ b/Src/xWorks/Avalonia/Composer/DetailComposer.cs
@@ -116,9 +116,11 @@ namespace SIL.FieldWorks.XWorks
 		public static ComposedDetail Compose(ILexEntry entry, LcmCache cache, bool showHiddenFields = false,
 			SlicePluginRegistry plugins = null,
 			ViewDefinitionOverrideResolver overrides = null,
-			ISet<string> showAllWritingSystemsFields = null)
+			ISet<string> showAllWritingSystemsFields = null,
+			Action<string> writingSystemFocused = null)
 			=> Compose((ICmObject)entry, cache, "Normal", showHiddenFields, plugins, overrides,
-				showAllWritingSystemsFields: showAllWritingSystemsFields);
+				showAllWritingSystemsFields: showAllWritingSystemsFields,
+				writingSystemFocused: writingSystemFocused);
 
 		/// <summary>
 		/// Compose the structured detail view for ANY record root + starting layout -- the
@@ -132,11 +134,14 @@ namespace SIL.FieldWorks.XWorks
 		/// <param name="showAllWritingSystemsFields">Template StableIds of parts under a
 		/// transient "Show all right now" reveal: every row of those parts composes with its
 		/// full writing-system set, ignoring per-field visibility restrictions.</param>
+		/// <param name="writingSystemFocused">The host's editor-focus callback for plugin rows;
+		/// null when no host supplies one.</param>
 		public static ComposedDetail Compose(ICmObject obj, LcmCache cache, string layoutName = "Normal",
 			bool showHiddenFields = false, SlicePluginRegistry plugins = null,
 			ViewDefinitionOverrideResolver overrides = null,
 			string layoutChoiceField = null,
-			ISet<string> showAllWritingSystemsFields = null)
+			ISet<string> showAllWritingSystemsFields = null,
+			Action<string> writingSystemFocused = null)
 		{
 			if (obj == null) throw new ArgumentNullException(nameof(obj));
 			if (cache == null) throw new ArgumentNullException(nameof(cache));
@@ -157,7 +162,7 @@ namespace SIL.FieldWorks.XWorks
 			IDetailEditContext composedContext = null;
 			var state = new ComposeState(cache, showHiddenFields,
 				plugins ?? SlicePluginRegistry.Default, () => composedContext, overrides,
-				showAllWritingSystemsFields);
+				showAllWritingSystemsFields, writingSystemFocused);
 			state.EnterModel(root);
 			foreach (var node in root.Roots)
 				state.Walk(node, obj, 0);
@@ -301,6 +306,8 @@ namespace SIL.FieldWorks.XWorks
 			// receive (resolved when the factory runs, after Compose has built the context).
 			private readonly SlicePluginRegistry _plugins;
 			private readonly Func<IDetailEditContext> _editContextAccessor;
+			// The host's editor-focus callback, handed to plugin rows through the build context.
+			private readonly Action<string> _writingSystemFocused;
 			// Parts under the host's transient "Show all right now" reveal (template StableIds);
 			// every row of those parts composes with its full writing-system set.
 			private readonly ISet<string> _showAllWsFields;
@@ -338,12 +345,14 @@ namespace SIL.FieldWorks.XWorks
 			public ComposeState(LcmCache cache, bool showHiddenFields,
 				SlicePluginRegistry plugins, Func<IDetailEditContext> editContextAccessor,
 				ViewDefinitionOverrideResolver overrides = null,
-				ISet<string> showAllWritingSystemsFields = null)
+				ISet<string> showAllWritingSystemsFields = null,
+				Action<string> writingSystemFocused = null)
 			{
 				_cache = cache;
 				_showHidden = showHiddenFields;
 				_plugins = plugins;
 				_editContextAccessor = editContextAccessor;
+				_writingSystemFocused = writingSystemFocused;
 				_overrides = overrides;
 				_showAllWsFields = showAllWritingSystemsFields;
 				_sda = cache.DomainDataByFlid;
@@ -2704,10 +2713,10 @@ namespace SIL.FieldWorks.XWorks
 			private void AddPluginRow(ViewNode node, ICmObject obj, int depth, ISlicePlugin plugin)
 			{
 				// ONE plugin contract -- the build context bundles everything a
-				// plugin can need (object, node, deferred edit-context accessor, cache); there is
-				// no
-				// service-aware marker type test.
-				var context = new SlicePluginBuildContext(obj, node, _editContextAccessor, _cache);
+				// plugin can need (object, node, deferred edit-context accessor, cache, focus
+				// callback); there is no service-aware marker type test.
+				var context = new SlicePluginBuildContext(obj, node, _editContextAccessor, _cache,
+					_writingSystemFocused);
 				Func<Avalonia.Controls.Control> factory = () => plugin.BuildControl(context);
 				AddField(new DetailField(StableId(node, obj), Localize(node.Label) ?? node.Field,
 					node.Field, node.WritingSystem, DetailFieldKind.Custom, node.EditorClassification,

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -351,7 +351,8 @@ namespace SIL.FieldWorks.XWorks
 				composed = lexEntry != null
 					? DetailComposer.Compose(lexEntry, Cache, showHidden,
 						overrides: ResolveViewOverride,
-						showAllWritingSystemsFields: m_showAllWsFields)
+						showAllWritingSystemsFields: m_showAllWsFields,
+						writingSystemFocused: OnDetailWritingSystemFocused)
 					// Non-entry roots compose against the tool's configured layout
 					// (m_layoutName, default "Normal"); a type-selected layout (m_layoutChoiceField, e.g.
 					// Notebook RnGenericRec keyed on "Type") resolves to the right variant inside Compose.
@@ -359,7 +360,8 @@ namespace SIL.FieldWorks.XWorks
 						string.IsNullOrEmpty(m_layoutName) ? "Normal" : m_layoutName, showHidden,
 						overrides: ResolveViewOverride,
 						layoutChoiceField: m_layoutChoiceField,
-						showAllWritingSystemsFields: m_showAllWsFields);
+						showAllWritingSystemsFields: m_showAllWsFields,
+						writingSystemFocused: OnDetailWritingSystemFocused);
 				if (composed != null)
 				{
 					detail = composed.Model;

--- a/Src/xWorks/Avalonia/Plugins/ReversalIndexEntryPlugin.cs
+++ b/Src/xWorks/Avalonia/Plugins/ReversalIndexEntryPlugin.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls;
 using SIL.FieldWorks.Common.FwAvalonia.Detail;
-using SIL.FieldWorks.Common.FwAvalonia.Seams;
 using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Text;
@@ -40,6 +39,9 @@ namespace SIL.FieldWorks.XWorks
 		public const string ReversalIndexEntrySliceClassName =
 			"SIL.FieldWorks.XWorks.LexEd.ReversalIndexEntrySlice";
 
+		/// <summary>The editor's automation id when the layout node declares none.</summary>
+		public const string DefaultAutomationId = "ReversalEntriesEditor";
+
 		public string LegacyClassName => ReversalIndexEntrySliceClassName;
 
 		public Control BuildControl(SlicePluginBuildContext context)
@@ -64,7 +66,7 @@ namespace SIL.FieldWorks.XWorks
 					kind: DetailFieldKind.Text,
 					editorClassification: node?.EditorClassification
 						?? SIL.FieldWorks.Common.FwAvalonia.ViewDefinition.EditorClassification.Known,
-					automationId: node?.AutomationId ?? "ReversalEntriesEditor",
+					automationId: node?.AutomationId ?? DefaultAutomationId,
 					localizationKey: node?.LocalizationKey,
 					routing: node?.Routing ?? SIL.FieldWorks.Common.FwAvalonia.ViewDefinition.HostRouting.Product,
 					values: rows,
@@ -74,9 +76,9 @@ namespace SIL.FieldWorks.XWorks
 					objectHvo: sense.Hvo);
 
 				var reversalContext = new ReversalDetailEditContext(cache, context.EditContext, entryByWsKey);
-				var automationId = node?.AutomationId ?? "ReversalEntriesEditor";
+				var automationId = node?.AutomationId ?? DefaultAutomationId;
 				return new FwMultiWsTextField(field, automationId, reversalContext,
-					writingSystemFocused: wsTag => WritingSystemKeyboards.Activate(cache, wsTag));
+					writingSystemFocused: context.WritingSystemFocused);
 			}
 			catch (Exception e)
 			{

--- a/Src/xWorks/Avalonia/Plugins/SlicePlugins.cs
+++ b/Src/xWorks/Avalonia/Plugins/SlicePlugins.cs
@@ -41,19 +41,22 @@ namespace SIL.FieldWorks.XWorks
 	/// Everything the composer hands a plugin factory, bundled into one contract:
 	/// the row's object and typed node, the detail view's edit context (resolved lazily through the
 	/// composer's deferred accessor -- the context object is created during compose, BEFORE the
-	/// edit context exists; plugin factories run at render time, after), and the cache.
+	/// edit context exists; plugin factories run at render time, after), the cache, and the
+	/// host's writing-system focus callback.
 	/// </summary>
 	public sealed class SlicePluginBuildContext
 	{
 		private readonly Func<IDetailEditContext> _editContextAccessor;
 
 		public SlicePluginBuildContext(ICmObject target, ViewNode node,
-			Func<IDetailEditContext> editContextAccessor, LcmCache cache)
+			Func<IDetailEditContext> editContextAccessor, LcmCache cache,
+			Action<string> writingSystemFocused = null)
 		{
 			Target = target;
 			Node = node;
 			_editContextAccessor = editContextAccessor;
 			Cache = cache;
+			WritingSystemFocused = writingSystemFocused;
 		}
 
 		/// <summary>The composed row's own object (the slice's object in legacy terms).</summary>
@@ -66,6 +69,12 @@ namespace SIL.FieldWorks.XWorks
 		public IDetailEditContext EditContext => _editContextAccessor?.Invoke();
 
 		public LcmCache Cache { get; }
+
+		/// <summary>
+		/// The host's editor-focus callback, raised with the writing-system tag of the plugin
+		/// editor that gained focus. Null when the host supplies none.
+		/// </summary>
+		public Action<string> WritingSystemFocused { get; }
 	}
 
 	/// <summary>

--- a/Src/xWorks/xWorksTests/Avalonia/Composer/DetailEditContextEditingTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Composer/DetailEditContextEditingTests.cs
@@ -407,6 +407,9 @@ namespace SIL.FieldWorks.XWorks
 		public override void TestSetup()
 		{
 			base.TestSetup();
+			// The reversal plugin tests build a real Avalonia editor, which needs the (headless)
+			// platform; run in isolation, no earlier fixture has initialized it.
+			FwAvaloniaRuntime.EnsureInitialized();
 			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
 			{
 				m_entry = Cache.ServiceLocator.GetInstance<ILexEntryFactory>().Create();

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailWritingSystemStateTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailWritingSystemStateTests.cs
@@ -5,8 +5,15 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Xml;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using NUnit.Framework;
+using SIL.FieldWorks.Common.FwAvalonia;
+using SIL.FieldWorks.Common.FwAvalonia.Detail;
 using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Infrastructure;
@@ -28,6 +35,7 @@ namespace SIL.FieldWorks.XWorks
 	{
 		private PropertyTable m_propertyTable;
 		private List<ICmObject> m_createdObjects;
+		private ILexEntry m_entry;
 		private RecordEditView m_view;
 		// The real subscriber under test. MockFwXWindow's bare-minimum LoadUI never loads the
 		// Main.xml listeners, so the fixture creates the one this channel needs itself.
@@ -66,6 +74,7 @@ namespace SIL.FieldWorks.XWorks
 		{
 			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, DestroyLexiconTestData);
 			m_createdObjects = null;
+			m_entry = null;
 			m_view = null;
 			// Unsubscribes from the process-wide Pub/Sub singleton; without it a disposed
 			// handler would still hear later fixtures' publishes.
@@ -110,6 +119,64 @@ namespace SIL.FieldWorks.XWorks
 				"focusing an analysis editor must move the combo property back");
 		}
 
+		// Plugin rows bypass SliceFactory, so the host's focus handler reaches them only
+		// through the callback Compose threads into SlicePluginBuildContext.
+		[Test]
+		public void PluginRowEditorFocus_UpdatesWritingSystemHvoProperty_ThroughPubSub()
+		{
+			var vernacular = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
+			var analysis = Cache.ServiceLocator.WritingSystems.DefaultAnalysisWritingSystem;
+			var sense = m_entry.SensesOS[0];
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				var repository = Cache.ServiceLocator.GetInstance<IReversalIndexRepository>();
+				var hadIndex = repository.AllInstances().Any(index => index.WritingSystem == analysis.Id);
+				var reversalIndex = repository.FindOrCreateIndexForWs(analysis.Handle);
+				if (!hadIndex)
+					m_createdObjects.Add(reversalIndex);
+				var reversalEntry = reversalIndex.FindOrCreateReversalEntry("dwelling");
+				reversalEntry.SensesRS.Add(sense);
+				m_createdObjects.Add(reversalEntry);
+			});
+
+			// Compose with the host's handler as the plugin callback, the way ShowAvaloniaEntry
+			// does, and realize the view with the same handler on the composer-row path.
+			var composed = DetailComposer.Compose(m_entry, Cache,
+				writingSystemFocused: m_view.OnDetailWritingSystemFocused);
+			FwAvaloniaRuntime.EnsureInitialized();
+			var view = new DataTree(composed.Model, composed.EditContext, m_view.OnDetailWritingSystemFocused);
+			var window = new Window { Content = view, Width = 520, Height = 360 };
+			try
+			{
+				window.Show();
+				Dispatcher.UIThread.RunJobs();
+				// The plugin stamps <row automation id>.<ws tag> on each of its value boxes.
+				var row = composed.Model.Fields.First(f => f.Kind == DetailFieldKind.Custom
+					&& f.ObjectHvo == sense.Hvo);
+				var boxId = (row.AutomationId ?? ReversalIndexEntryPlugin.DefaultAutomationId) + "." + analysis.Id;
+				var reversalBox = view.GetVisualDescendants().OfType<TextBox>()
+					.FirstOrDefault(box => AutomationProperties.GetAutomationId(box) == boxId);
+				Assert.That(reversalBox, Is.Not.Null,
+					"precondition: the Reversal Entries plugin row realized its analysis-ws editor");
+
+				m_view.OnDetailWritingSystemFocused(vernacular.Id);
+				Assert.That(CurrentWritingSystemHvoProperty(),
+					Is.EqualTo(vernacular.Handle.ToString(CultureInfo.InvariantCulture)),
+					"precondition: the combo property starts away from the reversal row's ws");
+
+				reversalBox.Focus();
+				Dispatcher.UIThread.RunJobs();
+
+				Assert.That(CurrentWritingSystemHvoProperty(),
+					Is.EqualTo(analysis.Handle.ToString(CultureInfo.InvariantCulture)),
+					"focusing a plugin row's editor must publish its ws like every composer-built row");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
 		private string CurrentWritingSystemHvoProperty()
 		{
 			return m_propertyTable.GetStringProperty(PropertyConstants.WritingSystemHvo, null);
@@ -133,17 +200,19 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var stemMorphType = GetMorphTypeOrCreateOne("stem");
 			var nounPartOfSpeech = GetGrammaticalCategoryOrCreateOne("noun", Cache.LangProject.PartsOfSpeechOA);
-			AddLexeme(m_createdObjects, "ws-state-entry", stemMorphType, "ws state gloss", nounPartOfSpeech);
+			m_entry = AddLexeme(m_createdObjects, "ws-state-entry", stemMorphType, "ws state gloss",
+				nounPartOfSpeech);
 		}
 
 		private void DestroyLexiconTestData()
 		{
 			if (m_createdObjects == null)
 				return;
-			foreach (var obj in m_createdObjects)
+			// Reverse order: a reversal entry is deleted before the index that owns it.
+			for (var i = m_createdObjects.Count - 1; i >= 0; i--)
 			{
-				if (obj.IsValidObject && obj is ILexEntry)
-					obj.Delete();
+				if (m_createdObjects[i].IsValidObject)
+					m_createdObjects[i].Delete();
 			}
 		}
 	}


### PR DESCRIPTION
In the New lexical edit UI, clicking into a Reversal Entries form now moves the toolbar writing-system combo to that form's writing system, the same way every other text field already does. Before, the keyboard switched but the combo kept showing the previous field's writing system.

**Why it was broken.** Editors built by SliceFactory receive the host's writing-system focus callback. Plugin-built rows never did: `SlicePluginBuildContext` carried no callback, so `ReversalIndexEntryPlugin` substituted its own keyboard-only lambda and nothing published `WritingSystemUnderCursorChanged`. The fix hands the plugin the host's real callback. The question worth a reviewer's time is not "what breaks" (nothing changes for composer-built rows) but whether the callback enters at the right layer, which is covered below.

**Where to look**

- `RecordEditView.ShowAvaloniaEntry`: two named arguments pass `OnDetailWritingSystemFocused` into `Compose`. This is the only production wiring, and the only touch on that file.
- `DetailComposer`: optional trailing parameter on both `Compose` overloads and `ComposeState`, passed into the plugin build context. Parameter plumbing only.
- `SlicePluginBuildContext.WritingSystemFocused`: the new seam plugins read.
- `ReversalIndexEntryPlugin`: forwards the context callback and drops its private keyboard-only fallback, so keyboard activation and the publish come from one path.
- `DetailWritingSystemStateTests`: the new test composes with the host handler, realizes the view headless, focuses the reversal editor, and asserts the toolbar's `WritingSystemHvo` property moved through Pub/Sub and `WritingSystemListHandler`.

**Deliberately not here**

- Plugin rows still lack the standard slice menu and TsString clipboard (deferred from #1095's review, tracked there).
- The callback is threaded at compose time, not through `DetailField.ControlFactory`, to keep clear of PR #1111's rewrite of `DetailModel.cs`. See the accordion.
- The new test supplies the host handler itself, so the two `RecordEditView` arguments are covered by manual test, not by the test.

**Verification.** `build.ps1 -CommentHygiene -TokenHygiene` green. Targeted `test.ps1` over the ws-state, plugin inventory, and reversal composer fixtures: 11/11. Manual check in Sena 3 (New UI mode): combo follows the cursor into the Portuguese and English reversal forms. Full suites not run. Two pre-existing reversal composer tests were order-dependent (no headless platform init) and now pass in isolation.

---

<details>
<summary>Design: compose-time threading vs the ControlFactory seam</summary>

`SliceFactory.CreateCustom` already holds a `SliceFactoryContext` with the host callback when it invokes a plugin's factory, so the architecturally purest fix would pass that context through `DetailField.ControlFactory`. That changes the delegate type in `DetailModel.cs`, which PR #1111 rewrites heavily along with `DetailComposer.cs`. Compose-time threading keeps the #1111 overlap to parameter-list additions.

Consequences accepted for now: the callback lives in two places (Compose and the DataTree constructor), both fed by the same method group in `RecordEditView`; and further host services for plugins (menu, clipboard) would repeat the same plumbing. The render-time seam is the target once #1111 lands.

</details>

<details>
<summary>Decision: the plugin's keyboard-only fallback is gone</summary>

The plugin used to call `WritingSystemKeyboards.Activate` itself. The host callback already does that and also publishes, so keeping a fallback would double-activate. Without a host callback the plugin row now behaves exactly like every composer-built row (no keyboard switching). No production or preview host composes plugin rows without the callback; the only such callers are tests that do not assert on keyboard behavior.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
Eight-angle review with one verifier per candidate: nine candidates, seven confirmed, two refuted.

Fixed before commit:
- Orphaned ctor `<param>` and consumer-narrating property summary on `SlicePluginBuildContext`.
- `Compose` `<param>` trimmed to its value contract.
- Headless platform init moved to `DetailComposerTests.TestSetup` (both reversal tests pass alone).
- Test registers its reversal index and entry for teardown; teardown deletes all registered objects.
- Window size aligned with sibling headless tests (the Form does not virtualize).
- Editor located by its full stamped automation id via the new `ReversalIndexEntryPlugin.DefaultAutomationId`.

Accepted as is: the new test supplies the host handler to `Compose` itself; the host's two named arguments are covered by manual test.

Refuted: dual injection points drifting (no callback-less host composes plugin rows); dropping the fallback (parity with composer rows).

Contract changes: optional trailing parameters only, plus one new public constant. No Critical or Important findings.
<!-- pr-preflight:summary:end -->

</details>

<details>
<summary>CI-ready checklist</summary>

- [x] Commit messages follow `.github/commit-guidelines.md`.
- [x] The change is unit tested (new headless test; two existing tests hardened).
- [x] Builds and tests pass locally via `build.ps1` and `test.ps1`.
- [x] AI-assisted work: `pr-preflight` ran before requesting review.
- [x] No `AGENTS.md` under the touched `Src/**` folders needs updating.
- [ ] AI code reviewer comments considered (pending review).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1121)
<!-- Reviewable:end -->
