### PR TITLE
Fix LT-22760

### DIFF
--- a/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
+++ b/Src/Utilities/AlloVarGen/AllomorphGeneratorDll/AlloGenFormBase.cs
@@ -862,44 +862,32 @@ namespace SIL.AllomorphGenerator
 		{
 			if (!File.Exists(OperationsFile))
 			{
-				if (String.IsNullOrEmpty(OperationsFile))
+				// probably first time it is run
+				var dlg = BuildCreateNewOpenCancelDialog();
+				var result = dlg.ShowDialog();
+				if (result == DialogResult.OK)
 				{
-					// probably first time it is run
-					var dlg = BuildCreateNewOpenCancelDialog();
-					var result = dlg.ShowDialog();
-					if (result == DialogResult.OK)
+					// create new operations file
+					ChangesMade = false;
+					SetupFontAndStyleInfo();
+					btnNewFile_Click(this, new EventArgs());
+					if (!String.IsNullOrEmpty(OperationsFile))
 					{
-						// create new operations file
-						ChangesMade = false;
-						SetupFontAndStyleInfo();
-						btnNewFile_Click(this, new EventArgs());
-						if (!String.IsNullOrEmpty(OperationsFile))
-						{
-							// Need to save it since it exists
-							DoSave();
-						}
+						// Need to save it since it exists
+						DoSave();
 					}
-					else if (result == DialogResult.Yes)
-					{
-						// Open existing operations file
-						btnBrowse_Click(this, new EventArgs());
-					}
-					else
-					{
-						// Assume it was canceled, so quit
-						this.Dispose();
-					}
+				}
+				else if (result == DialogResult.Yes)
+				{
+					// Open existing operations file
+					btnBrowse_Click(this, new EventArgs());
 				}
 				else
 				{
-					MessageBox.Show(
-						AllomorphGeneratorDll_Strings.ksOperationsFileNotFound,
-						AllomorphGeneratorDll_Strings.ksLoadError,
-						MessageBoxButtons.OK,
-						MessageBoxIcon.Error
-					);
+					// Assume it was canceled, so quit
+					this.Dispose();
 				}
-				return;
+			return;
 			}
 #if Marks
 			Provider.LoadDataFromFile(OperationsFile);


### PR DESCRIPTION
Change-Id: Ia24a6d7fc28fa18d6d8983e9f2fa44aedb89216a

The fix is to use the BuildCreateNewOpenCancelDialog whenever an operations file cannot be found.  Before we'd also check on the filename to see if it was null or empty before using this dialog.  There's no need for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1123)
<!-- Reviewable:end -->
