### PR TITLE
LT-21834: Recover from an abandoned lock when opening a project

### DIFF
--- a/Src/Common/FieldWorks/FieldWorks.cs
+++ b/Src/Common/FieldWorks/FieldWorks.cs
@@ -3121,6 +3121,14 @@ namespace SIL.FieldWorks
 			{
 				throw new StartupException(fie.Message, fie);
 			}
+			catch (AbandonedMutexException ame)
+			{
+				// Startup owns the machine-wide lock once the wait completes, so exiting
+				// here would abandon it again and make every later launch fail the same
+				// way (LT-21834).
+				Logger.WriteError(ame);
+				throw new StartupException(Properties.Resources.ksAbandonedMutexOnStartup, ame);
+			}
 			finally
 			{
 				CloseSplashScreen();

--- a/Src/Common/FieldWorks/Properties/Resources.Designer.cs
+++ b/Src/Common/FieldWorks/Properties/Resources.Designer.cs
@@ -120,6 +120,15 @@ namespace SIL.FieldWorks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Another SIL program that shares data with FieldWorks closed unexpectedly, so the project could not be opened.
+        /// </summary>
+        internal static string ksAbandonedMutexOnStartup {
+            get {
+                return ResourceManager.GetString("ksAbandonedMutexOnStartup", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Do you want to continue with the restore?.
         /// </summary>
         internal static string ksBackupErrorDuringRestore {

--- a/Src/Common/FieldWorks/Properties/Resources.resx
+++ b/Src/Common/FieldWorks/Properties/Resources.resx
@@ -331,4 +331,10 @@ We don't know why this happens. If you have any idea what recently changed on yo
 (To configure update settings, go to Tools-&gt;Options-&gt;Updates.)</value>
     <comment>Question asked on first launch. Options are Yes and No.</comment>
   </data>
+  <data name="ksAbandonedMutexOnStartup" xml:space="preserve">
+    <value>Another SIL program that shares data with FieldWorks closed unexpectedly, so the project could not be opened.
+
+Close any other SIL programs that are running, such as FieldWorks Lite or Paratext, and try again. If no other program is running, restart your computer.</value>
+    <comment>Shown on the Unable to Open Project dialog box when a shared lock was left behind by a program that crashed</comment>
+  </data>
 </root>


### PR DESCRIPTION
See comment below. Closing this. The fix is entirely in libpalaso https://github.com/sillsdev/libpalaso/pull/1544/

---

**Start here:** `Src/Common/FieldWorks/FieldWorks.cs` — the new `catch (AbandonedMutexException)` in `InitializeFirstApp`. Eight lines carry the change; the other two add its string.

## What it does

A program sharing this machine's writing system store, or a project's commit log, can exit while holding the lock guarding it. Opening a project then threw `AbandonedMutexException`, which nothing on the startup path caught, so FieldWorks crashed and exited. Because the thread receiving that exception owns the lock, exiting abandoned it again, so the next launch failed identically — users reported being unable to open FieldWorks at all, recurring every week or two.

Translating it into `StartupException` reaches the recovery `LaunchProject` already performs: dispose the cache, show the Welcome dialog, stay alive. The user sees:

> Another SIL program that shares data with FieldWorks closed unexpectedly, so the project could not be opened.
>
> Close any other SIL programs that are running, such as FieldWorks Lite or Paratext, and try again. If no other program is running, restart your computer.

## This is a mitigation, not a fix

Verified by hand. The dialog appears; retrying the same project from it opens the project; the dialog returns on every later launch. FieldWorks cannot close that gap: the `GlobalMutex` is private to `GlobalWritingSystemRepository` in libpalaso.

**It stands alone, and its value is now.** Nothing here depends on the companion libpalaso PR. Against today's shipped libpalaso it turns "cannot open FieldWorks at all" into one extra click per launch; once the real fix lands, this catch stops being reached.

## Where to look

- **The message above.** It names the two actions that resolved this for reporters, but nobody who fields these support requests has read it.
- The string resolves by name at run time, so a `.resx`/designer mismatch compiles and fails only when shown. Confirmed in the built exe.
- Two pre-existing weaknesses this path runs through are left alone: reopen-after-restore still crashes, and a partially built `LcmCache` is left undisposed. See *Deferred*.

## Deliberately not here

No automated test: once libpalaso ships this catch is unreachable, so a test could assert only that it compiles.

## Verification

`.\build.ps1 -CommentHygiene -TokenHygiene` clean. `.\test.ps1 -TestProject FieldWorksTests` — 35 tests, 34 passed, 1 skipped, none failed. Manual reproduction on FW 9.3.12 Debug matched the LT-21834 stack frame for frame. Nothing red.

**Next:** approve, or say the per-launch dialog is not worth shipping ahead of the libpalaso fix.

---

<details>
<summary><b>Reading this a year from now</b> — start here</summary>

Nothing was deleted from the branch to build this record; the investigation notes live outside the repository and stayed there. What follows is the reasoning behind a change that looks trivially small — eight lines and a string — and whose value is easy to misread in either direction.

The short version: this converts an unopenable application into one extra click per launch. That is worth shipping and is not a fix.

</details>

<details>
<summary><b>Decisions, and why</b></summary>

**Why translate to `StartupException` rather than handle it in place.** `LaunchProject` already has the recovery this needs — dispose the cache, reinitialise the log, re-show the Welcome dialog — reached by catching `StartupException`. Reusing it means no parallel recovery path and no new UI.

**Why the catch sits in `InitializeFirstApp`.** Both reported stacks pass through it: the 2024 report via `SharedXMLBackendProvider.StartupInternal`, the 2026 report via `EnsureDefaultCollationsPresent`. One catch covers both.

**Why the string names FLEx Lite and Paratext specifically.** Those are the two programs that share the writing system store and were named in reports. Closing FLEx Lite is what unblocked one reporter; a restart is what cleared it for others. The message gives the two actions that actually worked rather than generic advice.

**Why `Build/SilVersions.props` is not in this branch.** It was repointed at a locally built libpalaso during investigation. That pin exists on no other machine, so it is deliberately excluded.

</details>

<details>
<summary><b>Exception surface and reachability</b> — for a close or automated read</summary>

**Catch ordering.** The new clause follows `StartupException`, `LcmDataMigrationForbiddenException` and `LcmInitializationException`. None is a base of `AbandonedMutexException`, and none carries a filter, so the clause is reachable — had it not been, the compiler would have rejected it (CS0160) rather than silently skipping it. `using System.Threading;` was already present. The `finally { CloseSplashScreen(); }` still runs, since `finally` follows the catch list.

**Where the exception can originate.** Every route runs through libpalaso's `GlobalMutex`, and two reach FieldWorks startup:

- `SharedXMLBackendProvider.StartupInternal` → `InitializeAndLock` → the per-project commit-log mutex, named `<ProjectName>_Mutex`. This is the 2024 report.
- `EnsureDefaultCollationsPresent` → `WritingSystemManager.Save` → `GlobalWritingSystemRepository.TryGet` → `Lock` → the machine-wide writing system repository mutex, named after `C:\ProgramData\SIL\WritingSystemRepository\3` with separators replaced. This is the 2026 report, and every project open touches it.

Other `GlobalMutex` sites in libpalaso — the SLDR cache lock in particular — can throw the same exception but do not run on the FieldWorks startup path, so this change does not address them.

**What the diagnostics keep.** `Logger.WriteError(ame)` records the original exception, and the `StartupException` keeps it as `InnerException`, so a later crash report still carries the abandoning stack rather than only the user-facing text.

**Consequence of translating.** `StartupException` is recovered by `LaunchProject`, but the other `InitializeFirstApp` caller filters it to an `LcmFileLockedException` inner and re-throws anything else. On that path the exception still reaches the crash reporter, now presenting the localized message as its text with the mutex exception nested inside.

</details>

<details>
<summary><b>Surprising findings</b></summary>

**The two crash reports on the ticket are not the same mutex.** The 2024 report is liblcm's per-project commit-log mutex; the 2026 report is the machine-wide writing system repository mutex. Different library, different lock, same failure. That ruled out fixing either call site and located the defect in `GlobalMutex` itself.

**The recovery is not durable, and the reason is not obvious.** Retrying works because the thread already owns the mutex, so the second wait is a recursive acquisition that returns immediately — not because anything was repaired. The mutex is still owned and unreleased when the process exits, which re-arms the condition. This was expected to be a one-time recovery and was found by testing to be per-launch.

</details>

<details>
<summary><b>Deferred, and what would unblock it</b></summary>

**The `LcmCache` leak in `CreateCache`.** The cache is built, then a later step throws with no `try` or `using` around it, so `s_cache = CreateCache(...)` never completes and nothing disposes it. Pre-existing for any exception thrown after construction, including the current `LcmInitializationException` path. Unblocking it is a scoped change to `CreateCache`; it is not specific to this ticket and would widen this branch.

**Reopen-after-restore.** That caller re-throws any `StartupException` whose inner is not `LcmFileLockedException`, by design (LT-21913), so it still produces a crash report. Every reported occurrence of this bug is at launch. Extending it would mean changing a path with its own reasoning.

**A test for the catch.** Would need a FieldWorks build running against a `SIL.Core` without the fix, plus a way to abandon a machine-wide mutex from a test host. Achievable, but it would pin a path that is dead once libpalaso ships.

</details>

<details>
<summary><b>Evidence</b></summary>

A named mutex exists only while some process holds a handle to it, so killing a lone holder destroys it and nothing reproduces — which is why the reports involve a second SIL program running alongside. The reproduction therefore needs two processes.

1. Start a holder process that opens a mutex named `C:_ProgramData_SIL_WritingSystemRepository_3` and stays alive, keeping the name in existence.
2. Start a second process that opens the same mutex, waits on it, then exits without releasing it. That marks it abandoned.
3. Launch FieldWorks and open any project. `EnsureDefaultCollationsPresent` runs on every project open and takes that mutex.
4. Close FieldWorks and repeat step 3, to see whether the condition persists.
5. Stop the holder from step 1 afterwards, or FieldWorks will keep hitting this.

Do not check the mutex by waiting on it: acquiring an abandoned mutex *consumes* the abandonment, so verifying that way destroys the condition under test.

**Against the commit before this one.** Step 3 produced the crash reporter, `Msg: The wait completed due to an abandoned mutex`, with a stack matching the `Abandoned Mutex August 8 26.txt` attachment on LT-21834 frame for frame — `GlobalMutex.Lock()` → `TryGet` → `OnChangeNotifySharedStore` → `LdmlInFolderWritingSystemRepository.Save()` → `WritingSystemManager.Save()` → `EnsureDefaultCollationsPresent`. Step 4 reproduced it every time.

**Against this commit.** Step 3 produced the "Unable to Open Project" dialog. Retrying the same project from that dialog opened it. Step 4 showed the dialog again on each later launch.

</details>

<details>
<summary>Preflight review details</summary>

<!-- pr-preflight:summary:start -->
See `.review/summary.md` on the branch (gitignored; paste its contents here when posting).
<!-- pr-preflight:summary:end -->

</details>
