### PR TITLE
Attempt at fixing LT-22708

### DIFF
--- a/Src/FwParatextLexiconPlugin/FdoLexicon.cs
+++ b/Src/FwParatextLexiconPlugin/FdoLexicon.cs
@@ -2,6 +2,18 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using Paratext.LexicalContracts;
+using SIL.FieldWorks.WordWorks.Parser;
+using SIL.LCModel;
+using SIL.LCModel.Core.KernelInterfaces;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.DomainImpl;
+using SIL.LCModel.DomainServices;
+using SIL.LCModel.Infrastructure;
+using SIL.LCModel.Utils;
+using SIL.Machine.Morphology;
+using SIL.ObjectModel;
+using SIL.PlatformUtilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,18 +23,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Web;
-using Paratext.LexicalContracts;
-using SIL.LCModel.Core.Text;
-using SIL.LCModel.Core.KernelInterfaces;
-using SIL.LCModel;
-using SIL.LCModel.DomainImpl;
-using SIL.LCModel.DomainServices;
-using SIL.LCModel.Infrastructure;
-using SIL.LCModel.Utils;
-using SIL.FieldWorks.WordWorks.Parser;
-using SIL.Machine.Morphology;
-using SIL.ObjectModel;
-using SIL.PlatformUtilities;
+using XCore;
 using WordAnalysis = Paratext.LexicalContracts.WordAnalysis;
 
 namespace SIL.FieldWorks.ParatextLexiconPlugin
@@ -39,7 +40,8 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 		private readonly int m_defaultVernWs;
 		private PoorMansStemmer<string, char> m_stemmer;
 		private readonly string m_projectId;
-
+		Mediator Mediator { get; set; }
+		PropertyTable PropertyTable { get; set; }
 		internal FdoLexicon(string scrTextName, string projectId, LcmCache cache, int defaultVernWs)
 		{
 			m_scrTextName = scrTextName;
@@ -79,6 +81,10 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			{
 				m_parser.Dispose();
 				m_parser = null;
+				Mediator.Dispose();
+				Mediator = null;
+				PropertyTable.Dispose();
+				PropertyTable = null;
 			}
 		}
 
