### PR TITLE
LT-22738: Change the default restore option for Send/Receive data

### DIFF
--- a/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
+++ b/Src/FwCoreDlgs/BackupRestore/RestoreProjectDlg.cs
@@ -265,6 +265,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			m_presenter.EmptyProjectName = false;
 			if (m_txtOtherProjectName.Enabled && m_txtOtherProjectName.Text == String.Empty)
 				m_txtOtherProjectName.Text = m_presenter.GetSuggestedNewProjectName();
+			UpdateSendReceiveDataOption();
 		}
 
 		private void m_btnBrowse_Click(object sender, EventArgs e)
@@ -372,8 +373,7 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 			m_supportingFiles.Enabled = settings.IncludeSupportingFiles;
 			m_spellCheckAdditions.Checked = settings.IncludeSpellCheckAdditions;
 			m_spellCheckAdditions.Enabled = settings.IncludeSpellCheckAdditions;
-			m_sendReceiveData.Checked = settings.IncludeSendReceiveData;
-			m_sendReceiveData.Enabled = settings.IncludeSendReceiveData;
+			UpdateSendReceiveDataOption();
 			if (m_rdoDefaultFolder.Checked)
 				m_lblDefaultBackupIncludes.Text = m_presenter.IncludesFiles(settings);
 			else
@@ -384,6 +384,22 @@ namespace SIL.FieldWorks.FwCoreDlgs.BackupRestore
 				m_lblOtherBackupIncludes.Text = m_presenter.IncludesFiles(settings);
 			}
 			SetOriginalNameFromSettings();
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the Send/Receive option from the restore target. Restoring over the original
+		/// project keeps that project's repository history, so the option is forced on;
+		/// restoring to a different name leaves it off unless the user opts in (LT-22738).
+		/// It is unavailable either way when the backup holds no Send/Receive data.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		private void UpdateSendReceiveDataOption()
+		{
+			var backupHasSendReceiveData = Settings.Backup != null && Settings.Backup.IncludeSendReceiveData;
+			var restoringToOriginalName = m_rdoUseOriginalName.Checked;
+			m_sendReceiveData.Checked = backupHasSendReceiveData && restoringToOriginalName;
+			m_sendReceiveData.Enabled = backupHasSendReceiveData && !restoringToOriginalName;
 		}
 
 


### PR DESCRIPTION
The Send/Receive checkbox in the restore dialog now follows the restore
target instead of the backup contents. Restoring over the original name
forces it on, because that project keeps its repository history, and
restoring to a different name leaves it unchecked until the user asks for it.
It stays unavailable when the backup holds no Send/Receive data.

### Why it needed changing

LT-22629 made the checkbox editable, but it still started checked whenever the
backup happened to contain S/R data, so the narrow expert scenario was the
default for everyone.

Simply defaulting it off would have been worse:
`RestoreProjectPresenter.IsOkayToRestoreProject` refuses to restore over a
project that is using Send/Receive when the option is off, and its message
gives no hint that ticking the box would let the restore through. Forcing the
option on for an original-name restore keeps that path working and confines
the choice to restores under a new name, which is the case the ticket is
about.

### Validation

- `.\build.ps1 -CommentHygiene` - clean.
- `.\test.ps1 -CommentHygiene -TestProject Src/FwCoreDlgs/FwCoreDlgsTests -TestFilter FullyQualifiedName~RestoreProjectPresenterTests` - 3 passed.
- The dialog itself has no automated coverage; checkbox states were verified
  by reading the code paths.

The backup-side default is untouched; that is LT-22783.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1125)
<!-- Reviewable:end -->
