### PR TITLE
LT-22443: Stop CloseRootBox removing a PropChanged registration

### DIFF
--- a/Src/Common/SimpleRootSite/SimpleRootSite.cs
+++ b/Src/Common/SimpleRootSite/SimpleRootSite.cs
@@ -5335,20 +5335,8 @@ namespace SIL.FieldWorks.Common.RootSites
 			if (DesignMode || m_rootb == null)
 				return;
 
-			// Ensure we no longer receive PropChanged notifications after disposal.
-			// In some test scenarios (and occasionally during shutdown), notifications can arrive
-			// after the control has been disposed unless we explicitly unregister.
-			try
-			{
-				var notifyChange = this as IVwNotifyChange;
-				if (notifyChange != null)
-					(m_rootb.DataAccess as ISilDataAccess)?.RemoveNotification(notifyChange);
-			}
-			catch
-			{
-				// Best-effort: shutdown paths can be fragile and we don't want to throw during Dispose.
-			}
-
+			// Whoever calls AddNotification removes it. This method never adds one, and it also
+			// runs while the site is still alive, so removing one here deafens a live view.
 			if (m_Timer != null)
 				m_Timer.Stop();
 			// Can't flash IP, if the root box is toast.


### PR DESCRIPTION
Choosing texts in **Texts & Words -> Interlinear Texts** updates the list again
after you have visited another tool. The change deletes one call: the
`RemoveNotification` that #678 added to `SimpleRootSite.CloseRootBox`.

`CloseRootBox` never *adds* a PropChanged registration, so that call could only
ever remove one made by a subclass -- and every subclass in the tree already
removes its own in `Dispose`. It also runs while the site is still alive (handle
recreation, and a `RootSite` closing its slaves), so it could deafen a live
view. `InterestingTextsDecorator` and `ConcDecorator` count notifiees and detach
the shared `InterestingTextList` when the count hits zero; the double removal
drove that count to -1 on every tool switch, and nothing re-attached the list.

The question worth your time is not whether deleting the call is safe in
isolation. It is whether this is the right layer to fix it at.

**Where to look**

- `SimpleRootSite.cs` -- delete the call, or instead harden the two decorators
  to count distinct registrants? Argued in *Decisions*.
- Nothing relied on the call: all ~35 `AddNotification(this)` sites in `Src/`
  pair with a `RemoveNotification(this)` in the same class. See *Evidence*.
- #678's comment cites "some test scenarios" without naming one, and no test in
  the tree exercises it. If you know the real case, please say.
- Two tickets verified fixed, four more suspected on the same mechanism but
  never reproduced -- a second opinion on the blast radius is welcome.
  Separated out in *Evidence*.

**Deliberately not here**

- `ClearInterestingTextsList` and its `ConcDecorator` caller -- compensation for
  this bug, confirmed dead at runtime once the count is right, but LT-22508 is
  Closed with tester sign-off so removing it should follow a QA pass. Follow-up.
- No automated regression test. Asserting the invariant needs a real
  `IVwRootBox`, so COM plus an STA fixture; verified in the live app instead.

**Verification** -- clean `build.ps1 -CommentHygiene -TokenHygiene`, then seven
suites green: SimpleRootSite 115/115, RootSite 99, XMLViews 114/114, ITextDll
210, xWorks 1600, Widgets 19/19, DetailControls 119. An instrumented run on
Sena 3 confirms the notifiee count now stops at 1 and LT-22508's symptoms are
gone. LT-22508's own attached backups were not replayed.

---

<details>
<summary><b>Reading this a year from now</b> -- start here</summary>

This branch has no design document, and never did: the reasoning was developed
by instrumenting the running application and reading the notification
bookkeeping, so the record lives here rather than in the tree.

The one thing to carry forward: **in this repository, whoever calls
`AddNotification` is the one who calls `RemoveNotification`.** That is not
written down anywhere as a rule, but every one of the ~35 registration sites
follows it. `CloseRootBox` was the sole exception, and it cost six tickets. If
you are tempted to add a defensive `RemoveNotification` "just in case", this is
the PR that says don't.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

**Fix `SimpleRootSite`, not the decorators.** The alternative was to make
`InterestingTextsDecorator` and `ConcDecorator` track a set of registered
notifiees, so `m_notifieeCount` could not be corrupted by a redundant removal.
That is genuinely more robust -- it enforces the invariant those decorators
depend on instead of trusting callers -- and it was rejected anyway, for two
reasons. It leaves the actual defect in place, where it will keep deafening
live views on any SDA that is not one of these two. And it is a behavioural
change to two shared decorators in service of a regression whose cause is one
redundant line. The restored convention carries the invariant; if a future
stray removal proves the convention is not enough, the set is the next step,
not this one.

