### PR TITLE
LT-22691: Menus for reference-vector rows in the Avalonia detail view

### DIFF
--- a/Src/Common/FwAvalonia/AvaloniaHostControlBase.cs
+++ b/Src/Common/FwAvalonia/AvaloniaHostControlBase.cs
@@ -133,9 +133,36 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 		///                         False: Open under the anchor control.</param>
 		public void ShowContextMenu(IReadOnlyList<DetailMenuItem> items,
 			Avalonia.Controls.Control anchor, bool atPointer)
+			=> ShowContextMenu(items, anchor, atPointer, null);
+
+		/// <summary>
+		/// Shows a context menu and reports when it has closed.
+		/// </summary>
+		/// <param name="items">The menu items; null or empty shows nothing.</param>
+		/// <param name="anchor">The control to anchor the menu to.</param>
+		/// <param name="atPointer">True: Open at the pointer location.
+		///                         False: Open under the anchor control.</param>
+		/// <param name="closed">Invoked once the menu closes, or at once when nothing could be
+		/// shown; null for no notification.</param>
+		public void ShowContextMenu(IReadOnlyList<DetailMenuItem> items,
+			Avalonia.Controls.Control anchor, bool atPointer, Action closed)
 		{
 			var target = anchor ?? Host.Content as Avalonia.Controls.Control;
-			DetailMenuFlyout.Show(items, target, atPointer);
+			var flyout = DetailMenuFlyout.Show(items, target, atPointer);
+			if (closed == null)
+				return;
+			if (flyout == null)
+			{
+				closed();
+				return;
+			}
+			EventHandler onClosed = null;
+			onClosed = (s, e) =>
+			{
+				flyout.Closed -= onClosed;
+				closed();
+			};
+			flyout.Closed += onClosed;
 		}
 
 		public void ShowMessage(string message)

--- a/Src/Common/FwAvalonia/Detail/DataTree.cs
+++ b/Src/Common/FwAvalonia/Detail/DataTree.cs
@@ -54,6 +54,26 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		private readonly Action<string, bool> _expansionChanged;
 		private readonly Action<DetailMenuRequest> _menuRequested;
 		private readonly Action<DetailLinkRequest> _linkRequested;
+		// The vector rows of the shown fields, and the one whose item is current (at most one
+		// per view), so re-show continuity can read and restore that selection cheaply.
+		private readonly List<FwReferenceVectorField> _vectors = new List<FwReferenceVectorField>();
+
+		/// <summary>The reference-vector row that has a current item; null when none
+		/// does.</summary>
+		internal FwReferenceVectorField SelectedVector { get; private set; }
+
+		/// <summary>The reference-vector rows of the shown fields.</summary>
+		internal IReadOnlyList<FwReferenceVectorField> VectorRows => _vectors;
+
+		/// <summary>True when the rebuild that follows should give keyboard focus to the vector
+		/// row's current item.</summary>
+		internal bool VectorFocusRequested { get; private set; }
+
+		/// <summary>
+		/// Asks the rebuild that follows to give keyboard focus to the vector row's current item,
+		/// for a gesture (a menu-driven move) made while no editor had focus.
+		/// </summary>
+		public void RequestVectorFocusOnRebuild() => VectorFocusRequested = true;
 		private readonly IFwClipboard _clipboard;
 
 		// Computed once per view (not per field/row) from the widest WS abbreviation across the
@@ -299,6 +319,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		private void RebuildItems()
 		{
 			_form.Items.Clear();
+			_vectors.Clear();
+			SelectedVector = null;
 			var visible = DetailVisibility.ComputeVisibility(Model.Fields, GetRecordedExpansion);
 			for (var i = 0; i < Model.Fields.Count; i++)
 			{
@@ -488,12 +510,18 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			AutomationProperties.SetAutomationId(labelBlock, automationId + ".Label");
 			AutomationProperties.SetName(labelBlock, field.Label ?? field.Field ?? string.Empty);
 			ToolTip.SetTip(labelBlock, field.Label ?? field.Field); // 11.17: legacy label tooltips
-			// 13.3: the field's slice menu opens from a right-click on the label cell
-			// or from the hover "..." button in the left gutter.
-			var labelCell = WrapWithFieldMenu(labelBlock, field, automationId, out var labelKebab);
-
 			var editor = CreateEditor(field, automationId);
 			editor.Margin = new Thickness(0, 0, 0, FwAvaloniaDensity.FieldSpacing);
+			if (editor is FwReferenceVectorField vector)
+			{
+				_vectors.Add(vector);
+				vector.SelectionChanged += OnVectorSelectionChanged;
+			}
+
+			// 13.3: the field's slice menu opens from the label cell's right-click or the
+			// gutter "..." button; the editor's current item rides each request it raises.
+			var labelCell = WrapWithFieldMenu(labelBlock, field, automationId, out var labelKebab,
+				editor as IDetailItemSelection);
 
 			// Hover-reveal: the WHOLE row (label cell + editor) is the hover/focus
 			// surface for the field-options "..." and any editor affordance (chooser
@@ -507,6 +535,24 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			return new FieldContent { Content = editor, Label = labelCell };
 		}
 
+		// One current item per view: selecting in one vector row clears every other row's, so
+		// the item-relative commands always have a single target.
+		private void OnVectorSelectionChanged(object sender, EventArgs e)
+		{
+			if (!(sender is FwReferenceVectorField source))
+				return;
+			if (source.SelectedItemIndex < 0)
+			{
+				if (ReferenceEquals(SelectedVector, source))
+					SelectedVector = null;
+				return;
+			}
+			var previous = SelectedVector;
+			SelectedVector = source;
+			if (previous != null && !ReferenceEquals(previous, source))
+				previous.ClearSelection();
+		}
+
 		// The width of the left gutter holding the per-row field-options "..." button.
 		// Reserved on every row (when a host bridge is present) so labels align whether
 		// or not a row has a menu.
@@ -515,7 +561,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		// The label cell answers context-menu requests with the row's slice menu; the
 		// kebab opens its own menu or hotlinks. With no host bridge, content is unwrapped.
 		private Control WrapWithFieldMenu(Control inner, DetailField field, string automationId,
-			out Control kebab)
+			out Control kebab, IDetailItemSelection selection = null)
 		{
 			kebab = null;
 			if (_menuRequested == null)
@@ -546,7 +592,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 				{
 					// No pointer position is available here, so the menu drops from the
 					// icon rather than from wherever the mouse sits.
-					_menuRequested(DetailMenuRequest.FromAnchor(button, field, kind));
+					_menuRequested(DetailMenuRequest.FromAnchor(button, field, kind, selection));
 				};
 				rail.Child = button;
 				kebab = button;
@@ -556,19 +602,21 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			DockPanel.SetDock(rail, Dock.Left);
 			wrapper.Children.Add(rail);
 			wrapper.Children.Add(inner); // fills the width remaining after the gutter
-			WireLabelContextMenu(wrapper, field);
+			WireLabelContextMenu(wrapper, field, selection);
 			return wrapper;
 		}
 
 		/// <summary>
-		/// Wires up the Label context menu for a slice.
+		/// Wires up the Label context menu for a slice; the request carries the row editor's
+		/// current item when it keeps one.
 		/// </summary>
-		private void WireLabelContextMenu(Control cell, DetailField field)
+		private void WireLabelContextMenu(Control cell, DetailField field,
+			IDetailItemSelection selection)
 		{
 			cell.AddHandler(Control.ContextRequestedEvent, (s, e) =>
 			{
 				_menuRequested(DetailMenuRequest.FromContextRequested(cell, e, field,
-					DetailMenuKind.SliceMenu));
+					DetailMenuKind.SliceMenu, selection));
 				e.Handled = true;
 			}, Avalonia.Interactivity.RoutingStrategies.Bubble);
 		}

--- a/Src/Common/FwAvalonia/Detail/DetailFocusMemory.cs
+++ b/Src/Common/FwAvalonia/Detail/DetailFocusMemory.cs
@@ -22,19 +22,46 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 	/// </summary>
 	public static class DetailFocusMemory
 	{
-		/// <summary>What to restore: the focused editor's automation id/caret and the detail view scroll offset.</summary>
+		/// <summary>
+		/// What to restore: the focused editor's automation id/caret, the detail view scroll
+		/// offset, and the current item of a reference-vector row.
+		/// </summary>
 		public sealed class Memento
 		{
-			public Memento(string automationId, int caretIndex, double verticalOffset = 0)
+			public Memento(string automationId, int caretIndex, double verticalOffset = 0,
+				string vectorAutomationId = null, string vectorItemKey = null, int vectorItemIndex = -1,
+				bool focusVectorItem = false)
 			{
 				AutomationId = automationId;
 				CaretIndex = caretIndex;
 				VerticalOffset = verticalOffset;
+				VectorAutomationId = vectorAutomationId;
+				VectorItemKey = vectorItemKey;
+				VectorItemIndex = vectorItemIndex;
+				FocusVectorItem = focusVectorItem;
 			}
+
+			/// <summary>
+			/// True when the outgoing view asked for the vector row's current item to take
+			/// keyboard focus after the rebuild (a gesture made from a menu, with no editor
+			/// focused). A remembered focus on one of that row's items asks for the same.
+			/// </summary>
+			public bool FocusVectorItem { get; }
 
 			public string AutomationId { get; }
 			public int CaretIndex { get; }
 			public double VerticalOffset { get; }
+
+			/// <summary>The automation id of the reference-vector row that had a current item;
+			/// null when none did.</summary>
+			public string VectorAutomationId { get; }
+
+			/// <summary>The option key of that row's current item.</summary>
+			public string VectorItemKey { get; }
+
+			/// <summary>The index of that item, the fallback when no item has its key; -1 when
+			/// none.</summary>
+			public int VectorItemIndex { get; }
 		}
 
 		/// <summary>
@@ -49,9 +76,18 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 				return null;
 			var scroller = FindScroller(root);
 			var verticalOffset = scroller?.Offset.Y ?? 0;
+			// A reference-vector row's current item survives the rebuild too, so a move made
+			// from a menu (no focused editor) leaves the moved item current.
+			var tree = root as DataTree;
+			var selectedVector = tree?.SelectedVector ?? FindSelectedVector(root);
+			var vectorId = selectedVector == null ? null : AutomationProperties.GetAutomationId(selectedVector);
+			var vectorKey = selectedVector?.SelectedItemKey;
+			var vectorIndex = selectedVector?.SelectedItemIndex ?? -1;
+			var focusVector = tree?.VectorFocusRequested ?? false;
+
 			var focusManager = TopLevel.GetTopLevel(root)?.FocusManager;
 			if (!(focusManager?.GetFocusedElement() is Control focused) || !root.IsVisualAncestorOf(focused))
-				return new Memento(null, -1, verticalOffset);
+				return new Memento(null, -1, verticalOffset, vectorId, vectorKey, vectorIndex, focusVector);
 
 			// The editor itself carries the stable id (e.g. "LexemeFormEditor.vern"); walk up in
 			// case focus landed on an inner template part.
@@ -59,10 +95,93 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			{
 				var id = AutomationProperties.GetAutomationId(control);
 				if (!string.IsNullOrEmpty(id))
-					return new Memento(id, (focused as TextBox)?.CaretIndex ?? -1, verticalOffset);
+				{
+					return new Memento(id, (focused as TextBox)?.CaretIndex ?? -1, verticalOffset,
+						vectorId, vectorKey, vectorIndex, focusVector);
+				}
 			}
 
-			return new Memento(null, -1, verticalOffset);
+			return new Memento(null, -1, verticalOffset, vectorId, vectorKey, vectorIndex, focusVector);
+		}
+
+		// Whether the rebuilt view should focus the vector row's current item: the outgoing view
+		// asked for it, or the remembered focused control was one of that row's items.
+		private static bool WantsVectorFocus(Memento memento)
+		{
+			if (memento.FocusVectorItem)
+				return true;
+			return FwReferenceVectorField.IsItemAutomationId(memento.VectorAutomationId, memento.AutomationId);
+		}
+
+		/// <summary>
+		/// Clears keyboard focus when it sits inside <paramref name="root"/>, so replacing the
+		/// view detaches no focused element and the swap carries no focus-change side effects
+		/// into the new view. Capture first: this forgets which editor had focus.
+		/// </summary>
+		public static void ReleaseFocus(Control root)
+		{
+			if (root == null)
+				return;
+			var focusManager = TopLevel.GetTopLevel(root)?.FocusManager;
+			if (focusManager?.GetFocusedElement() is Control focused && root.IsVisualAncestorOf(focused))
+				focusManager.ClearFocus();
+		}
+
+		// The visual-tree fallback for a root that is not a DataTree.
+		private static FwReferenceVectorField FindSelectedVector(Control root)
+		{
+			foreach (var visual in root.GetVisualDescendants())
+			{
+				if (visual is FwReferenceVectorField vector && vector.SelectedItemKey != null)
+					return vector;
+			}
+			return null;
+		}
+
+		private static FwReferenceVectorField FindVector(Control root, string automationId)
+		{
+			var rows = (root as DataTree)?.VectorRows;
+			if (rows != null)
+			{
+				foreach (var row in rows)
+				{
+					if (AutomationProperties.GetAutomationId(row) == automationId)
+						return row;
+				}
+				return null;
+			}
+			foreach (var visual in root.GetVisualDescendants())
+			{
+				if (visual is FwReferenceVectorField vector
+					&& AutomationProperties.GetAutomationId(vector) == automationId)
+				{
+					return vector;
+				}
+			}
+			return null;
+		}
+
+		/// <summary>
+		/// Makes the memento's vector item current again in the row with the same automation id,
+		/// or, when no item has that key, the item now at its index. Returns false when the
+		/// memento carries none or the row is not shown or is empty.
+		/// </summary>
+		public static bool TryRestoreVectorSelection(Control root, Memento memento)
+			=> RestoreVectorSelection(root, memento) != null;
+
+		// The row whose selection was restored, or null.
+		private static FwReferenceVectorField RestoreVectorSelection(Control root, Memento memento)
+		{
+			if (root == null || string.IsNullOrEmpty(memento?.VectorAutomationId))
+				return null;
+			var vector = FindVector(root, memento.VectorAutomationId);
+			if (vector == null)
+				return null;
+			if (vector.SelectItem(memento.VectorItemKey))
+				return vector;
+			return memento.VectorItemIndex >= 0 && vector.SelectItemAt(memento.VectorItemIndex)
+				? vector
+				: null;
 		}
 
 		/// <summary>