@@ -646,7 +652,11 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
 			{
 				case "XAmple":
-					m_parser = new XAmpleParser(m_cache, parserDataDir);
+					// LT-22708 As of 2026.08.26, this is only called within FLEx from FdoLexiconTests.
+					// Creating the mediator and property table here works fine.
+					Mediator = new Mediator();
+					PropertyTable = new PropertyTable(Mediator);
+					m_parser = new XAmpleParser(m_cache, parserDataDir, PropertyTable);
 					break;
 				case "HC":
 					m_parser = new HCParser(m_cache);

--- a/Src/FwParatextLexiconPlugin/FdoLexicon.cs
+++ b/Src/FwParatextLexiconPlugin/FdoLexicon.cs
@@ -652,7 +652,8 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
 			{
 				case "XAmple":
-					// LT-22708 As of 2026.08.26, this is only called within FLEx from FdoLexiconTests.
+					// LT-22708 As of 2026.08.26, this is only called within FLEx from
+					// FdoLexiconTests.
 					// Creating the mediator and property table here works fine.
 					Mediator = new Mediator();
 					PropertyTable = new PropertyTable(Mediator);

--- a/Src/FwParatextLexiconPlugin/FdoLexicon.cs
+++ b/Src/FwParatextLexiconPlugin/FdoLexicon.cs
@@ -2,18 +2,6 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using Paratext.LexicalContracts;
-using SIL.FieldWorks.WordWorks.Parser;
-using SIL.LCModel;
-using SIL.LCModel.Core.KernelInterfaces;
-using SIL.LCModel.Core.Text;
-using SIL.LCModel.DomainImpl;
-using SIL.LCModel.DomainServices;
-using SIL.LCModel.Infrastructure;
-using SIL.LCModel.Utils;
-using SIL.Machine.Morphology;
-using SIL.ObjectModel;
-using SIL.PlatformUtilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,7 +11,18 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Web;
-using XCore;
+using Paratext.LexicalContracts;
+using SIL.LCModel.Core.Text;
+using SIL.LCModel.Core.KernelInterfaces;
+using SIL.LCModel;
+using SIL.LCModel.DomainImpl;
+using SIL.LCModel.DomainServices;
+using SIL.LCModel.Infrastructure;
+using SIL.LCModel.Utils;
+using SIL.FieldWorks.WordWorks.Parser;
+using SIL.Machine.Morphology;
+using SIL.ObjectModel;
+using SIL.PlatformUtilities;
 using WordAnalysis = Paratext.LexicalContracts.WordAnalysis;
 
 namespace SIL.FieldWorks.ParatextLexiconPlugin
@@ -40,8 +39,7 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 		private readonly int m_defaultVernWs;
 		private PoorMansStemmer<string, char> m_stemmer;
 		private readonly string m_projectId;
-		Mediator Mediator { get; set; }
-		PropertyTable PropertyTable { get; set; }
+
 		internal FdoLexicon(string scrTextName, string projectId, LcmCache cache, int defaultVernWs)
 		{
 			m_scrTextName = scrTextName;
@@ -81,10 +79,6 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			{
 				m_parser.Dispose();
 				m_parser = null;
-				Mediator.Dispose();
-				Mediator = null;
-				PropertyTable.Dispose();
-				PropertyTable = null;
 			}
 		}
 
@@ -648,23 +642,19 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 
 		private void InstantiateParser()
 		{
-			string parserDataDir = Path.Combine(ParatextLexiconPluginDirectoryFinder.CodeDirectory, "Language Explorer");
-			switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
-			{
-				case "XAmple":
-					// LT-22708 As of 2026.08.26, this is only called within FLEx from
-					// FdoLexiconTests.
-					// Creating the mediator and property table here works fine.
-					Mediator = new Mediator();
-					PropertyTable = new PropertyTable(Mediator);
-					m_parser = new XAmpleParser(m_cache, parserDataDir, PropertyTable);
-					break;
-				case "HC":
-					m_parser = new HCParser(m_cache);
-					break;
-				default:
-					throw new InvalidOperationException("The language project is set to use an unrecognized parser.");
-			}
+			// LT-22708 2026.09.11 Jason Naylor says to keep m_parser as null for now.
+			//string parserDataDir = Path.Combine(ParatextLexiconPluginDirectoryFinder.CodeDirectory, "Language Explorer");
+			//switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
+			//{
+			//	case "XAmple":
+			//		m_parser = new XAmpleParser(m_cache, parserDataDir, PropertyTable);
+			//		break;
+			//	case "HC":
+			//		m_parser = new HCParser(m_cache);
+			//		break;
+			//	default:
+			//		throw new InvalidOperationException("The language project is set to use an unrecognized parser.");
+			//}
 		}
 
 		private ILexEntry GetMatchingEntryFromStemmer(string wordForm)

--- a/Src/FwParatextLexiconPlugin/FdoLexicon.cs
+++ b/Src/FwParatextLexiconPlugin/FdoLexicon.cs
@@ -617,9 +617,6 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 		{
 			ILexEntry matchingEntry = null;
 			if (m_parser == null)
-				InstantiateParser();
-
-			if (m_parser == null)
 				return null;
 
 			if (!m_parser.IsUpToDate())
@@ -638,23 +635,6 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 				}
 			}
 			return matchingEntry;
-		}
-
-		private void InstantiateParser()
-		{
-			// LT-22708 2026.09.11 Jason Naylor says to keep m_parser as null for now.
-			//string parserDataDir = Path.Combine(ParatextLexiconPluginDirectoryFinder.CodeDirectory, "Language Explorer");
-			//switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
-			//{
-			//	case "XAmple":
-			//		m_parser = new XAmpleParser(m_cache, parserDataDir, PropertyTable);
-			//		break;
-			//	case "HC":
-			//		m_parser = new HCParser(m_cache);
-			//		break;
-			//	default:
-			//		throw new InvalidOperationException("The language project is set to use an unrecognized parser.");
-			//}
 		}
 
 		private ILexEntry GetMatchingEntryFromStemmer(string wordForm)

--- a/Src/FwParatextLexiconPlugin/FwParatextLexiconPluginTests/FdoLexiconTests.cs
+++ b/Src/FwParatextLexiconPlugin/FwParatextLexiconPluginTests/FdoLexiconTests.cs
@@ -556,10 +556,11 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			Assert.That(matchingLexeme.LexicalForm == "a", Is.True);
 
 			// Found by parser
