### PR TITLE
Ban the word "legacy" in code comments and commit messages

### DIFF
--- a/.claude/skills/commit-messages/SKILL.md
+++ b/.claude/skills/commit-messages/SKILL.md
@@ -34,6 +34,11 @@ is checked. There is no leniency for "just the summary" or "just this once."
 - Prefer several short lines over one long one, and several short
   paragraphs over one dense one -- a commit message is read in a `git log`
   pane, not a text editor with wrapping.
+- Don't use "legacy" as the name of a thing, here or in a code comment.
+  `git log` is read years later, when whatever was legacy at the time is
+  gone and the reader cannot recover what it meant. Name the class,
+  project, or UI -- "the WinForms DataTree", "the xCore Mediator" -- not
+  "the legacy path". PR descriptions are exempt.
 
 ## Verify before considering a commit done
 

--- a/.claude/skills/fieldworks-code-commenting/SKILL.md
+++ b/.claude/skills/fieldworks-code-commenting/SKILL.md
@@ -73,15 +73,27 @@ an agent passes one of them on every run.
 
 ## Legacy references
 
-Only as a behavioral-parity WHY ("matches the legacy X"). No temporal
-framing -- not "the replacement for X", not "until we build Y". Prefer
-symbol names over line numbers, which rot.
+Do not use the word "legacy" in a comment -- not "matches the legacy X",
+not "as legacy does". Legacy is being deleted; once it is gone the word
+names nothing the reader can look up, and they cannot tell whether the
+behavior it describes is still required.
+
+State what the code does in its own terms instead -- "a keyboard gesture
+has no pointer position, so the menu anchors under the field" rather than
+"matches legacy SliceTreeNode, which anchors at the cursor". No temporal
+framing either -- not "the replacement for X", not "until we build Y".
+
+This covers the assertion messages of new tests too. Commit messages
+follow the same rule (`.claude/skills/commit-messages/SKILL.md`). PR
+descriptions and review discussion are exempt, so do not coin a
+euphemism to avoid the word there.
 
 ## References to other code
 
 Only when the reader needs it to understand THIS symbol, never for
 completeness or navigation. `<see cref="X"/>` in doc comments; a bare
-symbol path in `//` comments, where tooling won't resolve it.
+symbol path in `//` comments, where tooling won't resolve it. Prefer
+symbol names over line numbers, which rot.
 
 **Link the contract, not the collaborator.** State what a delegation
 guarantees; leave the callee unnamed -- naming it documents HOW, not WHAT.

--- a/.claude/skills/pr-pitch/SKILL.md
+++ b/.claude/skills/pr-pitch/SKILL.md
@@ -128,6 +128,10 @@ leaves the reviewer guessing whether they are approving, splitting or blocking.
 - No section that exists only to demonstrate rigor.
 - Every claim with a name in it must be true of the current tree. Re-verify
   claims carried over from an earlier version of the body.
+- "Legacy" is allowed here, and in review discussion. Code comments and
+  commit messages must name the actual class or UI instead, but a PR body
+  is read alongside the diff while the context is live -- use the team's
+  own word rather than coining a euphemism for it.
 - Word-count before publishing. Over 400, cut -- do not rationalize.
 
 ## Phases 4 and 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ Minimal, high-signal guidance for coding agents in this repository.
 	`.claude/skills/fieldworks-code-commenting/SKILL.md`.
 - Follow the commit-message rules in
 	`.claude/skills/commit-messages/SKILL.md` for every commit.
+- Do not write "legacy" in code comments or commit messages -- name the
+	actual class, project, or UI, or state what the code does in its own
+	terms. PR descriptions and review discussion may use the term freely.
 
 ## Context model
 


### PR DESCRIPTION
The code-comment standard allowed "legacy X" as a behavioral-parity WHY. Once the code it refers to is deleted, the word names nothing a reader can look up, and they cannot tell whether the behavior is still required.

Ban the term in comments and in commit messages, which are both read long after the referent is gone. PR descriptions and review discussion stay exempt: they are read alongside the diff while the context is live, so the team's own word is the clearest one there.

State the scope in AGENTS.md, where it is in context regardless of which skill fires, then repeat the relevant half where each artifact is authored -- the two skills for the ban, pr-pitch for the exemption, so a PR body is not written under a rule that does not apply to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/FieldWorks/1134)
<!-- Reviewable:end -->