@@ -79,6 +198,48 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 				return false;
 			scroller.Offset = new Vector(scroller.Offset.X, memento.VerticalOffset);
 			return true;
+		}
+
+		// How many layout passes the restore waits for the scroller to measure before giving
+		// up on the offset, so the handler never outlives a view that never shows content.
+		private const int MaxLayoutPassesToWait = 10;
+
+		/// <summary>
+		/// Restores the memento once the incoming view has laid out: the scroll offset first (an
+		/// offset set before layout is clamped to zero by the still-empty extent), then the
+		/// vector row's current item, then focus -- the remembered editor, or else that current
+		/// item when the memento asks for it, so a move or removal made from the row keeps the
+		/// keyboard in the row. Safe to call before the view is attached.
+		/// </summary>
+		public static void RestoreAfterLayout(Control root, Memento memento)
+		{
+			if (root == null || memento == null)
+				return;
+			// Wait for the first layout pass: rows join the visual tree only when the form
+			// templates, and the offset only takes once the scroller has measured its content.
+			var scroller = FindScroller(root);
+			var needsScroll = scroller != null && memento.VerticalOffset > 0;
+			var passes = 0;
+			EventHandler onLayout = null;
+			onLayout = (s, e) =>
+			{
+				if (needsScroll && scroller.Extent.Height <= 0 && ++passes < MaxLayoutPassesToWait)
+					return;
+				root.LayoutUpdated -= onLayout;
+				if (needsScroll)
+					TryRestoreScroll(root, memento);
+				var vector = RestoreVectorSelection(root, memento);
+				if (!TryRestoreFocus(root, memento) && vector != null && WantsVectorFocus(memento))
+					vector.FocusItemAt(vector.SelectedItemIndex);
+				// A bring-into-view request queued by a focus change is applied by the next
+				// arrange; the remembered offset is re-asserted after it.
+				if (needsScroll)
+				{
+					Avalonia.Threading.Dispatcher.UIThread.Post(() => TryRestoreScroll(root, memento),
+						Avalonia.Threading.DispatcherPriority.Background);
+				}
+			};
+			root.LayoutUpdated += onLayout;
 		}
 
 		/// <summary>
@@ -182,7 +343,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		{
 			var restoredScroll = TryRestoreScroll(root, memento);
 			var restoredFocus = TryRestoreFocus(root, memento);
-			return restoredScroll || restoredFocus;
+			var restoredSelection = TryRestoreVectorSelection(root, memento);
+			return restoredScroll || restoredFocus || restoredSelection;
 		}
 
 		private static ScrollViewer FindScroller(Control root)

--- a/Src/Common/FwAvalonia/Detail/DetailModel.cs
+++ b/Src/Common/FwAvalonia/Detail/DetailModel.cs
@@ -1512,8 +1512,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			Func<Control> controlFactory = null,
 			Func<string, IReadOnlyList<DetailChoiceOption>> searchOptions = null,
 			IReadOnlyList<DetailChooserLink> chooserLinks = null,
-			IReadOnlyList<DetailParagraph> paragraphs = null)
+			IReadOnlyList<DetailParagraph> paragraphs = null,
+			bool canReorderItems = false)
 		{
+			CanReorderItems = canReorderItems;
 			Paragraphs = paragraphs ?? Array.Empty<DetailParagraph>();
 			ChooserLinks = chooserLinks ?? new List<DetailChooserLink>();
 			Items = items ?? new List<DetailChoiceOption>();
@@ -1566,6 +1568,13 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// (key = possibility guid, name = display name). Empty for other kinds.
 		/// </summary>
 		public IReadOnlyList<DetailChoiceOption> Items { get; }
+
+		/// <summary>
+		/// Whether the user may reorder <see cref="Items"/> (Move Left / Move Right): a real
+		/// reference sequence, or a virtual one whose layout allows reordering. False for other
+		/// kinds.
+		/// </summary>
+		public bool CanReorderItems { get; }
 
 		/// <summary>False for display-only fields (e.g. reference fields without chooser write-back yet).</summary>
 		public bool IsEditable { get; }
@@ -1707,6 +1716,19 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		public IReadOnlyList<DetailChooserLink> ChooserLinks { get; }
 	}
 
+	/// <summary>
+	/// A field editor that keeps one of its items current (a reference vector's selected
+	/// entry). Menu requests read it so item-relative commands know which item they act on.
+	/// </summary>
+	public interface IDetailItemSelection
+	{
+		/// <summary>The option key of the current item; null when no item is selected.</summary>
+		string SelectedItemKey { get; }
+
+		/// <summary>The index of the current item in the field's Items; -1 when none.</summary>
+		int SelectedItemIndex { get; }
+	}
+
 	/// <summary>Which configured menu a context-menu request maps to.</summary>
 	public enum DetailMenuKind
 	{
@@ -1717,7 +1739,13 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		ContextMenu,
 
 		/// <summary>The section hotlinks commands.</summary>
-		Hotlinks
+		Hotlinks,
+
+		/// <summary>
+		/// The per-item menu of a reference-vector row, opened on one of its items; the request's
+		/// selected item is the item under the pointer.
+		/// </summary>
+		ItemMenu
 	}
 
 	/// <summary>
@@ -1732,13 +1760,29 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 	public sealed class DetailMenuRequest
 	{
 		private DetailMenuRequest(DetailField field, DetailMenuKind kind, Control anchorControl,
-			bool openAtPointer)
+			bool openAtPointer, IDetailItemSelection selection, bool isDefaultActivation = false)
 		{
 			Field = field;
 			Kind = kind;
 			AnchorControl = anchorControl;
 			OpenAtPointer = openAtPointer;
+			SelectedItemKey = selection?.SelectedItemKey;
+			SelectedItemIndex = selection?.SelectedItemIndex ?? -1;
+			IsDefaultActivation = isDefaultActivation;
 		}
+
+		/// <summary>
+		/// The request for an item's default activation (Ctrl+click on a reference-vector
+		/// item): the host runs the item menu's first enabled jump command instead of showing
+		/// the menu.
+		/// </summary>
+		/// <param name="anchor">The item that was activated.</param>
+		/// <param name="field">The row the item belongs to.</param>
+		/// <param name="selection">The row editor's current item (the activated one).</param>
+		public static DetailMenuRequest FromDefaultActivation(Control anchor, DetailField field,
+			IDetailItemSelection selection)
+			=> new DetailMenuRequest(field, DetailMenuKind.ItemMenu, anchor, openAtPointer: false,
+				selection, isDefaultActivation: true);
 
 		/// <summary>
 		/// The request for a ContextRequested event: a right-click opens at the pointer, while
@@ -1748,9 +1792,12 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// <param name="e">Read only for whether it carries a pointer position.</param>
 		/// <param name="field">The row the menu acts on.</param>
 		/// <param name="kind">Which configured menu the request maps to.</param>
+		/// <param name="selection">The row editor's current item, when it keeps one.</param>
 		public static DetailMenuRequest FromContextRequested(Control surface,
-			ContextRequestedEventArgs e, DetailField field, DetailMenuKind kind)
-			=> new DetailMenuRequest(field, kind, surface, e.TryGetPosition(surface, out _));
+			ContextRequestedEventArgs e, DetailField field, DetailMenuKind kind,
+			IDetailItemSelection selection = null)
+			=> new DetailMenuRequest(field, kind, surface, e.TryGetPosition(surface, out _),
+				selection);
 
 		/// <summary>
 		/// The request for a pointer-less activation -- a button's mouse or keyboard Click, which
@@ -1759,12 +1806,30 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// <param name="anchor">The control to drop the menu from.</param>
 		/// <param name="field">The row the menu acts on.</param>
 		/// <param name="kind">Which configured menu the activation maps to.</param>
+		/// <param name="selection">The row editor's current item, when it keeps one.</param>
 		public static DetailMenuRequest FromAnchor(Control anchor, DetailField field,
-			DetailMenuKind kind)
-			=> new DetailMenuRequest(field, kind, anchor, openAtPointer: false);
+			DetailMenuKind kind, IDetailItemSelection selection = null)
+			=> new DetailMenuRequest(field, kind, anchor, openAtPointer: false, selection);
 
 		public DetailField Field { get; }
 		public DetailMenuKind Kind { get; }
+
+		/// <summary>
+		/// The option key of the row's current item at request time (a reference vector's
+		/// selected entry); null when the row has none. Item-relative commands such as
+		/// Move Left / Move Right act on it.
+		/// </summary>
+		public string SelectedItemKey { get; }
+
+		/// <summary>The index of <see cref="SelectedItemKey"/> in the field's Items; -1 when
+		/// none.</summary>
+		public int SelectedItemIndex { get; }
+
+		/// <summary>
+		/// True for a Ctrl+click on an item: the host runs the item menu's default command
+		/// (its first enabled jump) rather than showing the menu.
+		/// </summary>
+		public bool IsDefaultActivation { get; }
 
 		/// <summary>
 		/// The control the request came from; the menu anchors under it when

--- a/Src/Common/FwAvalonia/Detail/FwFieldControls.cs
+++ b/Src/Common/FwAvalonia/Detail/FwFieldControls.cs
@@ -1209,22 +1209,26 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 	/// possibility tree indented by <see cref="DetailChoiceOption.Depth"/> for enumerated lists,
 	/// or the host search delegate's results for search-backed vectors (lexicons search, lists
 	/// enumerate), both behind the same filter box and virtualized capped list.
-	/// Right-clicking an item offers Remove. Without an edit context the row is read-only display.
+	/// Clicking an item (any button) makes it the row's current item, shown with the
+	/// selected-row brush and exposed through <see cref="IDetailItemSelection"/> so menu
+	/// requests can carry it. Right-clicking an item raises the host's per-item menu when a
+	/// bridge is supplied, else offers a local Remove; Backspace or Delete removes the focused
+	/// item. Without an edit context the row is read-only display whose items still select.
 	/// Hover-reveal polish: the separator bars, the "+" launcher, and -- only when the
 	/// row's list resolved a list-editor target -- the CONFIGURE gear (which directly dispatches
 	/// the host jump, never a flyout: <see cref="DetailGearChrome"/>) fade in on row hover; the
 	/// items/text stay always visible.
 	/// </summary>
