### PR TITLE
Suppress git worktree add progress that aborts the script under PS 5.1

### DIFF
--- a/scripts/Worktree-CreateFromBranch.ps1
+++ b/scripts/Worktree-CreateFromBranch.ps1
@@ -380,17 +380,20 @@ else {
 		$targetWorktreePath = $desiredPath
 	}
 	else {
+		# --quiet suppresses the progress git writes to stderr, which PowerShell 5.1
+		# turns into a terminating error under $ErrorActionPreference = "Stop"
+		# even though git exited 0.
 		if ($hasLocal) {
 			Write-Host "Creating worktree at $desiredPath for existing local branch '$branch'..."
-			& git -C $mainRepoRoot worktree add $desiredPath $branch
+			& git -C $mainRepoRoot worktree add --quiet $desiredPath $branch
 		}
 		elseif ($hasRemote) {
 			Write-Host "Creating worktree at $desiredPath for remote branch 'origin/$branch'..."
-			& git -C $mainRepoRoot worktree add -b $branch $desiredPath "origin/$branch"
+			& git -C $mainRepoRoot worktree add --quiet -b $branch $desiredPath "origin/$branch"
 		}
 		else {
 			Write-Host "Branch '$branch' not found; creating new branch and worktree at $desiredPath..."
-			& git -C $mainRepoRoot worktree add -b $branch $desiredPath
+			& git -C $mainRepoRoot worktree add --quiet -b $branch $desiredPath
 		}
 
 		if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
`Worktree-CreateFromBranch.ps1` aborts partway through, leaving a worktree created but never colorized or opened:

```
git.exe : Updating files:  17% (996/5711)
At scripts\Worktree-CreateFromBranch.ps1:385 char:4
+             & git -C $mainRepoRoot worktree add $desiredPath $branch
    + FullyQualifiedErrorId : NativeCommandError
```

git writes checkout progress to stderr and exits 0. Under Windows PowerShell 5.1 with `$ErrorActionPreference = "Stop"`, that stderr becomes a terminating error, so the script dies after the worktree exists but before `Setup-WorktreeColor.ps1` runs. It only bites when the checkout is large enough for git to print progress, which is why it comes and goes.

`--quiet` on the three `worktree add` calls removes the stderr at its source. That is this repo's existing answer to the same problem — `Build/Agent/comment-hygiene.ps1:89` says so in as many words. Real failures still fail: the `$LASTEXITCODE` check is untouched, and `worktree add --quiet` for an already-checked-out branch still exits 128 and throws.

## Verified

- **Windows PowerShell 5.1** (5.1.19041.6456): the full script end to end, through colorization and the VS Code launch. A/B against the pre-fix script under the same harness — pre-fix threw and produced no workspace file, post-fix completed.
- Failure path: exit 128, friendly throw, no directory created.
- `comment-hygiene.ps1`: clean.
- **PowerShell 7 was not run. It is not installed on this machine.** PSScriptAnalyzer's `PSUseCompatibleSyntax` against 5.1 and 7.0 is clean, but that is a static check only. `--quiet` is a git-side flag and carries no PowerShell-version semantics either way.

## Deliberately not here

Six other sites in this script use `git ... 2>$null`, which **causes** this failure rather than preventing it: any explicit stderr redirection makes PowerShell 5.1 consume stderr as ErrorRecords. `Get-RepoRoot "C:\Windows"` throws `NativeCommandError` instead of its intended message, so the friendly `throw` is unreachable. They only fire in states this script does not normally reach, and fixing them well wants a shared helper, so they belong in their own change. The same idiom bit `Build/Agent/check-whitespace.ps1:18` and `comment-hygiene.ps1:107` on the day this was found.

`Build/Agent/powershell-compat.ps1` globs `Build/Agent` only, so `scripts/` has never been covered by that gate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1131)
<!-- Reviewable:end -->
