### PR TITLE
Run as many tests as possible in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
         id: test
         shell: powershell
         run: |
-          .\test.ps1 -Configuration Debug -NoBuild -Coverage -TestFilter 'TestCategory!=LongRunning&TestCategory!=ByHand&TestCategory!=SmokeTest&TestCategory!=DesktopRequired'
+          .\test.ps1 -Configuration Debug -NoBuild -Coverage -TestFilter 'TestCategory!=DesktopRequired'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
to catch test failures before merging PRs. Previously, these tests had been saved for CD builds to save time, but those failures are too easy to ignore.

https://github.com/sillsdev/FieldWorks/actions/workflows/CI.yml completed in 14:09 for this PR, which is the third-shortest successful time in the last page runs (range 12:33-16:14), so we are saving next to no time by excluding "long-running" tests from CI builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1127)
<!-- Reviewable:end -->