-	public sealed class FwReferenceVectorField : StackPanel, IHoverAffordanceProvider, IDisposable
+	public sealed class FwReferenceVectorField : StackPanel, IHoverAffordanceProvider,
+		IDetailItemSelection, IDisposable
 	{
 		private readonly List<Control> _affordances = new List<Control>();
-		// Teardown for the per-item Remove handlers, the add picker's OptionCommitted/Dismissed
-		// subscriptions, the gear click, and the option flyout -- so a recycled vector cell
-		// releases
-		// every closure it wired and drops its flyout, mirroring FwChooserField/FwMultiWsTextField
-		// (wiring these with NO teardown leaks the editor path
-		// when VirtualizingStackPanel discards the container). Empty for read-only rows.
+		// Teardown for the per-item select/Remove handlers, the add picker's subscriptions, the
+		// gear click, and the option flyout, so a recycled vector cell releases every closure.
 		private readonly List<Action> _teardown = new List<Action>();
+		private readonly IReadOnlyList<DetailChoiceOption> _items;
+		private readonly List<TextBlock> _itemBlocks = new List<TextBlock>();
+		private int _selectedIndex = -1;
 		private bool _disposed;
 
 		/// <summary>
@@ -1233,13 +1237,18 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// -- legacy commits each chooser-dialog gesture as it lands, and the row's Items are a
 		/// compose-time snapshot, so without a commit + re-show nothing visibly changes.
 		/// Failed stages never fire it.
+		/// <paramref name="menuRequested"/> (optional): the host bridge that shows the row's
+		/// menus. When present, right-clicking an item raises a <see
+		/// cref="DetailMenuKind.ItemMenu"/> request carrying that item instead of the local
+		/// Remove flyout.
 		/// </summary>
 		public FwReferenceVectorField(
 			DetailField field,
 			string automationId,
 			IDetailEditContext editContext,
 			Action gestureCompleted = null,
-			Action<DetailLinkRequest> linkRequested = null)
+			Action<DetailLinkRequest> linkRequested = null,
+			Action<DetailMenuRequest> menuRequested = null)
 		{
 			Orientation = Orientation.Horizontal;
 			// 14.2-style hit-testing rule: a null background only hit-tests the glyphs -- the
@@ -1249,9 +1258,11 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 			AutomationProperties.SetAutomationId(this, automationId);
 			AutomationProperties.SetName(this, field.Label ?? field.Field ?? automationId);
 
+			_items = field.Items;
 			var editable = editContext != null && field.IsEditable;
-			foreach (var item in field.Items)
+			for (var index = 0; index < field.Items.Count; index++)
 			{
+				var item = field.Items[index];
 				var text = new TextBlock
 				{
 					Text = item.Name,
@@ -1262,8 +1273,61 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 					// the right-click or the Remove flyout only opens over ink.
 					Background = FwAvaloniaDensity.TransparentBrush
 				};
-				AutomationProperties.SetAutomationId(text, automationId + ".Item." + item.Key);
+				AutomationProperties.SetAutomationId(text, ItemAutomationId(automationId, item.Key));
+				// Any button selects, so a right-click's menu acts on the item under the pointer;
+				// focus selects too. Items are focusable (a click focuses one) but not tab stops.
+				var itemIndex = index;
+				text.Focusable = true;
+				KeyboardNavigation.SetIsTabStop(text, false);
+				EventHandler<GotFocusEventArgs> focusSelect = (s, e) => SelectItem(itemIndex);
+				text.GotFocus += focusSelect;
+				EventHandler<PointerPressedEventArgs> select = (s, e) =>
+				{
+					SelectItem(itemIndex);
+					// Ctrl+click runs the item menu's default jump without showing the menu.
+					if (menuRequested != null
+						&& e.GetCurrentPoint(text).Properties.IsLeftButtonPressed
+						&& e.KeyModifiers.HasFlag(KeyModifiers.Control))
+					{
+						menuRequested(DetailMenuRequest.FromDefaultActivation(text, field, this));
+						e.Handled = true;
+					}
+				};
+				text.PointerPressed += select;
+				_itemBlocks.Add(text);
+				_teardown.Add(() =>
+				{
+					text.PointerPressed -= select;
+					text.GotFocus -= focusSelect;
+				});
 				if (editable)
+				{
+					// Backspace or Delete removes the focused item.
+					EventHandler<KeyEventArgs> keyRemove = (s, e) =>
+					{
+						if (e.Key != Key.Back && e.Key != Key.Delete)
+							return;
+						e.Handled = true;
+						if (editContext.TryRemoveReferenceItem(field, item.Key))
+							gestureCompleted?.Invoke();
+					};
+					text.KeyDown += keyRemove;
+					_teardown.Add(() => text.KeyDown -= keyRemove);
+				}
+				if (menuRequested != null)
+				{
+					// The press above already made this the current item, so the request's
+					// selected item is the one under the pointer.
+					EventHandler<ContextRequestedEventArgs> itemMenu = (s, e) =>
+					{
+						menuRequested(DetailMenuRequest.FromContextRequested(text, e, field,
+							DetailMenuKind.ItemMenu, this));
+						e.Handled = true;
+					};
+					text.AddHandler(ContextRequestedEvent, itemMenu);
+					_teardown.Add(() => text.RemoveHandler(ContextRequestedEvent, itemMenu));
+				}
+				else if (editable)
 				{
 					var removeItem = new MenuItem { Header = FwAvaloniaStrings.Remove };
 					var key = item.Key;
@@ -1371,6 +1435,83 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// <summary>The separator bars, "+" launcher, and configure gear reveal on row hover.</summary>
 		public IReadOnlyList<Control> HoverAffordances => _affordances;
 
+		private const string ItemAutomationIdInfix = ".Item.";
+
+		/// <summary>The automation id of the item with this option key in the row with this
+		/// automation id.</summary>
+		public static string ItemAutomationId(string rowAutomationId, string itemKey)
+			=> rowAutomationId + ItemAutomationIdInfix + itemKey;
+
+		/// <summary>Whether an automation id names an item of the row with this automation
+		/// id.</summary>
+		public static bool IsItemAutomationId(string rowAutomationId, string automationId)
+			=> rowAutomationId != null && automationId != null
+				&& automationId.StartsWith(rowAutomationId + ItemAutomationIdInfix, StringComparison.Ordinal);
+
+		/// <summary>The option key of the selected item; null when none is selected.</summary>
+		public string SelectedItemKey => _selectedIndex < 0 ? null : _items[_selectedIndex].Key;
+
+		/// <summary>The index of the selected item in the field's Items; -1 when none.</summary>
+		public int SelectedItemIndex => _selectedIndex;
+
+		/// <summary>Makes the item with this option key current; false when no item has
+		/// it.</summary>
+		public bool SelectItem(string key)
+		{
+			for (var i = 0; i < _items.Count; i++)
+			{
+				if (!string.Equals(_items[i].Key, key, StringComparison.Ordinal))
+					continue;
+				SelectItem(i);
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Makes the item at this index current, clamped to the row's items; false when the row
+		/// is empty.
+		/// </summary>
+		public bool SelectItemAt(int index)
+		{
+			if (_itemBlocks.Count == 0)
+				return false;
+			SelectItem(Math.Max(0, Math.Min(index, _itemBlocks.Count - 1)));
+			return true;
+		}
+
+		/// <summary>
+		/// Makes the item at this index current, clamped to the row's items, and gives it
+		/// keyboard focus; false when the row is empty.
+		/// </summary>
+		public bool FocusItemAt(int index)
+		{
+			if (!SelectItemAt(index))
+				return false;
+			_itemBlocks[_selectedIndex].Focus();
+			return true;
+		}
+
+		/// <summary>Raised after the current item changes, including when it is
+		/// cleared.</summary>
+		public event EventHandler SelectionChanged;
+
+		/// <summary>Leaves the row with no current item.</summary>
+		public void ClearSelection() => SelectItem(-1);
+
+		// Exactly one item is current at a time; the highlight moves with it.
+		private void SelectItem(int index)
+		{
+			if (index == _selectedIndex)
+				return;
+			if (_selectedIndex >= 0)
+				_itemBlocks[_selectedIndex].Background = FwAvaloniaDensity.TransparentBrush;
+			_selectedIndex = index;
+			if (index >= 0)
+				_itemBlocks[index].Background = FwAvaloniaDensity.SelectedRowBrush;
+			SelectionChanged?.Invoke(this, EventArgs.Empty);
+		}
+
 		/// <summary>
 		/// The count of still-attached subscriptions/handlers -- zero after <see
 		/// cref="Dispose"/>.
@@ -1379,10 +1520,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		public int AttachedHandlerCount => _teardown.Count;
 
 		/// <summary>
-		/// Detaches the per-item Remove handlers and the add picker's subscriptions and drops the option
-		/// flyout so a recycled reference-vector cell does not retain its closures. Idempotent;
-		/// a no-op for read-only rows (none wired). The host (DataTree / EditableCellHost)
-		/// already disposes IDisposable editors on teardown, so wiring IDisposable here is enough.
+		/// Detaches the per-item select and Remove handlers and the add picker's subscriptions
+		/// and drops the option flyout so a recycled reference-vector cell does not retain its
+		/// closures. Idempotent. The host (DataTree / EditableCellHost) already disposes
+		/// IDisposable editors on teardown, so wiring IDisposable here is enough.
 		/// </summary>
 		public void Dispose()
 		{

--- a/Src/Common/FwAvalonia/Detail/IDetailEditContext.cs
+++ b/Src/Common/FwAvalonia/Detail/IDetailEditContext.cs
@@ -61,6 +61,15 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		bool TryRemoveReferenceItem(DetailField field, string optionKey);
 
 		/// <summary>
+		/// Stages moving an item (by option key) one place within a <see
+		/// cref="DetailFieldKind.ReferenceVector"/> row: forward is toward the end of the vector
+		/// (Move Right), otherwise toward the start (Move Left). Returns false -- without opening
+		/// the session -- when the row cannot be reordered, the item is not in the vector, or it
+		/// is already at that end.
+		/// </summary>
+		bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward);
+
+		/// <summary>
 		/// Validates the staged state. Empty result means commit may proceed; messages are
 		/// user-facing (validation seam, deterministic order).
 		/// </summary>

--- a/Src/Common/FwAvalonia/Detail/SliceFactory.cs
+++ b/Src/Common/FwAvalonia/Detail/SliceFactory.cs
@@ -50,7 +50,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 		/// switch).</summary>
 		public Action<string> WritingSystemFocused { get; }
 
-		/// <summary>Right-click slice/section menu callback (null on hosts without a slice menu).</summary>
+		/// <summary>Right-click menu callback for rows, sections, and vector items (null on
+		/// hosts without a menu bridge; vector rows then keep a local Remove flyout).</summary>
 		public Action<DetailMenuRequest> MenuRequested { get; }
 
 		/// <summary>Hyperlink follow callback for choosers/vectors (null -> no link
@@ -108,7 +109,8 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Detail
 					// focus-loss autosave uses, whose re-show rebuilds the row from domain truth. A host
 					// that owns its own commit (an in-cell editor) passes a null Save and just stages.
 					return new FwReferenceVectorField(field, automationId, context.EditContext,
-						context.EditContext == null ? null : context.Save, context.LinkRequested);
+						context.EditContext == null ? null : context.Save, context.LinkRequested,
+						context.MenuRequested);
 				case DetailFieldKind.StructuredText:
 					// An editable multi-paragraph StText field. Per-paragraph text edits stage and
 					// ride the focus-loss autosave; structural gestures (add/delete/style) commit

--- a/Src/Common/FwAvalonia/DetailHostControl.cs
+++ b/Src/Common/FwAvalonia/DetailHostControl.cs
@@ -56,16 +56,18 @@ namespace SIL.FieldWorks.Common.FwAvalonia
 				});
 			view.EditCompleted += (s, e) => RaiseDetailEditCompleted();
 
+			// Continuity across the re-show, applied once the new view lays out. Focus leaves the
+			// old view first: detaching a focused editor makes Avalonia refocus and scroll away.
 			var focusMemento = DetailFocusMemory.Capture(CurrentContent);
-			if (focusMemento != null)
-				DetailFocusMemory.TryRestoreScroll(view, focusMemento);
+			DetailFocusMemory.ReleaseFocus(CurrentContent);
 			SetHostContent(view);
-			if (!string.IsNullOrEmpty(focusMemento?.AutomationId))
-			{
-				Avalonia.Threading.Dispatcher.UIThread.Post(
-					() => DetailFocusMemory.TryRestoreFocus(view, focusMemento),
-					Avalonia.Threading.DispatcherPriority.Input);
-			}
+			DetailFocusMemory.RestoreAfterLayout(view, focusMemento);
 		}
+
+		/// <summary>
+		/// Asks the next re-show to give keyboard focus to the vector row's current item, for a
+		/// gesture (a menu-driven move) made while no editor had focus.
+		/// </summary>
+		public void FocusVectorItemOnNextShow() => (CurrentContent as DataTree)?.RequestVectorFocusOnRebuild();
 	}
 }

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailEditingTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailEditingTests.cs
@@ -45,6 +45,15 @@ namespace FwAvaloniaTests
 			ReferenceRemoves.Add((field.Field, optionKey));
 			return ReferenceGestureResult;
 		}
+
+		public readonly List<(string Field, string Key, bool Forward)> ReferenceMoves
+			= new List<(string, string, bool)>();
+
+		public bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward)
+		{
+			ReferenceMoves.Add((field.Field, optionKey, forward));
+			return ReferenceGestureResult;
+		}
 		public IReadOnlyList<string> ValidateResult = new List<string>();
 		public int CommitCount;
 		public int CancelCount;

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailEditorParityTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailEditorParityTests.cs
@@ -101,13 +101,13 @@ namespace FwAvaloniaTests
 		}
 
 		[AvaloniaTest]
-		public void ReferenceVector_ReadOnly_HasNothingToDetach()
+		public void ReferenceVector_ReadOnly_WiresOnlyTheItemSelectHandlers()
 		{
-			// A read-only vector (no edit context) wires no edit handlers, so its teardown is
-			// empty --
-			// Dispose is a safe no-op.
+			// A read-only vector (no edit context) wires no edit handlers: its teardown holds
+			// exactly one select handler per item, and Dispose releases them.
 			var vector = new FwReferenceVectorField(VectorFieldWithItems(), "PublishIn", editContext: null);
-			Assert.That(vector.AttachedHandlerCount, Is.EqualTo(0));
+			Assert.That(vector.AttachedHandlerCount, Is.EqualTo(1),
+				"one item, one select handler; no Remove handler or add-picker subscription");
 			vector.Dispose();
 			Assert.That(vector.AttachedHandlerCount, Is.EqualTo(0));
 		}

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailFocusMemoryTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailFocusMemoryTests.cs
@@ -182,6 +182,127 @@ namespace FwAvaloniaTests
 				"rebuilding the detail view should keep the user at the same scroll position instead of jumping back to the top");
 		}
 