-			lexeme = m_lexicon.CreateLexeme(LexemeType.Prefix, "pre");
-			m_lexicon.AddLexeme(lexeme);
-			matchingLexeme = m_lexicon.FindClosestMatchingLexeme("prea");
-			Assert.That(matchingLexeme.LexicalForm == "a", Is.True);
+			// LT-22708 2026.09.11 Jason Naylor says to keep m_parser as null for now.
+			//lexeme = m_lexicon.CreateLexeme(LexemeType.Prefix, "pre");
+			//m_lexicon.AddLexeme(lexeme);
+			//matchingLexeme = m_lexicon.FindClosestMatchingLexeme("prea");
+			//Assert.That(matchingLexeme.LexicalForm == "a", Is.True);
 
 			// Found by unsupervised stemmer
 			m_lexicon.AddLexeme(m_lexicon.CreateLexeme(LexemeType.Stem, "b"));

--- a/Src/FwParatextLexiconPlugin/FwParatextLexiconPluginTests/FdoLexiconTests.cs
+++ b/Src/FwParatextLexiconPlugin/FwParatextLexiconPluginTests/FdoLexiconTests.cs
@@ -555,13 +555,6 @@ namespace SIL.FieldWorks.ParatextLexiconPlugin
 			matchingLexeme = m_lexicon.FindClosestMatchingLexeme("a");
 			Assert.That(matchingLexeme.LexicalForm == "a", Is.True);
 
-			// Found by parser
-			// LT-22708 2026.09.11 Jason Naylor says to keep m_parser as null for now.
-			//lexeme = m_lexicon.CreateLexeme(LexemeType.Prefix, "pre");
-			//m_lexicon.AddLexeme(lexeme);
-			//matchingLexeme = m_lexicon.FindClosestMatchingLexeme("prea");
-			//Assert.That(matchingLexeme.LexicalForm == "a", Is.True);
-
 			// Found by unsupervised stemmer
 			m_lexicon.AddLexeme(m_lexicon.CreateLexeme(LexemeType.Stem, "b"));
 			m_lexicon.AddLexeme(m_lexicon.CreateLexeme(LexemeType.Stem, "c"));

--- a/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
+++ b/Src/LexText/ParserCore/ParserCoreTests/ParseWorkerTests.cs
@@ -24,6 +24,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		private String m_taskDetailsString;
 		private IdleQueue m_idleQueue;
 		private CoreWritingSystemDefinition m_vernacularWS;
+		Mediator Mediator { get; set; }
+		PropertyTable PropertyTable { get; set; }
 		#endregion Data Members
 
 		#region Non-test methods
@@ -67,6 +69,8 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			base.FixtureSetup();
 			m_vernacularWS = Cache.ServiceLocator.WritingSystems.DefaultVernacularWritingSystem;
 			m_idleQueue = new IdleQueue {IsPaused = true};
+			Mediator = new Mediator();
+			PropertyTable = new PropertyTable(Mediator);
 		}
 
 		public override void FixtureTeardown()
@@ -74,7 +78,10 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			m_vernacularWS = null;
 			m_idleQueue.Dispose();
 			m_idleQueue = null;
-
+			Mediator.Dispose();
+			Mediator = null;
+			PropertyTable.Dispose();
+			PropertyTable = null;
 			base.FixtureTeardown();
 		}
 
@@ -106,7 +113,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public void TryAWord()
 		{
 			XDocument lowerXDoc = new XDocument(new XComment("cats"));
-			var parserWorker = new ParserWorker(Cache, null, HandleTaskUpdate, m_idleQueue, null);
+			var parserWorker = new ParserWorker(Cache, PropertyTable, HandleTaskUpdate, m_idleQueue, null);
 			parserWorker.Parser = new TestParserClass(null, lowerXDoc);
 
 			// SUT
@@ -141,7 +148,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 				});
 			});
 
-			var parserWorker = new ParserWorker(Cache, null, HandleTaskUpdate, m_idleQueue, null);
+			var parserWorker = new ParserWorker(Cache, PropertyTable, HandleTaskUpdate, m_idleQueue, null);
 			parserWorker.Parser = new TestParserClass(lowerResult, null);
 
 			// SUT