**Land this before removing the compensations.** `ClearInterestingTextsList`
(LT-22508) and the re-query cache clear in `EnsureInterestingTextsSubscription`
(LT-22396) both exist to paper over the premature teardown. Removing them in
the same PR would have made the diff read as a refactor and put a Closed,
signed-off ticket at risk in the same change that fixes an open one.

**Keep a comment in place of the deleted code.** The two lines left behind say
why the removal must not come back. Without them the next person reads a method
that plausibly ought to unregister, and re-adds the call.

</details>

<details>
<summary><b>Paths not taken</b></summary>

- **Hardening the decorators to count distinct registrants** -- see
  *Decisions*. Still the right follow-up if the convention proves insufficient.
- **Keeping the call but guarding it** (remove only when this instance
  registered) -- that is the set-tracking fix wearing a disguise, and it puts
  the bookkeeping in a base class that has no business owning it.
- **Reverting #678's hunk verbatim, comment and all** -- rejected because the
  original comment asserts a rationale ("notifications can arrive after the
  control has been disposed") that holds for no subclass in the tree; keeping
  it would preserve the misleading claim.
- **Fixing it in `XmlBrowseViewBase` instead**, by not removing in `Dispose`
  and letting `CloseRootBox` be the single remover -- rejected: it inverts the
  repo-wide convention for one class, and `CloseRootBox` runs on live controls.

</details>

<details>
<summary><b>Surprising findings</b></summary>

**The reported acceptance test already passed before this change.** LT-22443's
steps (Interlinear Texts -> Choose Texts -> Statistics -> back -> Choose Texts)
update correctly on current `main`. LT-22396 added a cache clear on every
re-query, which masks the symptom: `GetObjectSet()` recomputes even when the
decorator has gone deaf. So the ticket's own repro no longer demonstrates the
bug, and the count going negative is the thing that actually needed fixing.
Anyone re-testing LT-22443 by its written steps will see it pass either way.

**`CloseRootBox` is not a teardown-only path.** `OnHandleDestroyed` calls it,
and WinForms destroys handles on *recreation*. The comment already in that
method says as much -- "if we always do it, we break switching fields in DE
views, and anywhere else a root box is shared" -- which is exactly the hazard
#678's line walked into.

**The count did not merely reach zero; it went negative,** one per round trip.
So even the `m_notifieeCount <= 0` guard could not have saved it: after enough
switches the count never climbs back above zero.

</details>

<details>
<summary><b>Evidence</b></summary>

**Every registrant unregisters itself.** Rootsite subclasses that implement
`IVwNotifyChange`, add/remove pairs verified in each: `InnerFwTextBox` (3/3),
`InnerFwListBox`, `XmlBrowseViewBase`, `OneColumnXmlBrowseView`,
`MSADlglauncherView`, `PhonologicalFeatureListDlgLauncherView`,
`ReversalIndexEntrySliceView`, and `InterlinDocRootSiteBase` (removal in its
Designer partial). `SimpleRootSite` and `RootSite` contain no
`AddNotification(this)` at all, so the deleted call was never cleaning up after
itself.

The three launchers that register on an inner view's `RootBox.DataAccess`
(`PossibilityAtomicReferenceLauncher`, `PossibilityVectorReferenceLauncher`,
`LabeledMultiStringControl`) pass `this` -- the launcher, not the rootsite -- so
`CloseRootBox` never removed them, before or after. All three do unregister.

**Counts, from the instrumented run on Sena 3.** Leaving Interlinear Texts,
before: `3 -> 2 -> 1 -> 0 -> -1`, plus
`base.RemoveNotification(m_interestingTexts)`. After: `3 -> 2 -> 1`. Leaving
Concordance, `ConcDecorator` after: `3 -> 2 -> 1`, and
`ClearInterestingTextsList` never fires. The doubled remover is the same
`XmlBrowseView` instance twice, once from its own `Dispose` and once from
`CloseRootBox`.

**The list stays attached.** After an Interlinear -> Concordance -> Interlinear
round trip, inserting a text delivered `PropChanged`
(`TextTags.kflidContents`, ins=1) to the *same* `InterestingTextList` instance,
and the new text appeared immediately (4 -> 5). Undoing it left no blank row and
no "Deleted object detected". Those are LT-22508's symptoms 1 and 3.

**The ticket cluster -- two verified, four suspected.** Reproduced and
confirmed fixed: LT-22443 (this one), and LT-22508 (labelled `regression`),
whose symptoms 1 and 3 were exercised directly. Suspected on mechanism alone
and never reproduced: LT-22580, LT-22620, LT-22694, LT-21629. All four describe
new or imported texts disappearing, or deselected scripture persisting, and all
were filed after #678 landed on 2026-02-17 -- but treat them as a hypothesis
worth retesting, not as fixed by this PR.

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1132)
<!-- Reviewable:end -->