+		private static DataTree NewVectorView(params string[] keys)
+		{
+			var field = new DetailField("LexEntry/x/#7", "Subentries", "Subentries", null,
+				DetailFieldKind.ReferenceVector, EditorClassification.Known, "Subentries", null,
+				HostRouting.Inherit, null, null, null, isEditable: false,
+				items: keys.Select(k => new DetailChoiceOption(k, k.ToUpperInvariant())).ToList());
+			return new DataTree(new DetailModel("LexEntry", "Normal",
+				new List<DetailField> { field }, new List<ViewDiagnostic>()));
+		}
+
+		private static TextBlock FindChip(Control root, string automationId)
+			=> root.GetVisualDescendants().OfType<TextBlock>()
+				.Single(t => AutomationProperties.GetAutomationId(t) == automationId);
+
+		// A move or a keyboard removal leaves no focused editor; the row's current item (or,
+		// when no item has its key, the item now at its index) takes focus after the rebuild.
+		[AvaloniaTest]
+		public void RestoreAfterLayout_FocusesTheCurrentItem_OnlyWhenAskedTo_OrAfterAnItemRemoval()
+		{
+			var first = NewVectorView("a", "b", "c");
+			var window = new Window { Content = first, Width = 420, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			Assert.That(first.GetVisualDescendants().OfType<FwReferenceVectorField>().Single().SelectItem("b"), Is.True);
+
+			// A selection alone (focus elsewhere) restores the highlight but never takes focus.
+			var passive = DetailFocusMemory.Capture(first);
+			Assert.That(passive.AutomationId, Is.Null, "nothing is focused");
+			Assert.That(passive.FocusVectorItem, Is.False);
+			var second = NewVectorView("a", "b", "c");
+			DetailFocusMemory.RestoreAfterLayout(second, passive);
+			window.Content = second;
+			Dispatcher.UIThread.RunJobs();
+			var restored = second.GetVisualDescendants().OfType<FwReferenceVectorField>().Single();
+			Assert.That(restored.SelectedItemKey, Is.EqualTo("b"));
+			Assert.That(FindChip(second, "Subentries.Item.b").IsFocused, Is.False,
+				"an unrelated re-show must not pull focus into the row");
+
+			// The outgoing view asked for it (a menu-driven move): the current item takes focus.
+			second.RequestVectorFocusOnRebuild();
+			var requested = DetailFocusMemory.Capture(second);
+			Assert.That(requested.FocusVectorItem, Is.True);
+			var third = NewVectorView("a", "b", "c");
+			DetailFocusMemory.RestoreAfterLayout(third, requested);
+			window.Content = third;
+			Dispatcher.UIThread.RunJobs();
+			Assert.That(FindChip(third, "Subentries.Item.b").IsFocused, Is.True);
+
+			// Keyboard focus sat on an item that the rebuilt row lacks: the item now at its index
+			// takes over.
+			FindChip(third, "Subentries.Item.b").Focus();
+			Dispatcher.UIThread.RunJobs();
+			var removal = DetailFocusMemory.Capture(third);
+			Assert.That(removal.AutomationId, Is.EqualTo("Subentries.Item.b"));
+			var fourth = NewVectorView("a", "c");
+			DetailFocusMemory.RestoreAfterLayout(fourth, removal);
+			window.Content = fourth;
+			Dispatcher.UIThread.RunJobs();
+			Assert.That(fourth.GetVisualDescendants().OfType<FwReferenceVectorField>().Single().SelectedItemKey,
+				Is.EqualTo("c"));
+			Assert.That(FindChip(fourth, "Subentries.Item.c").IsFocused, Is.True);
+		}
+
+		// A vector row's current item is view state; it must survive the rebuild even when
+		// nothing is focused (the move was made from a menu).
+		[AvaloniaTest]
+		public void CaptureAndRestore_CarryTheVectorRowsCurrentItem_AcrossAViewRebuild()
+		{
+			var first = NewVectorView("a", "b");
+			var window = new Window { Content = first, Width = 420, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			var vector = first.GetVisualDescendants().OfType<FwReferenceVectorField>().Single();
+			Assert.That(vector.SelectItem("b"), Is.True);
+
+			var memento = DetailFocusMemory.Capture(first);
+			Assert.That(memento.AutomationId, Is.Null, "nothing is focused");
+			Assert.That(memento.VectorAutomationId, Is.EqualTo("Subentries"));
+			Assert.That(memento.VectorItemKey, Is.EqualTo("b"));
+
+			// Handed over BEFORE the new view is attached, as the host does; the row only joins
+			// the visual tree on the first layout pass.
+			var second = NewVectorView("a", "b");
+			DetailFocusMemory.RestoreAfterLayout(second, memento);
+			window.Content = second;
+			Dispatcher.UIThread.RunJobs();
+
+			var restored = second.GetVisualDescendants().OfType<FwReferenceVectorField>().Single();
+			Assert.That(restored.SelectedItemKey, Is.EqualTo("b"), "the current item follows the rebuild");
+
+			var third = NewVectorView("a", "b");
+			Assert.That(DetailFocusMemory.TryRestoreVectorSelection(third,
+				new DetailFocusMemory.Memento(null, -1, 0, "Subentries", "zzz")), Is.False,
+				"an item that disappeared restores nothing");
+		}
+
+		// A re-show driven from a menu (a vector item moved or removed) has no focused editor,
+		// and the host hands the memento to the NEW view before it has laid out.
+		[AvaloniaTest]
+		public void RestoreAfterLayout_KeepsTheScrollOffset_WithNoFocusedEditor_WhenGivenBeforeLayout()
+		{
+			var first = NewLongView();
+			var window = new Window { Content = first, Width = 420, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+			FindScroller(first).Offset = new Avalonia.Vector(0, 120);
+			Dispatcher.UIThread.RunJobs();
+
+			var memento = DetailFocusMemory.Capture(first);
+			Assert.That(memento.AutomationId, Is.Null, "precondition: nothing in the view is focused");
+
+			// Handed the memento BEFORE it is attached or laid out, as the host does.
+			var second = NewLongView();
+			DetailFocusMemory.RestoreAfterLayout(second, memento);
+			window.Content = second;
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(FindScroller(second).Offset.Y, Is.EqualTo(120).Within(0.5),
+				"the deferred restore lands after layout, so the user stays where they were");
+		}
+
 		// A single-text-field view's editor automation id is exactly
 		// <paramref name="stableId"/> + ".vern", reproducing the ghost id
 		// ("...@ownerHvo/ghost.vern") and real successor ("...@newHvo.vern").

--- a/Src/Common/FwAvalonia/FwAvaloniaTests/DetailMenuTests.cs
+++ b/Src/Common/FwAvalonia/FwAvaloniaTests/DetailMenuTests.cs
@@ -42,6 +42,10 @@ namespace FwAvaloniaTests
   <part id='LexEntry-Detail-Senses'>
     <seq field='Senses' menu='mnuDataTree-Sense' hotlinks='mnuDataTree-Sense-Hotlinks'/>
   </part>
+  <part id='LexEntry-Detail-Subentries'>
+	<slice field='Subentries' label='Subentries' menu='mnuReorderVector' reorder='true'
+		   editor='custom' assemblyPath='LexEdDll.dll' class='SIL.FieldWorks.XWorks.LexEd.EntrySequenceReferenceSlice'/>
+  </part>
 </bin></PartInventory>";
 
 		private static ViewDefinitionModel Import(string layoutXml)
@@ -96,6 +100,21 @@ namespace FwAvaloniaTests
 				"sequence nodes keep their menu so per-item headers can show the sense menu");
 			Assert.That(model.Roots[1].HotlinksId, Is.EqualTo("mnuDataTree-Sense-Hotlinks"));
 			Assert.That(model.Diagnostics, Is.Empty);
+		}
+
+		[Test]
+		public void Import_ReorderFlag_LandsOnTheNode_AndIsNotReportedAsUnhandled()
+		{
+			var model = Import(@"
+<layout class='LexEntry' type='detail' name='Menus'>
+  <part ref='Subentries'/>
+  <part ref='CitationForm'/>
+</layout>");
+
+			Assert.That(model.Roots[0].Reorder, Is.True, "reorder='true' rides the typed node");
+			Assert.That(model.Roots[1].Reorder, Is.False, "absent means not reorderable");
+			Assert.That(model.Diagnostics.Where(d => d.Message.Contains("reorder")), Is.Empty,
+				"reorder is a handled slice attribute");
 		}
 	}
 
@@ -641,6 +660,260 @@ namespace FwAvaloniaTests
 			var child = (MenuItem)top[1].Items[0];
 			Assert.That(child.Padding, Is.EqualTo(SIL.FieldWorks.Common.FwAvalonia.FwAvaloniaDensity.MenuItemPadding),
 				"submenu items compact too");
+		}
+
+		// A read-only reference-vector row (no edit context): items still select, since the
+		// item-relative commands act on whichever item is current.
+		private static DetailField VectorField(string id, params string[] itemKeys)
+			=> new DetailField(id, id, id, null, DetailFieldKind.ReferenceVector,
+				EditorClassification.Known, id, null, HostRouting.Inherit, null, null, null,
+				isEditable: false, indent: 0, menuId: "mnuReorderVector", objectHvo: 1234,
+				items: itemKeys.Select(k => new DetailChoiceOption(k, k.ToUpperInvariant())).ToList());
+
+		[AvaloniaTest]
+		public void VectorRow_WithNoItemClicked_RequestCarriesNoSelectedItem()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			Assert.That(vector.SelectedItemKey, Is.Null);
+			Assert.That(vector.SelectedItemIndex, Is.EqualTo(-1));
+
+			RightClick(window, Find<TextBlock>(view, "Subentries.Label"));
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].SelectedItemKey, Is.Null);
+			Assert.That(requests[0].SelectedItemIndex, Is.EqualTo(-1));
+		}
+
+		[AvaloniaTest]
+		public void ClickingAVectorItem_SelectsIt_AndTheLabelMenuRequestCarriesIt()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+			var second = Find<TextBlock>(view, "Subentries.Item.b");
+
+			LeftClick(window, second);
+
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			Assert.That(vector.SelectedItemKey, Is.EqualTo("b"));
+			Assert.That(vector.SelectedItemIndex, Is.EqualTo(1));
+			Assert.That(second.Background, Is.SameAs(FwAvaloniaDensity.SelectedRowBrush),
+				"the current item is highlighted");
+			Assert.That(requests, Is.Empty, "selecting an item opens no menu");
+
+			RightClick(window, Find<TextBlock>(view, "Subentries.Label"));
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
+			Assert.That(requests[0].SelectedItemKey, Is.EqualTo("b"));
+			Assert.That(requests[0].SelectedItemIndex, Is.EqualTo(1));
+		}
+
+		[AvaloniaTest]
+		public void SelectingInOneVectorRow_ClearsTheOtherRowsSelection()
+		{
+			var (window, view, _) = Show(VectorField("Subentries", "a", "b"),
+				VectorField("ComplexForms", "c", "d"));
+			var subentries = Find<FwReferenceVectorField>(view, "Subentries");
+			var complexForms = Find<FwReferenceVectorField>(view, "ComplexForms");
+
+			LeftClick(window, Find<TextBlock>(view, "Subentries.Item.b"));
+			Assert.That(subentries.SelectedItemKey, Is.EqualTo("b"));
+
+			LeftClick(window, Find<TextBlock>(view, "ComplexForms.Item.c"));
+
+			Assert.That(complexForms.SelectedItemKey, Is.EqualTo("c"));
+			Assert.That(subentries.SelectedItemKey, Is.Null, "one current item per view");
+			Assert.That(Find<TextBlock>(view, "Subentries.Item.b").Background,
+				Is.SameAs(FwAvaloniaDensity.TransparentBrush), "the old highlight is gone");
+			Assert.That(subentries.SelectItem("a"), Is.True);
+			Assert.That(complexForms.SelectedItemKey, Is.Null, "a programmatic select clears the others too");
+		}
+
+		[AvaloniaTest]
+		public void ClickingAnotherVectorItem_MovesTheSelection_AndTheHighlight()
+		{
+			var (window, view, _) = Show(VectorField("Subentries", "a", "b"));
+			var first = Find<TextBlock>(view, "Subentries.Item.a");
+			var second = Find<TextBlock>(view, "Subentries.Item.b");
+
+			LeftClick(window, second);
+			LeftClick(window, first);
+
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			Assert.That(vector.SelectedItemKey, Is.EqualTo("a"));
+			Assert.That(first.Background, Is.SameAs(FwAvaloniaDensity.SelectedRowBrush));
+			Assert.That(second.Background, Is.SameAs(FwAvaloniaDensity.TransparentBrush),
+				"only one item is current at a time");
+		}
+
+		[AvaloniaTest]
+		public void RightClickingAVectorItem_SelectsIt_SoItsMenuActsOnTheItemUnderThePointer()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+
+			RightClick(window, Find<TextBlock>(view, "Subentries.Item.a"));
+
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			Assert.That(vector.SelectedItemKey, Is.EqualTo("a"));
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ItemMenu), "the item's own menu, not the row's");
+			Assert.That(requests[0].SelectedItemKey, Is.EqualTo("a"));
+
+			ClickKebab(Find<Button>(view, "Subentries.FieldMenu"));
+
+			Assert.That(requests, Has.Count.EqualTo(2));
+			Assert.That(requests[1].Kind, Is.EqualTo(DetailMenuKind.SliceMenu));
+			Assert.That(requests[1].SelectedItemKey, Is.EqualTo("a"),
+				"the field-options button carries the current item too");
+		}
+
+		[AvaloniaTest]
+		public void RightClickingAVectorItem_RaisesTheItemMenuRequest_ForThatItem()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+
+			var second = Find<TextBlock>(view, "Subentries.Item.b");
+			RightClick(window, second);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ItemMenu));
+			Assert.That(requests[0].SelectedItemKey, Is.EqualTo("b"),
+				"the item under the pointer is the request's item");
+			Assert.That(requests[0].SelectedItemIndex, Is.EqualTo(1));
+			Assert.That(requests[0].Field.ObjectHvo, Is.EqualTo(1234), "the row's object still rides along");
+			Assert.That(requests[0].OpenAtPointer, Is.True);
+			Assert.That(ReferenceEquals(requests[0].AnchorControl, second), Is.True);
+			Assert.That(second.ContextFlyout, Is.Null, "one menu: the bridged item menu replaces the local flyout");
+		}
+
+		[AvaloniaTest]
+		public void CtrlClickingAVectorItem_RaisesTheDefaultActivation_ForThatItem()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+			var second = Find<TextBlock>(view, "Subentries.Item.b");
+
+			var point = second.TranslatePoint(new Point(2, 2), window);
+			Assert.That(point, Is.Not.Null);
+			window.MouseDown(point.Value, MouseButton.Left, RawInputModifiers.Control);
+			window.MouseUp(point.Value, MouseButton.Left, RawInputModifiers.Control);
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].IsDefaultActivation, Is.True, "Ctrl+click runs the default jump");
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ItemMenu));
+			Assert.That(requests[0].SelectedItemKey, Is.EqualTo("b"));
+			Assert.That(requests[0].OpenAtPointer, Is.False);
+
+			LeftClick(window, second);
+			Assert.That(requests, Has.Count.EqualTo(1), "a plain click only selects");
+		}
+
+		[AvaloniaTest]
+		public void FocusingAVectorItem_SelectsIt_AndTheContextMenuKey_RaisesTheItemMenuUnderIt()
+		{
+			var (window, view, requests) = Show(VectorField("Subentries", "a", "b"));
+			var second = Find<TextBlock>(view, "Subentries.Item.b");
+
+			second.Focus();
+			Dispatcher.UIThread.RunJobs();
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			Assert.That(vector.SelectedItemKey, Is.EqualTo("b"), "keyboard focus selects the item");
+
+			PressContextMenuKey(window);
+
+			Assert.That(requests, Has.Count.EqualTo(1));
+			Assert.That(requests[0].Kind, Is.EqualTo(DetailMenuKind.ItemMenu));
+			Assert.That(requests[0].IsDefaultActivation, Is.False);
+			Assert.That(requests[0].SelectedItemKey, Is.EqualTo("b"));
+			Assert.That(requests[0].OpenAtPointer, Is.False, "a keyboard-raised menu anchors under the item");
+			Assert.That(ReferenceEquals(requests[0].AnchorControl, second), Is.True);
+		}
+
+		// Items take focus from a click (so the keys and the context-menu key reach them) but
+		// add no Tab stops to the detail view.
+		[AvaloniaTest]
+		public void VectorItems_AreFocusable_ButNotTabStops()
+		{
+			var (_, view, _) = Show(VectorField("Subentries", "a", "b"));
+			var vector = Find<FwReferenceVectorField>(view, "Subentries");
+			var first = Find<TextBlock>(view, "Subentries.Item.a");
+			Assert.That(first.Focusable, Is.True);
+			Assert.That(KeyboardNavigation.GetIsTabStop(first), Is.False, "items are not tab stops");
+			Assert.That(vector.Focusable, Is.False, "nor is the row");
+		}
+
+		// Backspace or Delete on a focused item removes it, staging through the edit context
+		// and completing the gesture; read-only rows ignore the keys.
+		[AvaloniaTest]
+		public void DeleteOrBackspace_OnAFocusedVectorItem_RemovesIt_ThroughTheEditContext()
+		{
+			var field = new DetailField("v", "Publish In", "PublishIn", null, DetailFieldKind.ReferenceVector,
+				EditorClassification.Known, "PublishIn", null, HostRouting.Inherit, null,
+				new List<DetailChoiceOption> { new DetailChoiceOption("p1", "Main Dictionary") }, null,
+				isEditable: true, items: new List<DetailChoiceOption>
+				{
+					new DetailChoiceOption("p1", "Main Dictionary"),
+					new DetailChoiceOption("p2", "Pocket")
+				});
+			var context = new FakeDetailEditContext();
+			var gestures = 0;
+			var vector = new FwReferenceVectorField(field, "PublishIn", context, () => gestures++,
+				menuRequested: r => { });
+			var window = new Window { Content = vector, Width = 480, Height = 200 };
+			window.Show();
+			Dispatcher.UIThread.RunJobs();
+
+			Find<TextBlock>(vector, "PublishIn.Item.p2").Focus();
+			Dispatcher.UIThread.RunJobs();
+#pragma warning disable 618 // the Key-based overload avoids the headless physical-key map
+			window.KeyPress(Key.Delete, RawInputModifiers.None);
+			window.KeyRelease(Key.Delete, RawInputModifiers.None);
+#pragma warning restore 618
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(context.ReferenceRemoves, Is.EqualTo(new[] { ("PublishIn", "p2") }));
+			Assert.That(gestures, Is.EqualTo(1), "a successful remove completes the gesture once");
+
+			Find<TextBlock>(vector, "PublishIn.Item.p1").Focus();
+			Dispatcher.UIThread.RunJobs();
+#pragma warning disable 618
+			window.KeyPress(Key.Back, RawInputModifiers.None);
+			window.KeyRelease(Key.Back, RawInputModifiers.None);
+#pragma warning restore 618
+			Dispatcher.UIThread.RunJobs();
+
+			Assert.That(context.ReferenceRemoves.Count, Is.EqualTo(2));
+			Assert.That(context.ReferenceRemoves[1], Is.EqualTo(("PublishIn", "p1")), "Backspace removes too");
+
+			// A read-only row (no edit context) ignores the keys.
+			var readOnly = new FwReferenceVectorField(field, "ReadOnly", null);
+			window.Content = readOnly;
+			Dispatcher.UIThread.RunJobs();
+			Find<TextBlock>(readOnly, "ReadOnly.Item.p1").Focus();
+			Dispatcher.UIThread.RunJobs();
+#pragma warning disable 618
+			window.KeyPress(Key.Delete, RawInputModifiers.None);
+			window.KeyRelease(Key.Delete, RawInputModifiers.None);
+#pragma warning restore 618
+			Dispatcher.UIThread.RunJobs();
+			Assert.That(context.ReferenceRemoves.Count, Is.EqualTo(2), "nothing wired on a read-only row");
+		}
+
+		[AvaloniaTest]
+		public void EditableVectorItem_WithAMenuBridge_HasNoLocalRemoveFlyout_AndWithoutOneKeepsIt()
+		{
+			var field = new DetailField("v", "Publish In", "PublishIn", null, DetailFieldKind.ReferenceVector,
+				EditorClassification.Known, "PublishIn", null, HostRouting.Inherit, null,
+				new List<DetailChoiceOption> { new DetailChoiceOption("p1", "Main Dictionary") }, null,
+				isEditable: true, items: new List<DetailChoiceOption> { new DetailChoiceOption("p1", "Main Dictionary") });
+
+			var bridged = new FwReferenceVectorField(field, "Bridged", new FakeDetailEditContext(),
+				menuRequested: r => { });
+			Assert.That(Find<TextBlock>(bridged, "Bridged.Item.p1").ContextFlyout, Is.Null);
+
+			var local = new FwReferenceVectorField(field, "Local", new FakeDetailEditContext());
+			Assert.That(Find<TextBlock>(local, "Local.Item.p1").ContextFlyout, Is.Not.Null,
+				"without a host bridge the row keeps its local Remove flyout");
 		}
 
 		[AvaloniaTest]