--- a/Src/LexText/ParserCore/ParserWorker.cs
+++ b/Src/LexText/ParserCore/ParserWorker.cs
@@ -63,7 +63,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			switch (m_cache.LanguageProject.MorphologicalDataOA.ActiveParser)
 			{
 				case "XAmple":
-					m_parser = new XAmpleParser(cache, dataDir);
+					m_parser = new XAmpleParser(cache, dataDir, m_propertyTable);
 					agent = cache.ServiceLocator.GetInstance<ICmAgentRepository>().GetObject(CmAgentTags.kguidAgentXAmpleParser);
 					break;
 				case "HC":

--- a/Src/LexText/ParserCore/XAmpleParser.cs
+++ b/Src/LexText/ParserCore/XAmpleParser.cs
@@ -2,6 +2,12 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using SIL.FieldWorks.Common.FwUtils;
+using SIL.LCModel;
+using SIL.LCModel.DomainServices;
+using SIL.LCModel.Infrastructure;
+using SIL.ObjectModel;
+using SIL.Xml;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,12 +17,8 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
-using SIL.LCModel;
-using SIL.LCModel.DomainServices;
-using SIL.LCModel.Infrastructure;
-using SIL.ObjectModel;
-using SIL.Xml;
 using XAmpleManagedWrapper;
+using XCore;
 
 namespace SIL.FieldWorks.WordWorks.Parser
 {
@@ -25,6 +27,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		private static readonly char[] Digits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
 		private XAmpleWrapper m_xample;
+		private PropertyTable m_propTable;
 		private readonly string m_dataDir;
 		private readonly LcmCache m_cache;
 		private ParserModelChangeListener m_changeListener;
@@ -33,7 +36,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		private bool m_forceUpdate;
 		private XElement xampleAddonFileRoot;
 
-		public XAmpleParser(LcmCache cache, string dataDir)
+		public XAmpleParser(LcmCache cache, string dataDir, PropertyTable propertyTable)
 		{
 			m_cache = cache;
 			m_xample = new XAmpleWrapper();
@@ -43,6 +46,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 			m_database = ConvertNameToUseAnsiCharacters(m_cache.ProjectId.Name);
 			m_transformer = new M3ToXAmpleTransformer(m_database);
 			m_forceUpdate = true;
+			m_propTable = propertyTable;
 			InitXAmpleAddonDataInfo();
 		}
 		private void InitXAmpleAddonDataInfo()
@@ -58,7 +62,11 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					{
 						xampleAddonFileRoot = doc.Root;
 						var preparer = new XAmplePropertiesPreparer(m_cache, xampleAddonFileRoot, false);
-						preparer.AddListsAndFields();
+						if (!preparer.ListsAlreadyAdded())
+						{
+							preparer.AddListsAndFields();
+							FwUtils.Publisher.Publish(new PublisherParameterObject(EventConstants.ReloadAreaTools, "lists", m_propTable.GetWindow()));
+						}
 					}
 				}
 			}

--- a/Src/LexText/ParserCore/XAmplePropertiesPreparer.cs
+++ b/Src/LexText/ParserCore/XAmplePropertiesPreparer.cs
@@ -2,7 +2,6 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
-using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.DomainServices;
@@ -61,22 +60,13 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		public Boolean ListsAlreadyAdded()
 		{
 			var possListRepository = Cache.ServiceLocator.GetInstance<ICmPossibilityListRepository>();
-			var customList = possListRepository.AllInstances().FirstOrDefault(list => list.Name.BestAnalysisAlternative.Text == customListName);
-			if (customList != null)
-			{
-				return true;
-			}
-			return false;
+			return possListRepository.AllInstances().Any(list => list.Name.BestAnalysisAlternative.Text == customListName);
 		}
 
 		public Boolean XAmplePropertiesCustomFieldAlreadyAdded(string fieldName, int fieldClassId)
 		{
 			var customFields = GetListOfCustomFields();
-			if (customFields.Find(fd => fd.Name == fieldName) != null)
-			{
-				return true;
-			}
-			return false;
+			return customFields.Any(fd => fd.Name == fieldName && fd.Class == fieldClassId);
 		}
 
 		public void AddListsAndFields()