--- a/Src/Common/FwAvalonia/Preview/DetailPreviewSupport.cs
+++ b/Src/Common/FwAvalonia/Preview/DetailPreviewSupport.cs
@@ -169,6 +169,12 @@ namespace SIL.FieldWorks.Common.FwAvalonia.Preview
 			return true;
 		}
 
+		public bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward)
+		{
+			IsOpen = true;
+			return true;
+		}
+
 		// The preview context accepts every gesture so the preview shows editable StText affordances.
 		public bool TrySetParagraphText(DetailField field, int paragraphIndex, DetailRichTextValue value)
 		{

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionModel.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionModel.cs
@@ -385,8 +385,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			IReadOnlyList<ViewChooserLink> chooserLinks = null,
 			ViewStringList enumStringList = null,
 			IReadOnlyList<string> visibleWritingSystems = null,
-			bool toggleValue = false)
+			bool toggleValue = false,
+			bool reorder = false)
 		{
+			Reorder = reorder;
 			ToggleValue = toggleValue;
 			VisibleWritingSystems = visibleWritingSystems;
 			EnumStringList = enumStringList;
@@ -557,6 +559,12 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 		/// PartOfSpeech "Final" / inflection-class flag round-trips with the same sense the WinForms slice shows.
 		/// </summary>
 		public bool ToggleValue { get; }
+
+		/// <summary>
+		/// The slice's <c>reorder="true"</c> layout attribute: the user may reorder the items
+		/// even when the property is virtual; the order persists as a virtual ordering.
+		/// </summary>
+		public bool Reorder { get; }
 	}
 
 	/// <summary>

--- a/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/ViewDefinitionOverrideApplier.cs
@@ -309,7 +309,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				n.LocalizationKey, n.AutomationId, n.Routing, n.BoldEmphasis, n.FontScalePercent, n.MenuId,
 				n.ContextMenuId, n.HotlinksId, n.GhostField, n.GhostWs, n.GhostClass, n.GhostLabel,
 				n.ForVariant, n.CustomEditorClass, n.CustomEditorAssembly, n.GhostInitMethod, n.Condition,
-				n.ChooserLinks, n.EnumStringList, visibleWritingSystems, n.ToggleValue);
+				n.ChooserLinks, n.EnumStringList, visibleWritingSystems, n.ToggleValue, n.Reorder);
 
 		// Copy a (leaf) node under a new StableId; AutomationId is dropped so the duplicate gets a fresh,
 		// non-colliding identity (the renderer derives one from the new StableId by convention).
@@ -320,6 +320,6 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 				n.LocalizationKey, null, n.Routing, n.BoldEmphasis, n.FontScalePercent, n.MenuId,
 				n.ContextMenuId, n.HotlinksId, n.GhostField, n.GhostWs, n.GhostClass, n.GhostLabel,
 				n.ForVariant, n.CustomEditorClass, n.CustomEditorAssembly, n.GhostInitMethod, n.Condition,
-				n.ChooserLinks, n.EnumStringList, n.VisibleWritingSystems, n.ToggleValue);
+				n.ChooserLinks, n.EnumStringList, n.VisibleWritingSystems, n.ToggleValue, n.Reorder);
 	}
 }

--- a/Src/Common/FwAvalonia/ViewDefinition/XmlLayoutImporter.cs
+++ b/Src/Common/FwAvalonia/ViewDefinition/XmlLayoutImporter.cs
@@ -36,7 +36,7 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 			{
 				"label", "abbr", "field", "ws", "editor", "visibility", "expansion",
 				"localizationKey", "labelId", "automationId", "routing", "menu", "contextMenu", "hotlinks",
-				"forVariant", "visibleWritingSystems"
+				"forVariant", "visibleWritingSystems", "reorder"
 			};
 
 		public static readonly HashSet<string> HandledObjSeqAttributes =
@@ -413,7 +413,10 @@ namespace SIL.FieldWorks.Common.FwAvalonia.ViewDefinition
 						visibleWritingSystems: visibleWss,
 						// Legacy toggleValue= on a boolean slice (the displayed checkbox is the
 						// logical inverse of the stored property); carried so the composer inverts read+write.
-						toggleValue: ParseOptionalBool(Attr(contentEl, "toggleValue")) ?? false);
+						toggleValue: ParseOptionalBool(Attr(contentEl, "toggleValue")) ?? false,
+						// The slice's reorder= attribute: its items may be reordered
+						// even when the property is virtual.
+						reorder: ParseOptionalBool(Attr(contentEl, "reorder")) ?? false);
 				}
 				case "obj":
 				case "seq":

--- a/Src/Common/FwAvaloniaDialogs/InMemoryDetailEditContext.cs
+++ b/Src/Common/FwAvaloniaDialogs/InMemoryDetailEditContext.cs
@@ -69,6 +69,8 @@ namespace FwAvaloniaDialogs
 
 		public bool TryRemoveReferenceItem(DetailField field, string optionKey) => false;
 
+		public bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward) => false;
+
 		// The Insert Entry dialog edits plain lexeme-form/gloss strings only; it implements neither
 		// IStructuredTextEditing (no StText rows) nor picture editing.
 

--- a/Src/FdoUi/FdoUiCore.cs
+++ b/Src/FdoUi/FdoUiCore.cs
@@ -783,6 +783,13 @@ namespace SIL.FieldWorks.FdoUi
 			return HandleRightClick(mediator, propertyTable, hostControl, shouldDisposeThisWhenClosed, ContextMenuId, adjustMenu);
 		}
 
+		/// <summary>The message of the jump commands a ctrl-click runs.</summary>
+		public const string JumpToToolMessage = "JumpToTool";
+
+		/// <summary>The suffix appended to the label of the menu item a ctrl-click
+		/// runs.</summary>
+		public static string CtrlClickSuffix => FdoUiStrings.ksCtrlClick;
+
 		/// <summary>
 		/// Given a populated choice group, mark the one that will be invoked by a ctrl-click.
 		/// This method is typically used as the menuAdjuster argument in calling HandleRightClick.
@@ -796,7 +803,7 @@ namespace SIL.FieldWorks.FdoUi
 				if (item1 == null || !(item1.Tag is CommandChoice) || !item1.Enabled)
 					continue;
 				var command = (CommandChoice) item1.Tag;
-				if (command.Message != "JumpToTool")
+				if (command.Message != JumpToToolMessage)
 					continue;
 
 				item1.Text += FdoUiStrings.ksCtrlClick;
@@ -838,7 +845,7 @@ namespace SIL.FieldWorks.FdoUi
 		private static bool IsCtrlClickItem(object item)
 		{
 			var command = item as CommandChoice;
-			if (command == null || command.Message != "JumpToTool")
+			if (command == null || command.Message != JumpToToolMessage)
 				return false;
 			var displayProps = command.GetDisplayProperties();
 			return (displayProps.Visible && displayProps.Enabled);

--- a/Src/xWorks/Avalonia/Composer/ComposedDetailEditContext.cs
+++ b/Src/xWorks/Avalonia/Composer/ComposedDetailEditContext.cs
@@ -25,6 +25,9 @@ namespace SIL.FieldWorks.XWorks
 		public Func<string, bool> Option;
 		public Func<string, bool> ReferenceAdd;
 		public Func<string, bool> ReferenceRemove;
+		/// <summary>(item key, forward) -> moved; null on rows whose items cannot be
+		/// reordered.</summary>
+		public Func<string, bool, bool> ReferenceMove;
 		public Func<int, DetailRichTextValue, bool> ParagraphText;
 		public Func<int, string, bool> ParagraphStyle;
 		public Func<int, bool> ParagraphInsert;
@@ -104,6 +107,14 @@ namespace SIL.FieldWorks.XWorks
 			if (setter == null)
 				return false;
 			return Stage(() => setter(optionKey), FieldLabelFor(field));
+		}
+
+		public override bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward)
+		{
+			var setter = Handler(field)?.ReferenceMove;
+			if (setter == null)
+				return false;
+			return Stage(() => setter(optionKey, forward), FieldLabelFor(field));
 		}
 
 		public bool TrySetParagraphText(DetailField field, int paragraphIndex,

--- a/Src/xWorks/Avalonia/Composer/DetailComposer.cs
+++ b/Src/xWorks/Avalonia/Composer/DetailComposer.cs
@@ -1491,14 +1491,17 @@ namespace SIL.FieldWorks.XWorks
 
 				var options = CreatePossibilityOptions(list, flat: false); // FlatList not imported; see above
 				var stableId = StableId(node, obj);
+				var canReorder = CanReorderItems(node, flid);
 				AddField(new DetailField(stableId, Localize(node.Label) ?? node.Field, node.Field,
 					node.WritingSystem, DetailFieldKind.ReferenceVector, node.EditorClassification,
 					node.AutomationId, node.LocalizationKey, node.Routing, null, options, null,
 					isEditable: true, indent: depth, menuId: node.MenuId, contextMenuId: node.ContextMenuId,
 					hotlinksId: node.HotlinksId, objectHvo: obj.Hvo, items: items,
-					chooserLinks: CreateChooserLinks(node, list)));
+					chooserLinks: CreateChooserLinks(node, list),
+					canReorderItems: canReorder));
 
 				var hvo = obj.Hvo;
+				RegisterReferenceMove(stableId, canReorder, obj, flid);
 				HandlerFor(stableId).ReferenceAdd = key =>
 				{
 					var possibility = ResolvePossibilityInList(list, key);
@@ -1556,13 +1559,16 @@ namespace SIL.FieldWorks.XWorks
 				}
 
 				var stableId = StableId(node, obj);
+				var canReorder = CanReorderItems(node, flid);
 				AddField(new DetailField(stableId, Localize(node.Label) ?? node.Field, node.Field,
 					node.WritingSystem, DetailFieldKind.ReferenceVector, node.EditorClassification,
 					node.AutomationId, node.LocalizationKey, node.Routing, null, options, null,
 					isEditable: true, indent: depth, menuId: node.MenuId, contextMenuId: node.ContextMenuId,
-					hotlinksId: node.HotlinksId, objectHvo: obj.Hvo, items: items));
+					hotlinksId: node.HotlinksId, objectHvo: obj.Hvo, items: items,
+					canReorderItems: canReorder));
 
 				var hvo = obj.Hvo;
+				RegisterReferenceMove(stableId, canReorder, obj, flid);
 				HandlerFor(stableId).ReferenceAdd = key =>
 				{
 					if (!Guid.TryParse(key, out var guid) || !candidateHvoByGuid.TryGetValue(guid, out var targetHvo))
@@ -2052,6 +2058,7 @@ namespace SIL.FieldWorks.XWorks
 				// row's
 				// object when it IS an entry, else its owning entry (e.g. obj is the LexEntryRef).
 				var owningEntry = obj as ILexEntry ?? obj.OwnerOfClass<ILexEntry>();
+				var canReorder = CanReorderItems(node, flid);
 
 				AddField(new DetailField(stableId, Localize(node.Label) ?? node.Field, node.Field,
 					node.WritingSystem, DetailFieldKind.ReferenceVector, node.EditorClassification,
@@ -2059,8 +2066,10 @@ namespace SIL.FieldWorks.XWorks
 					isEditable: true, indent: depth, menuId: node.MenuId, contextMenuId: node.ContextMenuId,
 					hotlinksId: node.HotlinksId, objectHvo: obj.Hvo, items: items,
 					searchOptions: query => SearchLexicon(query, hvo, flid, owningEntry),
-					chooserLinks: CreateChooserLinks(node)));
+					chooserLinks: CreateChooserLinks(node),
+					canReorderItems: canReorder));
 
+				RegisterReferenceMove(stableId, canReorder, obj, flid);
 				HandlerFor(stableId).ReferenceAdd = key =>
 				{
 					var target = ResolveEntryOrSense(key);
@@ -2189,6 +2198,7 @@ namespace SIL.FieldWorks.XWorks
 				}
 
 				var stableId = StableId(node, obj);
+				var canReorder = CanReorderItems(node, flid);
 
 				AddField(new DetailField(stableId, Localize(node.Label) ?? node.Field, node.Field,
 					node.WritingSystem, DetailFieldKind.ReferenceVector, node.EditorClassification,
@@ -2196,10 +2206,72 @@ namespace SIL.FieldWorks.XWorks
 					isEditable: true, indent: depth, menuId: node.MenuId, contextMenuId: node.ContextMenuId,
 					hotlinksId: node.HotlinksId, objectHvo: obj.Hvo, items: items,
 					searchOptions: query => SearchBackRefCandidates(query, obj),
-					chooserLinks: CreateChooserLinks(node)));
+					chooserLinks: CreateChooserLinks(node),
+					canReorderItems: canReorder));
 
 				HandlerFor(stableId).ReferenceAdd = key => TryAddBackRef(obj, kind, key);
 				HandlerFor(stableId).ReferenceRemove = key => TryRemoveBackRef(obj, flid, kind, key);
+				// Items are keyed on their owning complex-form entry, so the move resolves keys
+				// the same way.
+				RegisterReferenceMove(stableId, canReorder, obj, flid,
+					itemHvo => BackRefItemOwningEntry(
+						_cache.ServiceLocator.ObjectRepository.GetObject(itemHvo)).Guid.ToString());
+			}
+
+			// Whether a vector row's items may be reordered: a real reference sequence always
+			// may; a virtual one only when its layout says reorder="true".
+			private bool CanReorderItems(ViewNode node, int flid)
+			{
+				var isSequence = (CellarPropertyType)_mdc.GetFieldType(flid)
+					== CellarPropertyType.ReferenceSequence;
+				return (isSequence && !_mdc.get_IsVirtual(flid)) || node.Reorder;
+			}
+
+			// The one-place move of a vector item: a real reference sequence rewrites the whole
+			// vector, a virtual one records the new order as a virtual ordering. Rejects unknown
+			// items and moves past either end.
+			// keyOfItem maps a vector item to the option key its row shows (default: its guid).
+			private void RegisterReferenceMove(string stableId, bool canReorder, ICmObject obj, int flid,
+				Func<int, string> keyOfItem = null)
+			{
+				if (!canReorder)
+					return;
+				keyOfItem = keyOfItem
+					?? (itemHvo => _cache.ServiceLocator.ObjectRepository.GetObject(itemHvo).Guid.ToString());
+				var hvo = obj.Hvo;
+				var isVirtual = _mdc.get_IsVirtual(flid);
+				HandlerFor(stableId).ReferenceMove = (key, forward) =>
+				{
+					var size = _sda.get_VecSize(hvo, flid);
+					var order = new List<int>(size);
+					var from = -1;
+					for (var i = 0; i < size; i++)
+					{
+						var itemHvo = _sda.get_VecItem(hvo, flid, i);
+						order.Add(itemHvo);
+						if (from < 0 && string.Equals(keyOfItem(itemHvo), key, StringComparison.Ordinal))
+							from = i;
+					}
+					if (from < 0)
+						return false;
+					var to = forward ? from + 1 : from - 1;
+					if (to < 0 || to >= size)
+						return false;
+					var moved = order[from];
+					order.RemoveAt(from);
+					order.Insert(to, moved);
+
+					if (isVirtual)
+					{
+						VirtualOrderingServices.SetVO(obj, flid,
+							order.Select(h => _cache.ServiceLocator.ObjectRepository.GetObject(h)).ToList());
+					}
+					else
+					{
+						_sda.Replace(hvo, flid, 0, size, order.ToArray(), size);
+					}
+					return true;
+				};
 			}
 
 			// The owning complex-form entry of a back-ref vector item: the entry itself for the

--- a/Src/xWorks/Avalonia/DetailEditContextBase.cs
+++ b/Src/xWorks/Avalonia/DetailEditContextBase.cs
@@ -62,6 +62,10 @@ namespace SIL.FieldWorks.XWorks
 		public virtual bool TryRemoveReferenceItem(DetailField detailField, string optionKey) => false;
 
 		/// <inheritdoc />