--- a/Src/LexText/ParserCore/XAmplePropertiesPreparer.cs
+++ b/Src/LexText/ParserCore/XAmplePropertiesPreparer.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the LGPL, version 2.1 or later
 // (http://www.gnu.org/licenses/lgpl-2.1.html)
 
+using SIL.FieldWorks.Common.FwUtils;
 using SIL.LCModel;
 using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.DomainServices;
@@ -10,8 +11,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using System.Collections;
 using System.Xml.XPath;
+using XCore;
 
 namespace SIL.FieldWorks.WordWorks.Parser
 {
@@ -57,13 +58,33 @@ namespace SIL.FieldWorks.WordWorks.Parser
 					select fd).ToList();
 		}
 
+		public Boolean ListsAlreadyAdded()
+		{
+			var possListRepository = Cache.ServiceLocator.GetInstance<ICmPossibilityListRepository>();
+			var customList = possListRepository.AllInstances().FirstOrDefault(list => list.Name.BestAnalysisAlternative.Text == customListName);
+			if (customList != null)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		public Boolean XAmplePropertiesCustomFieldAlreadyAdded(string fieldName, int fieldClassId)
+		{
+			var customFields = GetListOfCustomFields();
+			if (customFields.Find(fd => fd.Name == fieldName) != null)
+			{
+				return true;
+			}
+			return false;
+		}
+
 		public void AddListsAndFields()
 		{
 			if (Root == null)
 			{
 				return;
 			}
-
 			AddXAmplePropertiesList();
 			var customFields = GetListOfCustomFields();
 			AddXAmplePropertiesCustomField(entryCustomFieldName, LexEntryTags.kClassId);
@@ -75,8 +96,7 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		/// </summary>
 		public void AddXAmplePropertiesCustomField(string fieldName, int fieldClassId)
 		{
-			var customFields = GetListOfCustomFields();
-			if (customFields.Find(fd => fd.Name == fieldName) != null)
+			if (XAmplePropertiesCustomFieldAlreadyAdded(fieldName, fieldClassId))
 			{
 				// already done; quit
 				return;
@@ -117,22 +137,15 @@ namespace SIL.FieldWorks.WordWorks.Parser
 		/// </summary>
 		public void AddXAmplePropertiesList()
 		{
-			if (Root == null)
+			if (Root == null || ListsAlreadyAdded())
 			{
 				// nothing to do
-				return;
-			}
-			var possListRepository = Cache.ServiceLocator.GetInstance<ICmPossibilityListRepository>();
-			var customList = possListRepository.AllInstances().FirstOrDefault(list => list.Name.BestAnalysisAlternative.Text == customListName);
-			if (customList != null)
-			{
 				return;
 			}
 			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
 			{
 				int ws = WritingSystemServices.kwsAnal;
-				Cache.ServiceLocator.GetInstance<ICmPossibilityListFactory>().CreateUnowned(customListName, ws);
-				customList = possListRepository.AllInstances().Last();
+				var customList = Cache.ServiceLocator.GetInstance<ICmPossibilityListFactory>().CreateUnowned(customListName, ws);
 				var propPoss = Cache.ServiceLocator.GetInstance<ICmCustomItemFactory>();
 				ws = Cache.DefaultAnalWs;
 				var elements = Root.XPathSelectElements("CustomList/Contents/Element");

--- a/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
+++ b/Src/Utilities/pcpatrflex/ToneParsFLExDll/ToneParsFLExForm.cs
@@ -723,7 +723,8 @@ namespace SIL.ToneParsFLEx
 					Path.Combine(
 						FwDirectoryFinder.CodeDirectory,
 						FwDirectoryFinder.ksFlexFolderName
-					)
+					),
+					PropTable
 				);
 			}
 			return m_XAmpleParser.IsUpToDate();


### PR DESCRIPTION
Change-Id: I24735bad6cd9e8823a0a028151afdc64722d5a8e
Using XAmple with additional properties can cause a crash per what is in https://jira.sil.org/browse/LT-22708.
This fix has the XAmple parser send a refresh message just after the new list is added.  It does cause the Try a Word window to flash and then disappear while the main window also flashes but returns.

I do not know what is causing the Try a Word window to disappear although I suspect it may have to do with the parser running in a separate thread...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1122)
<!-- Reviewable:end -->