+		public virtual bool TryMoveReferenceItem(DetailField detailField, string optionKey, bool forward)
+			=> false;
+
+		/// <inheritdoc />
 		public virtual IReadOnlyList<string> Validate()
 		{
 			// Validation seam (minimal rule set, deterministic order). The lexeme/citation-form

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.Avalonia.cs
@@ -480,6 +480,12 @@ namespace SIL.FieldWorks.XWorks
 		{
 			try
 			{
+				if (request.Kind == DetailMenuKind.ItemMenu)
+				{
+					OnDetailItemMenuRequested(request);
+					return;
+				}
+
 				// An adapter failure must not suppress the menu itself: items that need the hidden
 				// colleague chain disable, everything else still works (and the failure is logged).
 				try
@@ -515,11 +521,12 @@ namespace SIL.FieldWorks.XWorks
 				// adapter menu remains the fallback if materialization fails.
 				try
 				{
-					// Retarget the per-field Field Visibility / Move Field commands
-					// to the project override layer for the Avalonia detail view; every other command (Help,
-					// inserts, writing-system menu, ...) keeps its normal mediator dispatch.
-					var interceptor = BuildOverrideCommandInterceptor(request.Field);
-					var items = XCoreMenuBridge.CreateMenuItems(window, idArray, interceptor);
+					// Field Visibility / Move Field retarget to the override layer, the reorder
+					// commands to the row's current item; other commands keep their dispatch.
+					var registry = new OverrideCommandRegistry();
+					AddOverrideCommands(registry, request.Field);
+					AddMoveCommands(registry, request);
+					var items = XCoreMenuBridge.CreateMenuItems(window, idArray, registry.TryBuild);
 					if (items.Count > 0)
 					{
 						// A keyboard-opened menu anchors under the row it came from; a
@@ -584,26 +591,23 @@ namespace SIL.FieldWorks.XWorks
 					+ "'; using the shipped definition.", error));
 
 		/// <summary>
-		/// Builds the interceptor that retargets the per-field Field Visibility, Move Field, and
-		/// writing-system commands to the project override layer for the Avalonia detail view.
-		/// Returns null (intercept nothing -- every command keeps its normal mediator dispatch)
-		/// when the clicked row carries no (class, layout) context, e.g. the first-slice fallback
-		/// rows; that keeps the legacy behavior intact when the override layer cannot be
-		/// addressed.
+		/// Registers the per-field Field Visibility, Move Field, and writing-system commands that
+		/// retarget to the project override layer for the Avalonia detail view. Registers nothing
+		/// (every command keeps its normal mediator dispatch) when the clicked row carries no
+		/// (class, layout) context, e.g. the first-slice fallback rows, so ordinary dispatch
+		/// stays in force when the override layer cannot be addressed.
 		/// </summary>
-		private Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> BuildOverrideCommandInterceptor(
-			DetailField field)
+		internal void AddOverrideCommands(OverrideCommandRegistry registry, DetailField field)
 		{
 			if (field == null || string.IsNullOrEmpty(field.ClassName) || string.IsNullOrEmpty(field.LayoutName)
 				|| ViewOverrideStore == null)
 			{
-				return null;
+				return;
 			}
 
 			// Writing-system items dispatch normally; the resulting selection is then copied
 			// into the override. They need no located template node, so they stay registered
 			// even when locating fails.
-			var registry = new OverrideCommandRegistry();
 			registry.Add(IsWritingSystemVisibilityChoice, (c, d) => WritingSystemItem(c, d, field));
 			// Show all right now never dispatches or persists: it only marks the row for the
 			// host's transient reveal.
@@ -628,7 +632,7 @@ namespace SIL.FieldWorks.XWorks
 			{
 				Logger.WriteError("Resolving the field's override target failed; this row's "
 					+ "menu-button commands fall back to ordinary command dispatch.", e);
-				return registry.TryBuild;
+				return;
 			}
 
 			// Unknown/stale target: leave the field commands on the legacy path rather than
@@ -646,8 +650,6 @@ namespace SIL.FieldWorks.XWorks
 				registry.Add("CmdDataTree-MoveFieldDown",
 					(c, d) => MoveItem(d, field, location, up: false));
 			}
-
-			return registry.TryBuild;
 		}
 
 		// A Field Visibility menu item: checked when it is the field's current visibility, executes the

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.ReferenceVectorMenus.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.ReferenceVectorMenus.cs
@@ -209,7 +209,8 @@ namespace SIL.FieldWorks.XWorks
 		{
 			var field = request.Field;
 			var index = request.SelectedItemIndex;
-			var canMove = field.Kind == DetailFieldKind.ReferenceVector && field.CanReorderItems
+			var canMove = field.Kind == DetailFieldKind.ReferenceVector && field.IsEditable
+				&& field.CanReorderItems
 				&& index >= 0 && (forward ? index < field.Items.Count - 1 : index > 0);
 			var key = request.SelectedItemKey;
 			return new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), isEnabled: canMove,
@@ -230,10 +231,14 @@ namespace SIL.FieldWorks.XWorks
 			var context = m_detailEditContext.Current;
 			if (context == null || !context.TryMoveReferenceItem(field, key, forward))
 				return;
+			// A move that fails validation rolls back and never re-shows, so the focus
+			// request is made only once the commit is known to have succeeded; nothing
+			// clears a request the re-show does not consume.
+			if (m_detailEditContext.Settle().Count != 0)
+				return;
 			// The menu took keyboard focus; the re-show hands it to the moved item.
 			m_avaloniaEntryForm?.FocusVectorItemOnNextShow();
-			if (m_detailEditContext.Settle().Count == 0)
-				OnAvaloniaDetailEditCompleted(this, EventArgs.Empty);
+			OnAvaloniaDetailEditCompleted(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Src/xWorks/Avalonia/Hosting/RecordEditView.ReferenceVectorMenus.cs
+++ b/Src/xWorks/Avalonia/Hosting/RecordEditView.ReferenceVectorMenus.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) 2026 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System;
+using System.Collections.Generic;
+using SIL.FieldWorks.Common.FwAvalonia.Detail;
+using SIL.FieldWorks.FdoUi;
+using SIL.LCModel;
+using SIL.LCModel.Infrastructure;
+using SIL.Reporting;
+using XCore;
+
+namespace SIL.FieldWorks.XWorks
+{
+	/// <summary>
+	/// The reference-vector row menus of the Avalonia detail view: the per-item menu (the
+	/// reference-choices menu of the clicked item, answered by that item's object UI as a
+	/// temporary colleague) and the Move Left / Move Right commands, which act on the row's
+	/// current item through the detail edit context.
+	/// </summary>
+	public partial class RecordEditView
+	{
+		private const string MoveLeftCommandId = "CmdMoveTargetToPreviousInSequence";
+		private const string MoveRightCommandId = "CmdMoveTargetToNextInSequence";
+
+		/// <summary>
+		/// Shows the per-item menu of a reference-vector row, or for a Ctrl+click runs its
+		/// default jump command. Never throws: failures are logged.
+		/// </summary>
+		internal void OnDetailItemMenuRequested(DetailMenuRequest request)
+		{
+			if (IsDisposed || m_mediator == null || m_avaloniaEntryForm == null)
+				return;
+			try
+			{
+				if (request.IsDefaultActivation)
+				{
+					var ui = ResolveItemUi(request);
+					if (ui == null)
+						return;
+					// The item's object UI runs the first enabled jump itself, then disposes.
+					SyncMenuCommandAdapter(request.Field);
+					ui.HandleCtrlClick(this);
+					return;
+				}
+
+				var items = BuildReferenceItemMenu(request, out var colleague);
+				if (colleague == null)
+					return;
+				if (items.Count == 0)
+				{
+					colleague.Dispose();
+					return;
+				}
+				// The colleague answers the clicked command, which runs as the menu closes, so
+				// its disposal is queued behind the close.
+				try
+				{
+					m_avaloniaEntryForm.ShowContextMenu(items, request.AnchorControl, request.OpenAtPointer,
+						() => Avalonia.Threading.Dispatcher.UIThread.Post(colleague.Dispose,
+							Avalonia.Threading.DispatcherPriority.Background));
+				}
+				catch
+				{
+					colleague.Dispose();
+					throw;
+				}
+			}
+			catch (Exception e)
+			{
+				Logger.WriteError("Detail item menu failed.", e);
+			}
+		}
+
+		/// <summary>
+		/// Materializes the item menu for the request's selected item: the object UI of that
+		/// item joins the mediator as a temporary colleague (it answers the Show-in-tool jumps),
+		/// the first enabled jump is labeled as the Ctrl+click default, and the Move commands are
+		/// retargeted to the row's current item. Empty, with a null colleague, when the item
+		/// cannot be resolved.
+		/// </summary>
+		/// <param name="request">The item-menu request; its selected item is the target.</param>
+		/// <param name="colleague">The item's object UI, registered on the mediator; the caller
+		/// disposes it once the menu has closed.</param>
+		internal IReadOnlyList<DetailMenuItem> BuildReferenceItemMenu(DetailMenuRequest request,
+			out CmObjectUi colleague)
+		{
+			colleague = null;
+			var ui = ResolveItemUi(request);
+			if (ui == null)
+				return Array.Empty<DetailMenuItem>();
+
+			SyncMenuCommandAdapter(request.Field);
+
+			var registry = new OverrideCommandRegistry();
+			var marked = false;
+			// The first enabled jump is the Ctrl+click default; its label says so.
+			registry.Add(
+				choice => choice is CommandChoice command && string.Equals(command.Message,
+					CmObjectUi.JumpToToolMessage, StringComparison.Ordinal),
+				(choice, display) =>
+				{
+					if (marked || !display.Enabled)
+						return null;
+					marked = true;
+					return new DetailMenuItem(
+						XCoreMenuBridge.StripAccelerator(display.Text) + CmObjectUi.CtrlClickSuffix,
+						isEnabled: true, isChecked: display.Checked, children: null,
+						execute: () => choice.OnClick(null, EventArgs.Empty));
+				});
+			AddMoveCommands(registry, request);
+
+			var window = m_propertyTable.GetValue<XWindow>("window");
+			IReadOnlyList<DetailMenuItem> items;
+			try
+			{
+				items = XCoreMenuBridge.CreateMenuItems(window, new[] { ui.ContextMenuId },
+					registry.TryBuild, ui);
+			}
+			catch
+			{
+				ui.Dispose(); // a failed menu must not leave the colleague on the mediator
+				throw;
+			}
+			colleague = ui;
+			return items;
+		}
+
+		// Points the hidden command adapter at the row, so the row's own slice answers the
+		// commands that need slice context; when that fails, those commands stay hidden.
+		private void SyncMenuCommandAdapter(DetailField field)
+		{
+			try
+			{
+				EnsureMenuCommandAdapter(field.ObjectHvo, field.Field);
+			}
+			catch (Exception adapterError)
+			{
+				Logger.WriteError("Detail item menu command adapter failed; the commands that need "
+					+ "the hidden colleague chain stay hidden.", adapterError);
+			}
+		}
+
+		/// <summary>
+		/// The object UI of the request's selected item, wired to this view's mediator and
+		/// property table; null when the row's object, field, or item cannot be resolved.
+		/// </summary>
+		internal CmObjectUi ResolveItemUi(DetailMenuRequest request)
+		{
+			var field = request?.Field;
+			if (field == null || string.IsNullOrEmpty(request.SelectedItemKey)
+				|| !Cache.ServiceLocator.ObjectRepository.TryGetObject(field.ObjectHvo, out var rootObj))
+			{
+				return null;
+			}
+			var mdc = (IFwMetaDataCacheManaged)Cache.MetaDataCacheAccessor;
+			var flid = mdc.GetFieldId2(rootObj.ClassID, field.Field, true);
+			var targetHvo = ResolveVectorItem(rootObj, flid, request.SelectedItemKey);
+			if (targetHvo == 0)
+				return null;
+			var ui = ReferenceBaseUi.MakeUi(Cache, rootObj, flid, targetHvo);
+			if (ui == null)
+				return null;
+			ui.Mediator = m_mediator;
+			ui.PropTable = m_propertyTable;
+			return ui;
+		}
+
+		// The vector item a row's option key names: the item itself, or for a back-reference
+		// row (whose items are entry refs shown by their owning entry) the ref that entry owns.
+		private int ResolveVectorItem(ICmObject rootObj, int flid, string key)
+		{
+			var sda = Cache.DomainDataByFlid;
+			var repository = Cache.ServiceLocator.ObjectRepository;
+			var size = sda.get_VecSize(rootObj.Hvo, flid);
+			for (var i = 0; i < size; i++)
+			{
+				var hvo = sda.get_VecItem(rootObj.Hvo, flid, i);
+				if (!repository.TryGetObject(hvo, out var item))
+					continue;
+				if (string.Equals(item.Guid.ToString(), key, StringComparison.Ordinal))
+					return hvo;
+				if (item is ILexEntryRef && string.Equals(
+					item.OwnerOfClass<ILexEntry>()?.Guid.ToString(), key, StringComparison.Ordinal))
+				{
+					return hvo;
+				}
+			}
+			return 0;
+		}
+
+		/// <summary>
+		/// Registers Move Left / Move Right retargeted to the request's current item; registers
+		/// nothing for a row that is not a reference vector.
+		/// </summary>
+		internal void AddMoveCommands(OverrideCommandRegistry registry, DetailMenuRequest request)
+		{
+			if (request?.Field == null || request.Field.Kind != DetailFieldKind.ReferenceVector)
+				return;
+			registry.Add(MoveLeftCommandId, (choice, display) => MoveCommandItem(request, display, forward: false));
+			registry.Add(MoveRightCommandId, (choice, display) => MoveCommandItem(request, display, forward: true));
+		}
+
+		// A Move Left / Move Right item for the request's current item, enabled only when the
+		// row can be reordered and the item is not at that end.
+		private DetailMenuItem MoveCommandItem(DetailMenuRequest request, UIItemDisplayProperties display,
+			bool forward)
+		{
+			var field = request.Field;
+			var index = request.SelectedItemIndex;
+			var canMove = field.Kind == DetailFieldKind.ReferenceVector && field.CanReorderItems
+				&& index >= 0 && (forward ? index < field.Items.Count - 1 : index > 0);
+			var key = request.SelectedItemKey;
+			return new DetailMenuItem(XCoreMenuBridge.StripAccelerator(display.Text), isEnabled: canMove,
+				isChecked: false, children: null,
+				execute: canMove ? (Action)(() => MoveReferenceItem(field, key, forward)) : null);
+		}
+
+		/// <summary>
+		/// Moves a reference-vector item one place through the detail edit context and completes
+		/// the gesture the way every other detail edit does: validate-then-commit, then one
+		/// coalesced re-show, through which the moved item stays current.
+		/// </summary>
+		internal void MoveReferenceItem(DetailField field, string key, bool forward)
+		{
+			// Pending edits settle first, so the move is its own undo step and an invalid
+			// pending edit rolls back with its own warning instead of taking the move with it.
+			m_detailEditContext.Settle();
+			var context = m_detailEditContext.Current;
+			if (context == null || !context.TryMoveReferenceItem(field, key, forward))
+				return;
+			// The menu took keyboard focus; the re-show hands it to the moved item.
+			m_avaloniaEntryForm?.FocusVectorItemOnNextShow();
+			if (m_detailEditContext.Settle().Count == 0)
+				OnAvaloniaDetailEditCompleted(this, EventArgs.Empty);
+		}
+	}
+}

--- a/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
+++ b/Src/xWorks/Avalonia/Hosting/XCoreMenuBridge.cs
@@ -44,10 +44,23 @@ namespace SIL.FieldWorks.XWorks
 		/// </summary>
 		public static IReadOnlyList<DetailMenuItem> CreateMenuItems(XWindow window, string[] menuIds,
 			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> interceptor)
+			=> CreateMenuItems(window, menuIds, interceptor, null);
+
+		/// <summary>
+		/// As <see cref="CreateMenuItems(XWindow, string[])"/> with an interceptor, plus a
+		/// temporary colleague registered on the mediator before the menu populates, so
+		/// per-target commands (an item's Show-in-tool jumps) find their handler. The mediator
+		/// keeps one temporary colleague at a time; the host disposes it once the menu closes.
+		/// </summary>
+		public static IReadOnlyList<DetailMenuItem> CreateMenuItems(XWindow window, string[] menuIds,
+			Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem> interceptor,
+			IxCoreColleague temporaryColleague)
 		{
 			var group = window?.GetContextMenuChoiceGroup(menuIds);
 			if (group == null)
 				return new List<DetailMenuItem>();
+			if (temporaryColleague != null)
+				window.Mediator.AddTemporaryColleague(temporaryColleague);
 			group.PopulateNow();
 			return Convert(group, interceptor);
 		}

--- a/Src/xWorks/Avalonia/Plugins/ReversalIndexEntryPlugin.cs
+++ b/Src/xWorks/Avalonia/Plugins/ReversalIndexEntryPlugin.cs
@@ -199,6 +199,8 @@ namespace SIL.FieldWorks.XWorks
 
 		public bool TryRemoveReferenceItem(DetailField field, string optionKey) => false;
 
+		public bool TryMoveReferenceItem(DetailField field, string optionKey, bool forward) => false;
+
 		// The Reversal Entries plugin edits multi-unicode reversal forms only; it implements neither
 		// IStructuredTextEditing (no StText rows are composed for it) nor picture editing.
 

--- a/Src/xWorks/xWorksTests/Avalonia/Composer/BackRefVectorTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Composer/BackRefVectorTests.cs
@@ -68,6 +68,88 @@ namespace SIL.FieldWorks.XWorks
 			=> composed.Model.Fields.SingleOrDefault(f => f.Field == field
 				&& f.Kind == DetailFieldKind.ReferenceVector);
 
+		// ===== Reordering =====
+
+		// Subentries is virtual with reorder="true": a move records a virtual ordering that the
+		// recomposed row reflects, as one undo step.
+		[Test]
+		public void Subentries_MoveForward_RecordsAVirtualOrdering_AndRoundTrips()
+		{
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				m_complexRef.PrimaryLexemesRS.Add(m_component);
+				m_complex2Ref.PrimaryLexemesRS.Add(m_component);
+			});
+
+			var composed = Compose();
+			var field = FindField(composed, "Subentries");
+			Assert.That(field, Is.Not.Null);
+			Assert.That(field.CanReorderItems, Is.True, "reorder='true' makes the virtual vector reorderable");
+			var before = field.Items.Select(i => i.Key).ToList();
+			Assert.That(before, Has.Count.EqualTo(2));
+
+			Assert.That(composed.EditContext.TryMoveReferenceItem(field, before[0], forward: true), Is.True);
+			composed.EditContext.Commit();
+
+			var after = FindField(Compose(), "Subentries").Items.Select(i => i.Key).ToList();
+			Assert.That(after, Is.EqualTo(new[] { before[1], before[0] }), "the first item moved right");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(FindField(Compose(), "Subentries").Items.Select(i => i.Key), Is.EqualTo(before),
+				"the move is one undo step");
+		}
+
+		[Test]
+		public void Subentries_MovePastAnEnd_OrUnknownItem_Rejects_WithoutOpeningASession()
+		{
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				m_complexRef.PrimaryLexemesRS.Add(m_component);
+				m_complex2Ref.PrimaryLexemesRS.Add(m_component);
+			});
+
+			var composed = Compose();
+			var field = FindField(composed, "Subentries");
+			var keys = field.Items.Select(i => i.Key).ToList();
+
+			Assert.That(composed.EditContext.TryMoveReferenceItem(field, keys[0], forward: false), Is.False,
+				"the first item cannot move left");
+			Assert.That(composed.EditContext.TryMoveReferenceItem(field, keys[1], forward: true), Is.False,
+				"the last item cannot move right");
+			Assert.That(composed.EditContext.TryMoveReferenceItem(field, Guid.NewGuid().ToString(), true), Is.False);
+			Assert.That(composed.EditContext.IsOpen, Is.False, "rejected moves never open the fence");
+		}
+
+		// ComponentLexemes is a real reference sequence: a move rewrites the vector itself.
+		[Test]
+		public void ComponentLexemes_MoveBackward_RewritesTheSequence_AndRoundTrips()
+		{
+			ILexEntry second = null;
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				second = MakeEntry("techo");
+				m_complexRef.ComponentLexemesRS.Add(second);
+			});
+
+			var composed = DetailComposer.Compose(m_complex, Cache);
+			var field = FindField(composed, "ComponentLexemes");
+			Assert.That(field, Is.Not.Null, "the complex form's Components row composes as a vector");
+			Assert.That(field.CanReorderItems, Is.True, "a real reference sequence is always reorderable");
+			Assert.That(field.Items.Select(i => i.Key),
+				Is.EqualTo(new[] { m_component.Guid.ToString(), second.Guid.ToString() }));
+
+			Assert.That(composed.EditContext.TryMoveReferenceItem(field, second.Guid.ToString(), forward: false),
+				Is.True);
+			composed.EditContext.Commit();
+
+			Assert.That(m_complexRef.ComponentLexemesRS.Select(c => c.Guid),
+				Is.EqualTo(new[] { second.Guid, m_component.Guid }), "the sequence itself was reordered");
+
+			Cache.ActionHandlerAccessor.Undo();
+			Assert.That(m_complexRef.ComponentLexemesRS.Select(c => c.Guid),
+				Is.EqualTo(new[] { m_component.Guid, second.Guid }), "one undo step");
+		}
+
 		// ===== Subentries =====
 
 		[Test]

--- a/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
+++ b/Src/xWorks/xWorksTests/Avalonia/Hosting/DetailObjectCommandExecutionTests.cs
@@ -154,6 +154,120 @@ namespace SIL.FieldWorks.XWorks
 				"the host can re-show the detail view after a hotlink-create");
 		}
 
+		// ===== Reference-vector rows: the per-item menu and Move Left / Move Right =====
+
+		private sealed class ItemSelection : IDetailItemSelection
+		{
+			public string SelectedItemKey { get; set; }
+			public int SelectedItemIndex { get; set; }
+		}
+
+		// Two complex forms whose primary lexeme is the test entry, so its Subentries row shows
+		// two items; then the host re-shows the record so its edit context knows the row.
+		private void MakeTwoSubentries()
+		{
+			NonUndoableUnitOfWorkHelper.Do(Cache.ActionHandlerAccessor, () =>
+			{
+				var stem = GetMorphTypeOrCreateOne("stem");
+				var noun = GetGrammaticalCategoryOrCreateOne("noun", Cache.LangProject.PartsOfSpeechOA);
+				foreach (var form in new[] { "command-entry-sub-a", "command-entry-sub-b" })
+				{
+					var complex = AddLexeme(m_createdObjects, form, stem, "sub " + form, noun);
+					var ler = Cache.ServiceLocator.GetInstance<ILexEntryRefFactory>().Create();
+					complex.EntryRefsOS.Add(ler);
+					ler.RefType = LexEntryRefTags.krtComplexForm;
+					ler.ComponentLexemesRS.Add(m_entry);
+					ler.PrimaryLexemesRS.Add(m_entry);
+				}
+			});
+			DrainMediatorAndIdleQueues();
+			RefreshedDetailFieldCount();
+		}
+
+		private DetailField SubentriesField()
+		{
+			var field = DetailComposer.Compose(m_entry, Cache).Model.Fields
+				.SingleOrDefault(f => f.Field == "Subentries" && f.Kind == DetailFieldKind.ReferenceVector);
+			Assert.That(field, Is.Not.Null, "the entry composes a Subentries vector row");
+			Assert.That(field.Items, Has.Count.EqualTo(2));
+			return field;
+		}
+
+		[Test]
+		public void SubentriesItemMenu_OffersTheJumpAsCtrlClickDefault_AndTheMoveCommands_ForTheClickedItem()
+		{
+			MakeTwoSubentries();
+			var field = SubentriesField();
+			var request = DetailMenuRequest.FromAnchor(null, field, DetailMenuKind.ItemMenu,
+				new ItemSelection { SelectedItemKey = field.Items[0].Key, SelectedItemIndex = 0 });
+
+			var items = m_view.BuildReferenceItemMenu(request, out var colleague);
+			try
+			{
+				Assert.That(colleague, Is.Not.Null, "the clicked item's object UI joins as the temporary colleague");
+				var jump = items.FirstOrDefault(i => !i.IsSeparator
+					&& i.Label.StartsWith("Show Entry in Lexicon", StringComparison.Ordinal));
+				Assert.That(jump, Is.Not.Null, "the clicked entry's jump command materializes");
+				Assert.That(jump.Label, Does.EndWith(SIL.FieldWorks.FdoUi.CmObjectUi.CtrlClickSuffix),
+					"the first enabled jump is marked as the Ctrl+click default, with the shared suffix");
+				Assert.That(jump.IsEnabled, Is.True);
+
+				var left = FindItem(items, "Move Left");
+				var right = FindItem(items, "Move Right");
+				Assert.That(left, Is.Not.Null, "Move Left materializes on the item menu");
+				Assert.That(right, Is.Not.Null, "Move Right materializes on the item menu");
+				Assert.That(left.IsEnabled, Is.False, "the first item cannot move left");
+				Assert.That(right.IsEnabled, Is.True, "the first item can move right");
+			}
+			finally
+			{
+				colleague?.Dispose();
+			}
+		}
+
+		[Test]
+		public void SubentriesCtrlClick_ResolvesTheClickedEntry_AndRunsTheDefaultJumpPath()
+		{
+			MakeTwoSubentries();
+			var field = SubentriesField();
+			var targetHvo = Cache.ServiceLocator.ObjectRepository.GetObject(new Guid(field.Items[1].Key)).Hvo;
+			var request = DetailMenuRequest.FromDefaultActivation(null, field,
+				new ItemSelection { SelectedItemKey = field.Items[1].Key, SelectedItemIndex = 1 });
+
+			// The host's half: the clicked item resolves to its own object UI, wired to this
+			// view's mediator so its jump commands can run.
+			using (var ui = m_view.ResolveItemUi(request))
+			{
+				Assert.That(ui, Is.Not.Null, "the clicked subentry resolves to an object UI");
+				Assert.That(ui.Object.Hvo, Is.EqualTo(m_entry.Hvo), "the UI's root is the row's object");
+				Assert.That(ui.Mediator, Is.Not.Null);
+				Assert.That(ui.PropTable, Is.Not.Null);
+				Assert.That(((SIL.FieldWorks.FdoUi.ReferenceBaseUi)ui).ContextMenuId, Is.EqualTo("mnuReferenceChoices"));
+			}
+			Assert.That(Cache.ServiceLocator.ObjectRepository.IsValidObjectId(targetHvo), Is.True);
+
+			// The default activation runs the object UI's Ctrl-click path end to end without
+			// faulting (the jump is a mediator FollowLink this headless window does not service).
+			Assert.DoesNotThrow(() => m_view.OnDetailItemMenuRequested(request));
+			DrainMediatorAndIdleQueues();
+		}
+
+		[Test]
+		public void SubentriesMoveRight_ThroughTheHost_ReordersTheRow()
+		{
+			MakeTwoSubentries();
+			var field = SubentriesField();
+			var before = field.Items.Select(i => i.Key).ToList();
+
+			m_view.MoveReferenceItem(field, before[0], forward: true);
+			DrainMediatorAndIdleQueues();
+
+			var after = SubentriesField().Items.Select(i => i.Key).ToList();
+			Assert.That(after, Is.EqualTo(new[] { before[1], before[0] }), "the first item moved right");
+			Assert.That(RefreshedDetailFieldCount(), Is.GreaterThan(0),
+				"the host re-shows the record after the coalesced completion");
+		}
+
 		// ----------------------------------------------------------------------------------------
 		// Delete Sense / Delete object
 		// ----------------------------------------------------------------------------------------
@@ -686,14 +800,10 @@ namespace SIL.FieldWorks.XWorks
 		private IReadOnlyList<DetailMenuItem> BuildItemsWithOverrideInterceptor(string[] menuIds,
 			DetailField field)
 		{
-			var build = typeof(RecordEditView).GetMethod("BuildOverrideCommandInterceptor",
-				BindingFlags.Instance | BindingFlags.NonPublic);
-			Assert.That(build, Is.Not.Null, "the override interceptor seam must exist");
-			var interceptor = (Func<ChoiceBase, UIItemDisplayProperties, DetailMenuItem>)build.Invoke(
-				m_view, new object[] { field });
-			TestContext.WriteLine("interceptor built: " + (interceptor != null));
+			var registry = new OverrideCommandRegistry();
+			m_view.AddOverrideCommands(registry, field);
 			var window = m_propertyTable.GetValue<XWindow>("window");
-			return XCoreMenuBridge.CreateMenuItems(window, menuIds, interceptor);
+			return XCoreMenuBridge.CreateMenuItems(window, menuIds, registry.TryBuild);
 		}
 
 		private ViewDefinitionOverride ReadOverrideFor(DetailField field)


### PR DESCRIPTION
Reference-vector rows (Publication Settings: Subentries, Referenced Complex Forms, Semantic Domains, Publish In, ...) now have support for the label and edit field menus.

- Items are selectable (to support the move left/right commands).
- Ctrl+click runs the first jump.
- Backspace or Delete removes the focused item.
- Move Left / Move Right on the label menu and the item menu act on the current item.
- Restore the scroll offset, the vector row's current item, and focus after a re-show.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1133)
<!-- Reviewable:end -->
